### PR TITLE
Extra CORS options

### DIFF
--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -75,13 +75,15 @@ const handler = middy(originalHandler)
 
 ## [cors](/src/middlewares/cors.js)
 
-Sets CORS headers (`Access-Control-Allow-Origin`), necessary for making cross-origin requests, to response object.
+Sets CORS headers (`Access-Control-Allow-Origin`, `Access-Control-Allow-Headers`, `Access-Control-Allow-Credentials`), necessary for making cross-origin requests, to response object.
 
 Sets headers in `after` and `onError` phases.
 
 ### Options
 
  - `origin` (string) (optional): origin to put in the header (default: "`*`")
+ - `headers` (string) (optional): value to put in Access-Control-Allow-Headers (default: `null`)
+ - `credentials` (bool) (optional): if true, sets the `Access-Control-Allow-Origin` as request header `Origin`, if present (default `false`)
 
 ### Sample usage
 

--- a/middlewares.d.ts
+++ b/middlewares.d.ts
@@ -4,6 +4,8 @@ import middy from './middy'
 
 interface ICorsOptions {
   origin: string;
+  headers: string;
+  credentials: boolean;
 }
 
 interface ICacheOptions {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.9.6",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.9.6",
+  "version": "0.10.0",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
   "files": [

--- a/src/middlewares/__tests__/cors.js
+++ b/src/middlewares/__tests__/cors.js
@@ -16,9 +16,7 @@ describe('📦 Middleware CORS', () => {
     handler(event, {}, (_, response) => {
       expect(response).toEqual({
         headers: {
-          'Access-Control-Allow-Origin': '*',
-          'Access-Control-Allow-Headers':
-            'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent'
+          'Access-Control-Allow-Origin': '*'
         }
       })
     })
@@ -49,9 +47,7 @@ describe('📦 Middleware CORS', () => {
     handler(event, {}, (_, response) => {
       expect(response).toEqual({
         headers: {
-          'Access-Control-Allow-Origin': 'https://example.com',
-          'Access-Control-Allow-Headers':
-            'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent'
+          'Access-Control-Allow-Origin': 'https://example.com'
         }
       })
     })
@@ -75,9 +71,7 @@ describe('📦 Middleware CORS', () => {
     handler(event, {}, (_, response) => {
       expect(response).toEqual({
         headers: {
-          'Access-Control-Allow-Origin': 'https://example.com',
-          'Access-Control-Allow-Headers':
-            'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent'
+          'Access-Control-Allow-Origin': 'https://example.com'
         }
       })
     })
@@ -101,9 +95,7 @@ describe('📦 Middleware CORS', () => {
     handler(event, {}, (_, response) => {
       expect(response).toEqual({
         headers: {
-          'Access-Control-Allow-Origin': 'https://example.com',
-          'Access-Control-Allow-Headers':
-            'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent'
+          'Access-Control-Allow-Origin': 'https://example.com'
         }
       })
     })
@@ -125,7 +117,9 @@ describe('📦 Middleware CORS', () => {
         next()
       }
     })
-    handler.use(cors())
+    handler.use(cors({
+      headers: 'x-example-2'
+    }))
 
     const event = {
       httpMethod: 'GET'
@@ -196,9 +190,7 @@ describe('📦 Middleware CORS', () => {
       expect(response).toEqual({
         headers: {
           'Access-Control-Allow-Credentials': 'false',
-          'Access-Control-Allow-Origin': '*',
-          'Access-Control-Allow-Headers':
-            'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent'
+          'Access-Control-Allow-Origin': '*'
         }
       })
     })
@@ -237,9 +229,7 @@ describe('📦 Middleware CORS', () => {
       expect(response).toEqual({
         headers: {
           'Access-Control-Allow-Credentials': 'true',
-          'Access-Control-Allow-Origin': 'http://example.com',
-          'Access-Control-Allow-Headers':
-            'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent'
+          'Access-Control-Allow-Origin': 'http://example.com'
         }
       })
     })
@@ -267,9 +257,7 @@ describe('📦 Middleware CORS', () => {
       expect(response).toEqual({
         headers: {
           'Access-Control-Allow-Credentials': 'true',
-          'Access-Control-Allow-Origin': 'http://example.com',
-          'Access-Control-Allow-Headers':
-            'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent'
+          'Access-Control-Allow-Origin': 'http://example.com'
         }
       })
     })

--- a/src/middlewares/__tests__/cors.js
+++ b/src/middlewares/__tests__/cors.js
@@ -16,7 +16,9 @@ describe('📦 Middleware CORS', () => {
     handler(event, {}, (_, response) => {
       expect(response).toEqual({
         headers: {
-          'Access-Control-Allow-Origin': '*'
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Headers':
+            'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent'
         }
       })
     })
@@ -47,7 +49,9 @@ describe('📦 Middleware CORS', () => {
     handler(event, {}, (_, response) => {
       expect(response).toEqual({
         headers: {
-          'Access-Control-Allow-Origin': 'https://example.com'
+          'Access-Control-Allow-Origin': 'https://example.com',
+          'Access-Control-Allow-Headers':
+            'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent'
         }
       })
     })
@@ -58,9 +62,11 @@ describe('📦 Middleware CORS', () => {
       cb(null, {})
     })
 
-    handler.use(cors({
-      origin: 'https://example.com'
-    }))
+    handler.use(
+      cors({
+        origin: 'https://example.com'
+      })
+    )
 
     const event = {
       httpMethod: 'GET'
@@ -69,7 +75,9 @@ describe('📦 Middleware CORS', () => {
     handler(event, {}, (_, response) => {
       expect(response).toEqual({
         headers: {
-          'Access-Control-Allow-Origin': 'https://example.com'
+          'Access-Control-Allow-Origin': 'https://example.com',
+          'Access-Control-Allow-Headers':
+            'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent'
         }
       })
     })
@@ -80,9 +88,11 @@ describe('📦 Middleware CORS', () => {
       throw new Error('')
     })
 
-    handler.use(cors({
-      origin: 'https://example.com'
-    }))
+    handler.use(
+      cors({
+        origin: 'https://example.com'
+      })
+    )
 
     const event = {
       httpMethod: 'GET'
@@ -91,9 +101,191 @@ describe('📦 Middleware CORS', () => {
     handler(event, {}, (_, response) => {
       expect(response).toEqual({
         headers: {
-          'Access-Control-Allow-Origin': 'https://example.com'
+          'Access-Control-Allow-Origin': 'https://example.com',
+          'Access-Control-Allow-Headers':
+            'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent'
         }
       })
+    })
+  })
+
+  test('It should not override already declared Access-Control-Allow-Headers header', () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, {})
+    })
+
+    // other middleware that puts the cors header
+    handler.use({
+      after: (handler, next) => {
+        handler.response = {
+          headers: {
+            'Access-Control-Allow-Headers': 'x-example'
+          }
+        }
+        next()
+      }
+    })
+    handler.use(cors())
+
+    const event = {
+      httpMethod: 'GET'
+    }
+
+    handler(event, {}, (_, response) => {
+      expect(response).toEqual({
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Headers': 'x-example'
+        }
+      })
+    })
+  })
+
+  test('It should use allowed headers specified in options', () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, {})
+    })
+
+    handler.use(
+      cors({
+        headers: 'x-example'
+      })
+    )
+
+    const event = {
+      httpMethod: 'GET'
+    }
+
+    handler(event, {}, (_, response) => {
+      expect(response).toEqual({
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Headers': 'x-example'
+        }
+      })
+    })
+  })
+
+  test('It should not override already declared Access-Control-Allow-Credentials header as false', () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, {})
+    })
+
+    // other middleware that puts the cors header
+    handler.use({
+      after: (handler, next) => {
+        handler.response = {
+          headers: {
+            'Access-Control-Allow-Credentials': 'false'
+          }
+        }
+        next()
+      }
+    })
+    handler.use(
+      cors({
+        credentials: true
+      })
+    )
+
+    const event = {
+      httpMethod: 'GET'
+    }
+
+    handler(event, {}, (_, response) => {
+      expect(response).toEqual({
+        headers: {
+          'Access-Control-Allow-Credentials': 'false',
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Headers':
+            'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent'
+        }
+      })
+    })
+  })
+
+  test('It should not override already declared Access-Control-Allow-Credentials header as true', () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, {})
+    })
+
+    // other middleware that puts the cors header
+    handler.use({
+      after: (handler, next) => {
+        handler.response = {
+          headers: {
+            'Access-Control-Allow-Credentials': 'true'
+          }
+        }
+        next()
+      }
+    })
+    handler.use(
+      cors({
+        credentials: false
+      })
+    )
+
+    const event = {
+      httpMethod: 'GET',
+      headers: {
+        Origin: 'http://example.com'
+      }
+    }
+
+    handler(event, {}, (_, response) => {
+      expect(response).toEqual({
+        headers: {
+          'Access-Control-Allow-Credentials': 'true',
+          'Access-Control-Allow-Origin': 'http://example.com',
+          'Access-Control-Allow-Headers':
+            'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent'
+        }
+      })
+    })
+  })
+
+  test('It should use change credentials as specified in options (true)', () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, {})
+    })
+
+    handler.use(
+      cors({
+        credentials: true
+      })
+    )
+
+    const event = {
+      httpMethod: 'GET',
+      headers: {
+        Origin: 'http://example.com'
+      }
+    }
+
+    handler(event, {}, (_, response) => {
+      expect(response).toEqual({
+        headers: {
+          'Access-Control-Allow-Credentials': 'true',
+          'Access-Control-Allow-Origin': 'http://example.com',
+          'Access-Control-Allow-Headers':
+            'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent'
+        }
+      })
+    })
+  })
+
+  test('It should not change anything if HTTP method is not present in the request', () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, {})
+    })
+
+    handler.use(cors())
+
+    const event = {}
+
+    handler(event, {}, (_, response) => {
+      expect(response).toEqual({})
     })
   })
 })

