### PR TITLE
Fix root export on typings and update AWS lambda types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ typings/
 .tern-port
 .DS_Store
 docs/
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,3 @@ typings/
 .tern-port
 .DS_Store
 docs/
-/.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/aws-lambda": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-0.0.21.tgz",
-      "integrity": "sha512-PDCjrTTYcFl22FJ9gwMw1UxQGBxNM5iXomM1EH3aT/sFX0Y4rDGz0SlLYRYzzf1FbOjiTrYSmzoz4FSiOgyCFQ=="
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-0.0.22.tgz",
+      "integrity": "sha512-x6aNGoioSD63EHEinEe3XNWTkmST9aLFd38SxV1/T8IGbH6X0lJ+nxqfoKzV+8PNbosa9sB49Q7pDYNLPqYc/w=="
     },
     "abab": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "The simple (but cool 😎) middleware engine for AWS lambda in Node.js",
   "main": "src/index.js",
   "types": "./typescript/middy.d.ts",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "regenerator-runtime": "^0.11.0"
   },
   "dependencies": {
-    "@types/aws-lambda": "0.0.21",
+    "@types/aws-lambda": "0.0.22",
     "ajv": "^5.2.2",
     "ajv-keywords": "^2.1.0",
     "http-errors": "^1.6.2",

--- a/typescript/middy.d.ts
+++ b/typescript/middy.d.ts
@@ -1,35 +1,41 @@
-import {Callback, Context, Handler, ProxyResult} from 'aws-lambda';
+import { Callback, Context, Handler, ProxyResult } from 'aws-lambda';
 
-export interface IMiddy {
-  use: IMiddyUseFunction;
-  before: IMiddyMiddlewareFunction;
-  after: IMiddyMiddlewareFunction;
-  onError: IMiddyMiddlewareFunction;
+
+
+declare var middy: {
+  (handler: Handler): middy.IMiddy;
+};
+
+declare namespace middy {
+  interface IMiddy {
+    use: IMiddyUseFunction;
+    before: IMiddyMiddlewareFunction;
+    after: IMiddyMiddlewareFunction;
+    onError: IMiddyMiddlewareFunction;
+  }
+
+  type IMiddyUseFunction = (config?: object) => IMiddy;
+
+  interface IMiddyMiddlewareObject {
+    before?: IMiddyMiddlewareFunction;
+    after?: IMiddyMiddlewareFunction;
+    onError?: IMiddyMiddlewareFunction;
+  }
+
+  type IMiddyMiddlewareFunction = (
+    handler: IHandlerLambda,
+    next: IMiddyNextFunction
+  ) => void | Promise<any>;
+
+  type IMiddyNextFunction = (error?: any) => void;
+
+  interface IHandlerLambda {
+    event: any;
+    context: Context;
+    response: ProxyResult | object;
+    error: Error;
+    callback: Callback;
+  }
 }
 
-export type IMiddyUseFunction = (config?: object) => IMiddy;
-
-export interface IMiddyMiddlewareObject {
-  before?: IMiddyMiddlewareFunction;
-  after?: IMiddyMiddlewareFunction;
-  onError?: IMiddyMiddlewareFunction;
-}
-
-type IMiddyMiddlewareFunction = (
-  handler: IHandlerLambda,
-  next: IMiddyNextFunction
-) => void | Promise<any>;
-
-export type IMiddyNextFunction = (error?: any) => void;
-
-export interface IHandlerLambda {
-  event: any;
-  context: Context;
-  response: ProxyResult | object;
-  error: Error;
-  callback: Callback;
-}
-declare let middy: (handler: Handler) => IMiddy;
-
-export default middy;
-
+export = middy;


### PR DESCRIPTION
I found an issue using the default export on the typescript types, so I refactor the types to create a signature of the middy default function and add a Namespace with the same name to the rest of the types, so you can use the following imports:

```typescript
import * as middy from 'middy';
import {IMiddy} from 'middy';
```