### PR TITLE
docs/missing link to doNotWaitForEmptyEventLoop middleware

### DIFF
--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -8,6 +8,7 @@
  - [s3KeyNormalizer](#s3keynormalizer)
  - [validator](#validator)
  - [urlencodeBodyParser](#urlencodebodyparser)
+ - [doNotWaitForEmptyEventLoop](#donotwaitforemptyeventloop)
 
 
 ## [cors](/src/middlewares/cors.js)

--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -3,12 +3,12 @@
 ## Available middlewares
 
  - [cors](#cors)
+ - [doNotWaitForEmptyEventLoop](#donotwaitforemptyeventloop)
  - [httpErrorHandler](#httperrorhandler)
  - [jsonBodyParser](#jsonbodyparser)
  - [s3KeyNormalizer](#s3keynormalizer)
  - [validator](#validator)
  - [urlencodeBodyParser](#urlencodebodyparser)
- - [doNotWaitForEmptyEventLoop](#donotwaitforemptyeventloop)
 
 
 ## [cors](/src/middlewares/cors.js)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "The simple (but cool 😎) middleware engine for AWS lambda in Node.js",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Middlewares documentation is missing a link to `doNotWaitForEmptyEventLoop` middleware