### PR TITLE
Make IMiddy extend Handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "src/index.js",
   "files": [

--- a/typescript/middy.d.ts
+++ b/typescript/middy.d.ts
@@ -7,7 +7,7 @@ declare var middy: {
 };
 
 declare namespace middy {
-  interface IMiddy {
+  interface IMiddy extends Handler {
     use: IMiddyUseFunction;
     before: IMiddyMiddlewareFunction;
     after: IMiddyMiddlewareFunction;


### PR DESCRIPTION

Hi! I was writing some tests for my App and I noticed this:
(newTechHandler is a handler returned by middy())
![image](https://user-images.githubusercontent.com/12840136/36625732-183e7ac8-1904-11e8-961d-af833d9f2ead.png)

this PR fixes this problem