### PR TITLE
Parse json body when content-type header is lower-cased

### DIFF
--- a/src/middlewares/__tests__/jsonBodyParser.js
+++ b/src/middlewares/__tests__/jsonBodyParser.js
@@ -21,6 +21,25 @@ describe('📦  Middleware JSON Body Parser', () => {
     })
   })
 
+  test('It should parse a JSON request when header key is lower-cased', () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, event.body) // propagates the body as a response
+    })
+
+    handler.use(jsonBodyParser())
+
+    // invokes the handler
+    const event = {
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({foo: 'bar'})
+    }
+    handler(event, {}, (_, body) => {
+      expect(body).toEqual({foo: 'bar'})
+    })
+  })
+
   test('It should handle invalid JSON as an UnprocessableEntity', () => {
     const handler = middy((event, context, cb) => {
       cb(null, event.body) // propagates the body as a response

--- a/src/middlewares/jsonBodyParser.js
+++ b/src/middlewares/jsonBodyParser.js
@@ -2,13 +2,17 @@ const createError = require('http-errors')
 
 module.exports = () => ({
   before: (handler, next) => {
-    if (handler.event.headers && handler.event.headers['Content-Type'] === 'application/json') {
+    const headers = handler.event.headers || {}
+    const contentType = headers['Content-Type'] || headers['content-type']
+
+    if (contentType === 'application/json') {
       try {
         handler.event.body = JSON.parse(handler.event.body)
       } catch (err) {
         throw new createError.UnprocessableEntity('Content type defined as JSON but an invalid JSON was provided')
       }
     }
+
     next()
   }
 })


### PR DESCRIPTION
Looks like a strange exception. Didn't work for me without this fix

See https://serverless.com/framework/docs/providers/aws/events/apigateway#example-lambda-proxy-event-default

![image](https://user-images.githubusercontent.com/3817380/34784105-0516ddd2-f636-11e7-9b53-ec7d3725500b.png)