--- a/src/middlewares/cors.js
+++ b/src/middlewares/cors.js
@@ -1,16 +1,38 @@
 const defaults = {
-  origin: '*'
+  origin: '*',
+  headers: 'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent',
+  credentials: false
 }
 
-function addCorsHeaders (opts, handler, next) {
+const getOrigin = (options, handler) => {
+  if (Object.prototype.hasOwnProperty.call(handler.response.headers, 'Access-Control-Allow-Origin')) {
+    return handler.response.headers['Access-Control-Allow-Origin']
+  }
+  handler.event.headers = handler.event.headers || {}
+  if (options.credentials && options.origin === '*' && Object.prototype.hasOwnProperty.call(handler.event.headers, 'Origin')) {
+    return handler.event.headers.Origin
+  }
+  return options.origin
+}
+
+const addCorsHeaders = (opts, handler, next) => {
   const options = Object.assign({}, defaults, opts)
 
-  if (handler.event.hasOwnProperty('httpMethod')) {
+  if (Object.prototype.hasOwnProperty.call(handler.event, 'httpMethod')) {
     handler.response = handler.response || {}
     handler.response.headers = handler.response.headers || {}
 
-    if (!handler.response.headers.hasOwnProperty('Access-Control-Allow-Origin')) {
-      handler.response.headers['Access-Control-Allow-Origin'] = options.origin
+    // Check if already setup the header Access-Control-Allow-Credentials
+    if (Object.prototype.hasOwnProperty.call(handler.response.headers, 'Access-Control-Allow-Credentials')) {
+      options.credentials = JSON.parse(handler.response.headers['Access-Control-Allow-Credentials'])
+    }
+    if (options.credentials) {
+      handler.response.headers['Access-Control-Allow-Credentials'] = String(options.credentials)
+    }
+    handler.response.headers['Access-Control-Allow-Origin'] = getOrigin(options, handler)
+
+    if (!Object.prototype.hasOwnProperty.call(handler.response.headers, 'Access-Control-Allow-Headers')) {
+      handler.response.headers['Access-Control-Allow-Headers'] = options.headers
     }
   }
 

--- a/src/middlewares/cors.js
+++ b/src/middlewares/cors.js
@@ -1,15 +1,13 @@
 const defaults = {
   origin: '*',
-  headers: 'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent',
+  headers: null,
   credentials: false
 }
 
 const getOrigin = (options, handler) => {
-  if (Object.prototype.hasOwnProperty.call(handler.response.headers, 'Access-Control-Allow-Origin')) {
-    return handler.response.headers['Access-Control-Allow-Origin']
-  }
   handler.event.headers = handler.event.headers || {}
-  if (options.credentials && options.origin === '*' && Object.prototype.hasOwnProperty.call(handler.event.headers, 'Origin')) {
+
+  if (options.credentials && options.origin === '*' && handler.event.headers.hasOwnProperty('Origin')) {
     return handler.event.headers.Origin
   }
   return options.origin
@@ -18,21 +16,26 @@ const getOrigin = (options, handler) => {
 const addCorsHeaders = (opts, handler, next) => {
   const options = Object.assign({}, defaults, opts)
 
-  if (Object.prototype.hasOwnProperty.call(handler.event, 'httpMethod')) {
+  if (handler.event.hasOwnProperty('httpMethod')) {
     handler.response = handler.response || {}
     handler.response.headers = handler.response.headers || {}
 
+    // Check if already setup Access-Control-Allow-Headers
+    if (options.headers !== null && !handler.response.headers.hasOwnProperty('Access-Control-Allow-Headers')) {
+      handler.response.headers['Access-Control-Allow-Headers'] = options.headers
+    }
+
     // Check if already setup the header Access-Control-Allow-Credentials
-    if (Object.prototype.hasOwnProperty.call(handler.response.headers, 'Access-Control-Allow-Credentials')) {
+    if (handler.response.headers.hasOwnProperty('Access-Control-Allow-Credentials')) {
       options.credentials = JSON.parse(handler.response.headers['Access-Control-Allow-Credentials'])
     }
+
     if (options.credentials) {
       handler.response.headers['Access-Control-Allow-Credentials'] = String(options.credentials)
     }
-    handler.response.headers['Access-Control-Allow-Origin'] = getOrigin(options, handler)
-
-    if (!Object.prototype.hasOwnProperty.call(handler.response.headers, 'Access-Control-Allow-Headers')) {
-      handler.response.headers['Access-Control-Allow-Headers'] = options.headers
+    // Check if already setup the header Access-Control-Allow-Origin
+    if (!handler.response.headers.hasOwnProperty('Access-Control-Allow-Origin')) {
+      handler.response.headers['Access-Control-Allow-Origin'] = getOrigin(options, handler)
     }
   }
 


### PR DESCRIPTION
Adds the ability to set Access-Control-Allow-Credentials and Access-Control-Allow-Headers for the CORS middleware.
It solves 2 of the 4 options from #43 