### PR TITLE
Add option to validate only POST body in validator middleware

### DIFF
--- a/src/middlewares/validator.js
+++ b/src/middlewares/validator.js
@@ -7,7 +7,7 @@ let ajv
 let previousConstructorOptions
 const defaults = {v5: true, $data: true, allErrors: true}
 
-module.exports = ({inputSchema, outputSchema, ajvOptions}) => {
+module.exports = ({inputSchema, outputSchema, ajvOptions, inputBodyOnly}) => {
   const options = Object.assign({}, defaults, ajvOptions)
   lazyLoadAjv(options)
 
@@ -20,7 +20,9 @@ module.exports = ({inputSchema, outputSchema, ajvOptions}) => {
         return next()
       }
 
-      const valid = validateInput(handler.event)
+      // validate only the body payload, or the whole event object
+      const data = inputBodyOnly ? handler.event.body : handler.event
+      const valid = validateInput(data)
 
       if (!valid) {
         const error = new createError.BadRequest('Event object failed validation')


### PR DESCRIPTION
Hey guys.

I'm automatically deriving POST body schemas from a swagger doc, but I'm unable to use the `validator` middleware since it validates the whole `event` object, and not just the `body` property.

This patch fixes it for me - but I'm not sure if the implementation is what you would like.