### PR TITLE
Middleware HTTP Content Negotiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   <a href="https://greenkeeper.io/">
     <img src="https://badges.greenkeeper.io/middyjs/middy.svg" alt="Greenkeeper badge"  style="max-width:100%;">
   </a>
-  <a href="https://gitter.im/middyjs">
+  <a href="https://gitter.im/middyjs/Lobby">
     <img src="https://badges.gitter.im/gitterHQ/gitter.svg" alt="Chat on Gitter"  style="max-width:100%;">
   </a>
 </p>
@@ -497,9 +497,10 @@ Currently available middlewares:
  - [`cache`](/docs/middlewares.md#cache): a simple but flexible caching layer
  - [`cors`](/docs/middlewares.md#cors): sets CORS headers on response
  - [`doNotWaitForEmptyEventLoop`](/docs/middlewares.md#donotwaitforemptyeventloop): sets callbackWaitsForEmptyEventLoop property to false
+ - [`httpContentNegotiation`](/docs/middlewares.md#httpcontentnegotiation): Parses `Accept-*` headers and provides utilities for content negotiation (charset, encoding, language and media type) for HTTP requests
  - [`httpErrorHandler`](/docs/middlewares.md#httperrorhandler): creates a proper HTTP response for errors that are created with the [http-errors](https://www.npmjs.com/package/http-errors) module and represents proper HTTP errors.
  - [`httpEventNormalizer`](/docs/middlewares.md#httpEventNormalizer): Normalizes HTTP events by adding an empty object for `queryStringParameters` and `pathParameters` if they are missing.
- - [`httpHeaderNormalizer`](/docs/middlewares.md#httpHeaderNormalizer): Normalizes HTTP header names to their canonical format
+ - [`httpHeaderNormalizer`](/docs/middlewares.md#httpheadernormalizer): Normalizes HTTP header names to their canonical format
  - [`jsonBodyParser`](/docs/middlewares.md#jsonbodyparser): automatically parses HTTP requests with JSON body and converts the body into an object. Also handles gracefully broken JSON if used in combination of
  `httpErrorHanler`.
  - [`s3KeyNormalizer`](/docs/middlewares.md#s3keynormalizer): normalizes key names in s3 events.

--- a/README.md.hb
+++ b/README.md.hb
@@ -26,7 +26,7 @@
   <a href="https://greenkeeper.io/">
     <img src="https://badges.greenkeeper.io/middyjs/middy.svg" alt="Greenkeeper badge"  style="max-width:100%;">
   </a>
-  <a href="https://gitter.im/middyjs">
+  <a href="https://gitter.im/middyjs/Lobby">
     <img src="https://badges.gitter.im/gitterHQ/gitter.svg" alt="Chat on Gitter"  style="max-width:100%;">
   </a>
 </p>
@@ -497,9 +497,10 @@ Currently available middlewares:
  - [`cache`](/docs/middlewares.md#cache): a simple but flexible caching layer
  - [`cors`](/docs/middlewares.md#cors): sets CORS headers on response
  - [`doNotWaitForEmptyEventLoop`](/docs/middlewares.md#donotwaitforemptyeventloop): sets callbackWaitsForEmptyEventLoop property to false
+ - [`httpContentNegotiation`](/docs/middlewares.md#httpcontentnegotiation): Parses `Accept-*` headers and provides utilities for content negotiation (charset, encoding, language and media type) for HTTP requests
  - [`httpErrorHandler`](/docs/middlewares.md#httperrorhandler): creates a proper HTTP response for errors that are created with the [http-errors](https://www.npmjs.com/package/http-errors) module and represents proper HTTP errors.
  - [`httpEventNormalizer`](/docs/middlewares.md#httpEventNormalizer): Normalizes HTTP events by adding an empty object for `queryStringParameters` and `pathParameters` if they are missing.
- - [`httpHeaderNormalizer`](/docs/middlewares.md#httpHeaderNormalizer): Normalizes HTTP header names to their canonical format
+ - [`httpHeaderNormalizer`](/docs/middlewares.md#httpheadernormalizer): Normalizes HTTP header names to their canonical format
  - [`jsonBodyParser`](/docs/middlewares.md#jsonbodyparser): automatically parses HTTP requests with JSON body and converts the body into an object. Also handles gracefully broken JSON if used in combination of
  `httpErrorHanler`.
  - [`s3KeyNormalizer`](/docs/middlewares.md#s3keynormalizer): normalizes key names in s3 events.

--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -7,6 +7,7 @@
  - [doNotWaitForEmptyEventLoop](#donotwaitforemptyeventloop)
  - [httpContentNegotiation](#httpcontentnegotiation)
  - [httpErrorHandler](#httperrorhandler)
+ - [httpEventNormalizer](#httpeventnormalizer)
  - [httpHeaderNormalizer](#httpheadernormalizer)
  - [jsonBodyParser](#jsonbodyparser)
  - [s3KeyNormalizer](#s3keynormalizer)

--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -191,8 +191,10 @@ const handler = middy((event, context, cb) => {
       break
     case 'application/yaml':
       body = `---\nmessage: ${message}`
+      break
     case 'application/json':
       body = JSON.stringify({ message })
+      break
     default:
       body = message
   }
@@ -200,7 +202,7 @@ const handler = middy((event, context, cb) => {
   return cb(null, {
     statusCode: 200,
     body
-  })  
+  })
 })
 
 handler
@@ -208,7 +210,7 @@ handler
   .use(httpContentNegotiation({
     parseCharsets: false,
     parseEncodings: false,
-    availableLanguages: ['it-it', 'fr-fr', 'en']
+    availableLanguages: ['it-it', 'fr-fr', 'en'],
     availableMediaTypes: ['application/xml', 'application/yaml', 'application/json', 'text/plain']
   }))
   .use(httpErrorHandler())

--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -136,7 +136,7 @@ handler(event, context, (_, response) => {
 
 ## [httpContentNegotiation](/src/middlewares/httpContentNegotiation.js)
 
-Parses `Accept-*` headers and provides utilities for [HTTP content negotiation](HTTP content negotiation) (charset, encoding, language and media type).
+Parses `Accept-*` headers and provides utilities for [HTTP content negotiation](https://tools.ietf.org/html/rfc7231#section-5.3) (charset, encoding, language and media type).
 
 By default the middleware parses charsets (`Accept-Charset`), languages (`Accept-Language`), encodings (`Accept-Encoding`) and media types (`Accept`) during the
 `before` phase and expands the `event` object by adding the following properties:

--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -5,8 +5,9 @@
  - [cache](#cache)
  - [cors](#cors)
  - [doNotWaitForEmptyEventLoop](#donotwaitforemptyeventloop)
+ - [httpContentNegotiation](#httpcontentnegotiation)
  - [httpErrorHandler](#httperrorhandler)
- - [httpHeaderNormalizer](#httpHeaderNormalizer)
+ - [httpHeaderNormalizer](#httpheadernormalizer)
  - [jsonBodyParser](#jsonbodyparser)
  - [s3KeyNormalizer](#s3keynormalizer)
  - [ssm](#ssm)
@@ -106,7 +107,7 @@ This will prevent lambda for timing out because of open database connections, et
 
 ### Options
 
-By default middleware sets the `callbackWaitsForEmptyEventLoop` property to `false` only in the `before` phase,
+By default the middleware sets the `callbackWaitsForEmptyEventLoop` property to `false` only in the `before` phase,
 meaning you can override it in handler to `true` if needed. You can set it in all steps with the options:
 
 - `runOnBefore` (defaults to `true`) - sets property before running your handler
@@ -130,6 +131,89 @@ handler.use(doNotWaitForEmptyEventLoop({runOnError: true}))
 handler(event, context, (_, response) => {
   expect(context.callbackWaitsForEmptyEventLoop).toEqual(false)
 })
+```
+
+
+## [httpContentNegotiation](/src/middlewares/httpContentNegotiation.js)
+
+Parses `Accept-*` headers and provides utilities for [HTTP content negotiation](HTTP content negotiation) (charset, encoding, language and media type).
+
+By default the middleware parses charsets (`Accept-Charset`), languages (`Accept-Language`), encodings (`Accept-Encoding`) and media types (`Accept`) during the
+`before` phase and expands the `event` object by adding the following properties:
+
+- `preferredCharsets` (`array`) - The list of charsets that can be safely used by the app (as the result of the negotiation)
+- `preferredCharset` (`string`) - The preferred charset  as the result of the negotiation
+- `preferredEncodings` (`array`) - The list of encodings that can be safely used by the app (as the result of the negotiation)
+- `preferredEncoding` (`string`) - The preferred encoding as the result of the negotiation
+- `preferredLanguages` (`array`) - The list of languages that can be safely used by the app (as the result of the negotiation)
+- `preferredLanguage` (`string`) - The preferred language as the result of the negotiation
+- `preferredMediaTypes` (`array`) - The list of media types that can be safely used by the app (as the result of the negotiation)
+- `preferredMediaType` (`string`) - The preferred media types as the result of the negotiation
+
+This middleware expects the headers in canonical format, so it should be attached after the [`httpHeaderNormalizer`](#httpheadernormalizer) middleware.
+It also can throw HTTP exception, so it can be convenient to use it in combination with the [`httpErrorHandler`](#httperrorhandler).
+
+### Options
+
+- `parseCharsets` (defaults to `true`) - Allows to enable/disable the charsets parsing
+- `availableCharsets` (defaults to `undefined`) - Allows to define the list of charsets supported by the lambda function
+- `parseEncodings` (defaults to `true`) - Allows to enable/disable the encodings parsing
+- `availableEncodings` (defaults to `undefined`) - Allows to define the list of encodings supported by the lambda function
+- `parseLanguages` (defaults to `true`) - Allows to enable/disable the languages parsing
+- `availableLanguages` (defaults to `undefined`) - Allows to define the list of languages supported by the lambda function
+- `parseMediaTypes` (defaults to `true`) - Allows to enable/disable the media types parsing
+- `availableMediaTypes` (defaults to `undefined`) - Allows to define the list of media types supported by the lambda function
+- `failOnMismatch` (defaults to `true`) - If set to true it will throw an HTTP `NotAcceptable` (406) exception whether the negotiation fails for one of the headers (e.g. none of the languages requested are supported by the app)
+
+### Sample Usage
+
+```javascript
+const middy = require('middy')
+const { httpContentNegotiation, httpHeaderNormalizer, httpErrorHandler } = require('middy/middlewares')
+
+const handler = middy((event, context, cb) => {
+  let message, body
+
+  switch (event.preferredLanguage) {
+    case 'it-it':
+      message = 'Ciao Mondo'
+      break
+    case 'fr-fr':
+      message = 'Bonjour le monde'
+      break
+    default:
+      message = 'Hello world'
+  }
+
+  switch (event.preferredMediaType) {
+    case 'application/xml':
+      body = `<message>${message}</message>`
+      break
+    case 'application/yaml':
+      body = `---\nmessage: ${message}`
+    case 'application/json':
+      body = JSON.stringify({ message })
+    default:
+      body = message
+  }
+
+  return cb(null, {
+    statusCode: 200,
+    body
+  })  
+})
+
+handler
+  .use(httpHeaderNormalizer())
+  .use(httpContentNegotiation({
+    parseCharsets: false,
+    parseEncodings: false,
+    availableLanguages: ['it-it', 'fr-fr', 'en']
+    availableMediaTypes: ['application/xml', 'application/yaml', 'application/json', 'text/plain']
+  }))
+  .use(httpErrorHandler())
+
+module.exports = { handler }
 ```
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -27,7 +27,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -446,7 +446,7 @@
         "babylon": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
           "dev": true
         }
       }
@@ -829,7 +829,7 @@
         "babylon": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
           "dev": true
         }
       }
@@ -998,7 +998,7 @@
         "babylon": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
           "dev": true
         }
       }
@@ -1267,7 +1267,7 @@
         "source-map-support": {
           "version": "0.4.18",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+          "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
           "dev": true,
           "requires": {
             "source-map": "0.5.6"
@@ -1997,7 +1997,7 @@
         "function-bind": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+          "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
           "dev": true
         }
       }
@@ -2394,7 +2394,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -3868,7 +3868,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -4233,7 +4233,7 @@
         "babylon": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
           "dev": true
         }
       }
@@ -4283,7 +4283,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -4318,7 +4318,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -4333,7 +4333,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -4446,7 +4446,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -4455,7 +4455,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -4489,7 +4489,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -4498,7 +4498,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -4587,7 +4587,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -4596,7 +4596,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -4639,7 +4639,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -4648,7 +4648,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -4683,7 +4683,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -4692,7 +4692,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -4736,7 +4736,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -4745,7 +4745,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -4820,7 +4820,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -4872,7 +4872,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -4929,7 +4929,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -4938,7 +4938,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -4975,7 +4975,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -4984,7 +4984,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -5018,7 +5018,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -5027,7 +5027,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -5122,7 +5122,7 @@
         "babylon": {
           "version": "7.0.0-beta.19",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
-          "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
+          "integrity": "sha1-6SjH6AfpcOBTaweKs+DEj54FJQM=",
           "dev": true
         }
       }
@@ -5238,7 +5238,7 @@
             "boom": {
               "version": "5.2.0",
               "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+              "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
               "dev": true,
               "requires": {
                 "hoek": "4.2.0"
@@ -5290,7 +5290,7 @@
         "hawk": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+          "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
           "dev": true,
           "requires": {
             "boom": "4.3.1",
@@ -5302,7 +5302,7 @@
         "hoek": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
+          "integrity": "sha1-ctnQdU9/4lyi0BrY+PmpRJqJUm0=",
           "dev": true
         },
         "http-signature": {
@@ -5340,13 +5340,13 @@
         "qs": {
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg=",
           "dev": true
         },
         "request": {
           "version": "2.83.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-          "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+          "integrity": "sha1-ygtl2gLtYpNYh4COb1EDgQNOM1Y=",
           "dev": true,
           "requires": {
             "aws-sign2": "0.7.0",
@@ -5376,7 +5376,7 @@
         "sntp": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-          "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+          "integrity": "sha1-LGzsFP7cIiJznK+bXD2F0cxaLMg=",
           "dev": true,
           "requires": {
             "hoek": "4.2.0"
@@ -5738,6 +5738,11 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -6114,7 +6119,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -6707,7 +6712,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "ajv-keywords": "^3.0.0",
     "content-type": "^1.0.4",
     "http-errors": "^1.6.2",
+    "negotiator": "^0.6.1",
     "qs": "^6.5.0",
     "querystring": "^0.2.0"
   },

--- a/src/middlewares/__tests__/httpContentNegotiation.js
+++ b/src/middlewares/__tests__/httpContentNegotiation.js
@@ -33,4 +33,49 @@ describe('🤑  Middleware HTTP Content Negotiation', () => {
       endTest()
     })
   })
+
+  test('It should skip the middleware if no headers are sent', (endTest) => {
+    // TODO
+    endTest()
+  })
+
+  test('It should not parse charset if disabled', (endTest) => {
+    // TODO
+    endTest()
+  })
+
+  test('It should not parse encoding if disabled', (endTest) => {
+    // TODO
+    endTest()
+  })
+
+  test('It should not parse language if disabled', (endTest) => {
+    // TODO
+    endTest()
+  })
+
+  test('It should not parse media types if disabled', (endTest) => {
+    // TODO
+    endTest()
+  })
+
+  test('It should fail with mismatching charset', (endTest) => {
+    // TODO
+    endTest()
+  })
+
+  test('It should fail with mismatching encoding', (endTest) => {
+    // TODO
+    endTest()
+  })
+
+  test('It should fail with mismatching language', (endTest) => {
+    // TODO
+    endTest()
+  })
+
+  test('It should fail with mismatching media type', (endTest) => {
+    // TODO
+    endTest()
+  })
 })

--- a/src/middlewares/__tests__/httpContentNegotiation.js
+++ b/src/middlewares/__tests__/httpContentNegotiation.js
@@ -1,0 +1,36 @@
+const middy = require('../../middy')
+const httpContentNegotiation = require('../httpContentNegotiation')
+
+describe('🤑  Middleware HTTP Content Negotiation', () => {
+  test('It should parse charset, encoding, language and media type', (endTest) => {
+    const handler = middy((event, context, callback) => callback(null, event))
+    handler.use(httpContentNegotiation({
+      availableCharsets: ['utf-8'],
+      availableEncodings: undefined,
+      availableLanguages: ['en-gb'],
+      availableMediaTypes: ['text/plain', 'text/x-dvi']
+    }))
+
+    const event = {
+      headers: {
+        'Accept-Charset': 'utf-8, iso-8859-5, unicode-1-1;q=0.8',
+        'Accept-Encoding': '*/*',
+        'Accept-Language': 'da, en-gb;q=0.8, en;q=0.7',
+        'Accept': 'text/plain; q=0.5, text/html, text/x-dvi; q=0.8, text/x-c'
+      }
+    }
+
+    handler(event, {}, (_, resultingEvent) => {
+      expect(resultingEvent.preferredCharsets).toEqual(['utf-8'])
+      expect(resultingEvent.preferredCharset).toEqual('utf-8')
+      expect(resultingEvent.preferredEncodings).toEqual(['*/*', 'identity'])
+      expect(resultingEvent.preferredEncoding).toEqual('*/*')
+      expect(resultingEvent.preferredLanguages).toEqual(['en-gb'])
+      expect(resultingEvent.preferredLanguage).toEqual('en-gb')
+      expect(resultingEvent.preferredMediaTypes).toEqual(['text/x-dvi', 'text/plain'])
+      expect(resultingEvent.preferredMediaType).toEqual('text/x-dvi')
+
+      endTest()
+    })
+  })
+})

--- a/src/middlewares/__tests__/httpContentNegotiation.js
+++ b/src/middlewares/__tests__/httpContentNegotiation.js
@@ -35,47 +35,167 @@ describe('🤑  Middleware HTTP Content Negotiation', () => {
   })
 
   test('It should skip the middleware if no headers are sent', (endTest) => {
-    // TODO
-    endTest()
+    const handler = middy((event, context, callback) => callback(null, event))
+    handler.use(httpContentNegotiation({
+      availableCharsets: ['utf-8'],
+      availableEncodings: undefined,
+      availableLanguages: ['en-gb'],
+      availableMediaTypes: ['text/plain', 'text/x-dvi']
+    }))
+
+    const event = {
+      foo: 'bar'
+    }
+
+    handler(event, {}, (_, resultingEvent) => {
+      expect(resultingEvent).toEqual({ foo: 'bar' })
+      endTest()
+    })
   })
 
   test('It should not parse charset if disabled', (endTest) => {
-    // TODO
-    endTest()
+    const handler = middy((event, context, callback) => callback(null, event))
+    handler.use(httpContentNegotiation({
+      parseCharsets: false,
+      availableEncodings: undefined,
+      availableLanguages: ['en-gb'],
+      availableMediaTypes: ['text/plain', 'text/x-dvi']
+    }))
+
+    const event = {
+      headers: {
+        'Accept-Charset': 'utf-8, iso-8859-5, unicode-1-1;q=0.8',
+        'Accept-Encoding': '*/*',
+        'Accept-Language': 'da, en-gb;q=0.8, en;q=0.7',
+        'Accept': 'text/plain; q=0.5, text/html, text/x-dvi; q=0.8, text/x-c'
+      }
+    }
+
+    handler(event, {}, (_, resultingEvent) => {
+      expect(resultingEvent.preferredCharsets).toBeUndefined()
+      expect(resultingEvent.preferredCharset).toBeUndefined()
+      expect(resultingEvent.preferredEncodings).toEqual(['*/*', 'identity'])
+      expect(resultingEvent.preferredEncoding).toEqual('*/*')
+      expect(resultingEvent.preferredLanguages).toEqual(['en-gb'])
+      expect(resultingEvent.preferredLanguage).toEqual('en-gb')
+      expect(resultingEvent.preferredMediaTypes).toEqual(['text/x-dvi', 'text/plain'])
+      expect(resultingEvent.preferredMediaType).toEqual('text/x-dvi')
+
+      endTest()
+    })
   })
 
   test('It should not parse encoding if disabled', (endTest) => {
-    // TODO
-    endTest()
+    const handler = middy((event, context, callback) => callback(null, event))
+    handler.use(httpContentNegotiation({
+      availableCharsets: ['utf-8'],
+      parseEncodings: undefined,
+      availableLanguages: ['en-gb'],
+      availableMediaTypes: ['text/plain', 'text/x-dvi']
+    }))
+
+    const event = {
+      headers: {
+        'Accept-Charset': 'utf-8, iso-8859-5, unicode-1-1;q=0.8',
+        'Accept-Encoding': '*/*',
+        'Accept-Language': 'da, en-gb;q=0.8, en;q=0.7',
+        'Accept': 'text/plain; q=0.5, text/html, text/x-dvi; q=0.8, text/x-c'
+      }
+    }
+
+    handler(event, {}, (_, resultingEvent) => {
+      expect(resultingEvent.preferredCharsets).toEqual(['utf-8'])
+      expect(resultingEvent.preferredCharset).toEqual('utf-8')
+      expect(resultingEvent.preferredEncodings).toBeUndefined()
+      expect(resultingEvent.preferredEncoding).toBeUndefined()
+      expect(resultingEvent.preferredLanguages).toEqual(['en-gb'])
+      expect(resultingEvent.preferredLanguage).toEqual('en-gb')
+      expect(resultingEvent.preferredMediaTypes).toEqual(['text/x-dvi', 'text/plain'])
+      expect(resultingEvent.preferredMediaType).toEqual('text/x-dvi')
+
+      endTest()
+    })
   })
 
   test('It should not parse language if disabled', (endTest) => {
-    // TODO
-    endTest()
+    const handler = middy((event, context, callback) => callback(null, event))
+    handler.use(httpContentNegotiation({
+      availableCharsets: ['utf-8'],
+      availableEncodings: undefined,
+      parseLanguages: false,
+      availableMediaTypes: ['text/plain', 'text/x-dvi']
+    }))
+
+    const event = {
+      headers: {
+        'Accept-Charset': 'utf-8, iso-8859-5, unicode-1-1;q=0.8',
+        'Accept-Encoding': '*/*',
+        'Accept-Language': 'da, en-gb;q=0.8, en;q=0.7',
+        'Accept': 'text/plain; q=0.5, text/html, text/x-dvi; q=0.8, text/x-c'
+      }
+    }
+
+    handler(event, {}, (_, resultingEvent) => {
+      expect(resultingEvent.preferredCharsets).toEqual(['utf-8'])
+      expect(resultingEvent.preferredCharset).toEqual('utf-8')
+      expect(resultingEvent.preferredEncodings).toEqual(['*/*', 'identity'])
+      expect(resultingEvent.preferredEncoding).toEqual('*/*')
+      expect(resultingEvent.preferredLanguages).toBeUndefined()
+      expect(resultingEvent.preferredLanguage).toBeUndefined()
+      expect(resultingEvent.preferredMediaTypes).toEqual(['text/x-dvi', 'text/plain'])
+      expect(resultingEvent.preferredMediaType).toEqual('text/x-dvi')
+
+      endTest()
+    })
   })
 
   test('It should not parse media types if disabled', (endTest) => {
-    // TODO
-    endTest()
+    const handler = middy((event, context, callback) => callback(null, event))
+    handler.use(httpContentNegotiation({
+      availableCharsets: ['utf-8'],
+      availableEncodings: undefined,
+      availableLanguages: ['en-gb'],
+      parseMediaTypes: false
+    }))
+
+    const event = {
+      headers: {
+        'Accept-Charset': 'utf-8, iso-8859-5, unicode-1-1;q=0.8',
+        'Accept-Encoding': '*/*',
+        'Accept-Language': 'da, en-gb;q=0.8, en;q=0.7',
+        'Accept': 'text/plain; q=0.5, text/html, text/x-dvi; q=0.8, text/x-c'
+      }
+    }
+
+    handler(event, {}, (_, resultingEvent) => {
+      expect(resultingEvent.preferredCharsets).toEqual(['utf-8'])
+      expect(resultingEvent.preferredCharset).toEqual('utf-8')
+      expect(resultingEvent.preferredEncodings).toEqual(['*/*', 'identity'])
+      expect(resultingEvent.preferredEncoding).toEqual('*/*')
+      expect(resultingEvent.preferredLanguages).toEqual(['en-gb'])
+      expect(resultingEvent.preferredLanguage).toEqual('en-gb')
+      expect(resultingEvent.preferredMediaTypes).toBeUndefined()
+      expect(resultingEvent.preferredMediaType).toBeUndefined()
+
+      endTest()
+    })
   })
 
-  test('It should fail with mismatching charset', (endTest) => {
-    // TODO
-    endTest()
-  })
+  test('It should fail when mismatching', (endTest) => {
+    const handler = middy((event, context, callback) => callback(null, event))
+    handler.use(httpContentNegotiation({
+      availableMediaTypes: ['text/plain', 'text/x-dvi']
+    }))
 
-  test('It should fail with mismatching encoding', (endTest) => {
-    // TODO
-    endTest()
-  })
+    const event = {
+      headers: {
+        'Accept': 'application/json'
+      }
+    }
 
-  test('It should fail with mismatching language', (endTest) => {
-    // TODO
-    endTest()
-  })
-
-  test('It should fail with mismatching media type', (endTest) => {
-    // TODO
-    endTest()
+    handler(event, {}, (err, resultingEvent) => {
+      expect(err.message).toEqual('Unsupported mediaType. Acceptable values: text/plain, text/x-dvi')
+      endTest()
+    })
   })
 })

--- a/src/middlewares/httpContentNegotiation.js
+++ b/src/middlewares/httpContentNegotiation.js
@@ -41,7 +41,7 @@ module.exports = (opts) => {
 
         if (options.parseLanguages) {
           const parseLanguage = require('negotiator/lib/language')
-          event.preferredLanguages = parseLanguage(event.headers['Accept-Language'], options.availableEncodings)
+          event.preferredLanguages = parseLanguage(event.headers['Accept-Language'], options.availableLanguages)
           event.preferredLanguage = event.preferredLanguages[0]
 
           if (typeof event.preferredLanguage === 'undefined' && options.failOnMismatch) {
@@ -51,7 +51,7 @@ module.exports = (opts) => {
 
         if (options.parseMediaTypes) {
           const parseMediaType = require('negotiator/lib/mediaType')
-          event.preferredMediaTypes = parseMediaType(event.headers['Accept'], options.availableEncodings)
+          event.preferredMediaTypes = parseMediaType(event.headers['Accept'], options.availableMediaTypes)
           event.preferredMediaType = event.preferredMediaTypes[0]
 
           if (typeof event.preferredMediaType === 'undefined' && options.failOnMismatch) {

--- a/src/middlewares/httpContentNegotiation.js
+++ b/src/middlewares/httpContentNegotiation.js
@@ -1,0 +1,66 @@
+const createError = require('http-errors')
+
+module.exports = (opts) => {
+  const defaults = {
+    parseCharsets: true,
+    availableCharsets: undefined,
+    parseEncodings: true,
+    availableEncodings: undefined,
+    parseLanguages: true,
+    availableLanguages: undefined,
+    parseMediaTypes: true,
+    availableMediaTypes: undefined,
+    failOnMismatch: true
+  }
+
+  const options = Object.assign({}, defaults, opts)
+
+  return ({
+    before: (handler, next) => {
+      const { event } = handler
+      if (event.headers) {
+        if (options.parseCharsets) {
+          const parseCharset = require('negotiator/lib/charset')
+          event.preferredCharsets = parseCharset(event.headers['Accept-Charset'], options.availableCharsets)
+          event.preferredCharset = event.preferredCharsets[0]
+
+          if (typeof event.preferredCharset === 'undefined' && options.failOnMismatch) {
+            throw new createError.NotAcceptable(`Unsupported charset. Acceptable charsets: ${options.availableCharsets.join(', ')}`)
+          }
+        }
+
+        if (options.parseEncodings) {
+          const parseEncoding = require('negotiator/lib/encoding')
+          event.preferredEncodings = parseEncoding(event.headers['Accept-Encoding'], options.availableEncodings)
+          event.preferredEncoding = event.preferredEncodings[0]
+
+          if (typeof event.preferredEncoding === 'undefined' && options.failOnMismatch) {
+            throw new createError.NotAcceptable(`Unsupported encoding. Acceptable encodings: ${options.availableEncodings.join(', ')}`)
+          }
+        }
+
+        if (options.parseLanguages) {
+          const parseLanguage = require('negotiator/lib/language')
+          event.preferredLanguages = parseLanguage(event.headers['Accept-Language'], options.availableEncodings)
+          event.preferredLanguage = event.preferredLanguages[0]
+
+          if (typeof event.preferredLanguage === 'undefined' && options.failOnMismatch) {
+            throw new createError.NotAcceptable(`Unsupported language. Acceptable languages: ${options.availableLanguages.join(', ')}`)
+          }
+        }
+
+        if (options.parseMediaTypes) {
+          const parseMediaType = require('negotiator/lib/mediaType')
+          event.preferredMediaTypes = parseMediaType(event.headers['Accept'], options.availableEncodings)
+          event.preferredMediaType = event.preferredMediaTypes[0]
+
+          if (typeof event.preferredMediaType === 'undefined' && options.failOnMismatch) {
+            throw new createError.NotAcceptable(`Unsupported mediaType. Acceptable mediaTypes: ${options.availableMediaTypes.join(', ')}`)
+          }
+        }
+      }
+
+      return next()
+    }
+  })
+}

--- a/src/middlewares/index.js
+++ b/src/middlewares/index.js
@@ -2,6 +2,7 @@ module.exports = {
   cache: require('./cache'),
   cors: require('./cors'),
   doNotWaitForEmptyEventLoop: require('./doNotWaitForEmptyEventLoop'),
+  httpContentNegotiation: require('./httpContentNegotiation'),
   httpErrorHandler: require('./httpErrorHandler'),
   httpEventNormalizer: require('./httpEventNormalizer'),
   httpHeaderNormalizer: require('./httpHeaderNormalizer'),


### PR DESCRIPTION
This PR implements a middleware that will simplify [HTTP content negotiation](https://tools.ietf.org/html/rfc7231#section-5.3) parsing and easily allow an API gateway Lambda function to support multiple charsets, encoding (e.g. compression algorithms), languages or content-types.

My current approach is to use the module [negotiator](http://npm.im/negotiator) (used also by express and koa) to parse the content negotiation headers and expand the current event with data that can be reused by other middlewares or in the handler.

For instance, this middleware can parse the incoming `Accept` header and expose the resulting information in something like `event.preferredMediaType`.

A usage example might look like the following:

```javascript
const middy = require('middy')
const { httpContentNegotiation } = require('middy/middlewares')

const handler = middy((event, context, callback) => {
  if (event.preferredMediaType === 'application/json') {
    return callback(null, {stastusCode: 200, body: JSON.stringify({foo: 'bar'})})
  }

  if (event.preferredMediaType === 'application/xml') {
    return callback(null, {stastusCode: 200, body: '<foo>bar</foo>'})
  }

  return callback(null, {statusCode: 406, body: 'Unsupported Media Type'})
})

handler.use(httpContentNegotiation())

module.exports = { handler }
```

This middleware could be the basis to create another middleware that allows to automatically serialize the API Gateway response body into the user preferred format (e.g. JSON vs XML). The combination of both middlewares should be enough to close issue number #64 (Improve HTTP error messages), as it will be easy to automatically serialize the error in the expected format.

Closes #103 

---

## TODO

- [x] Tests
- [x] Documentation
