### PR TITLE
Include middleware type definition when creating releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,14 @@
   "version": "0.10.3",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
-  "files": ["src", "index.js", "index.d.ts", "middlewares.js", "middlewares.d.ts", "!__tests__"],
+  "files": [
+    "src",
+    "index.js",
+    "index.d.ts",
+    "middlewares.js",
+    "middlewares.d.ts",
+    "!__tests__"
+  ],
   "types": "./index.d.ts",
   "scripts": {
     "test:lint": "eslint --ignore-pattern='node_modules/' --ignore-pattern='coverage/' --ignore-pattern='docs/' .",
@@ -21,7 +28,14 @@
     "type": "git",
     "url": "git+https://github.com/middyjs/middy.git"
   },
-  "keywords": ["Lambda", "Middleware", "Serverless", "Framework"],
+  "keywords": [
+    "Lambda",
+    "Middleware",
+    "Serverless",
+    "Framework",
+    "AWS",
+    "AWS Lambda"
+  ],
   "author": "Luciano Mammino, Peter Caulfield, Joe Minichino, Domagoj Katavic",
   "license": "MIT",
   "bugs": {
@@ -58,6 +72,8 @@
     "querystring": "^0.2.0"
   },
   "jest": {
-    "collectCoverageFrom": ["src/**/*.js"]
+    "collectCoverageFrom": [
+      "src/**/*.js"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.10.2",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
-  "files": ["src", "typescript", "index.js", "index.d.ts", "middlewares.js", "middlewares.d.ts", "!__tests__"],
+  "files": ["src", "index.js", "index.d.ts", "middlewares.js", "middlewares.d.ts", "!__tests__"],
   "types": "./index.d.ts",
   "scripts": {
     "test:lint": "eslint --ignore-pattern='node_modules/' --ignore-pattern='coverage/' --ignore-pattern='docs/' .",

--- a/package.json
+++ b/package.json
@@ -3,14 +3,7 @@
   "version": "0.10.2",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
-  "files": [
-    "src",
-    "typescript",
-    "index.js",
-    "index.d.ts",
-    "middlewares.js",
-    "!__tests__"
-  ],
+  "files": ["src", "typescript", "index.js", "index.d.ts", "middlewares.js", "middlewares.d.ts", "!__tests__"],
   "types": "./index.d.ts",
   "scripts": {
     "test:lint": "eslint --ignore-pattern='node_modules/' --ignore-pattern='coverage/' --ignore-pattern='docs/' .",
@@ -28,12 +21,7 @@
     "type": "git",
     "url": "git+https://github.com/middyjs/middy.git"
   },
-  "keywords": [
-    "Lambda",
-    "Middleware",
-    "Serverless",
-    "Framework"
-  ],
+  "keywords": ["Lambda", "Middleware", "Serverless", "Framework"],
   "author": "Luciano Mammino, Peter Caulfield, Joe Minichino, Domagoj Katavic",
   "license": "MIT",
   "bugs": {
@@ -70,8 +58,6 @@
     "querystring": "^0.2.0"
   },
   "jest": {
-    "collectCoverageFrom": [
-      "src/**/*.js"
-    ]
+    "collectCoverageFrom": ["src/**/*.js"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
   "files": ["src", "index.js", "index.d.ts", "middlewares.js", "middlewares.d.ts", "!__tests__"],


### PR DESCRIPTION
Included the new middleware.d.ts type definition file in the package.json files array.