### PR TITLE
Update ssm middleware to accept paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,19 +494,20 @@ on how to write a middleware.
 
 Currently available middlewares:
 
- - [`cache`](/docs/middlewares.md#cache): a simple but flexible caching layer
- - [`cors`](/docs/middlewares.md#cors): sets CORS headers on response
- - [`doNotWaitForEmptyEventLoop`](/docs/middlewares.md#donotwaitforemptyeventloop): sets callbackWaitsForEmptyEventLoop property to false
+ - [`cache`](/docs/middlewares.md#cache): A simple but flexible caching layer
+ - [`cors`](/docs/middlewares.md#cors): Sets CORS headers on response
+ - [`doNotWaitForEmptyEventLoop`](/docs/middlewares.md#donotwaitforemptyeventloop): Sets callbackWaitsForEmptyEventLoop property to false
  - [`httpContentNegotiation`](/docs/middlewares.md#httpcontentnegotiation): Parses `Accept-*` headers and provides utilities for content negotiation (charset, encoding, language and media type) for HTTP requests
- - [`httpErrorHandler`](/docs/middlewares.md#httperrorhandler): creates a proper HTTP response for errors that are created with the [http-errors](https://www.npmjs.com/package/http-errors) module and represents proper HTTP errors.
+ - [`httpErrorHandler`](/docs/middlewares.md#httperrorhandler): Creates a proper HTTP response for errors that are created with the [http-errors](https://www.npmjs.com/package/http-errors) module and represents proper HTTP errors.
  - [`httpEventNormalizer`](/docs/middlewares.md#httpEventNormalizer): Normalizes HTTP events by adding an empty object for `queryStringParameters` and `pathParameters` if they are missing.
  - [`httpHeaderNormalizer`](/docs/middlewares.md#httpheadernormalizer): Normalizes HTTP header names to their canonical format
  - [`httpPartialResponse`](/docs/middlewares.md#httppartialresponse): Filter response objects attributes based on query string parameters.
- - [`jsonBodyParser`](/docs/middlewares.md#jsonbodyparser): automatically parses HTTP requests with JSON body and converts the body into an object. Also handles gracefully broken JSON if used in combination of
+ - [`jsonBodyParser`](/docs/middlewares.md#jsonbodyparser): Automatically parses HTTP requests with JSON body and converts the body into an object. Also handles gracefully broken JSON if used in combination of
  `httpErrorHanler`.
- - [`s3KeyNormalizer`](/docs/middlewares.md#s3keynormalizer): normalizes key names in s3 events.
- - [`validator`](/docs/middlewares.md#validator): automatically validates incoming events and outgoing responses against custom schemas
- - [`urlEncodeBodyParser`](/docs/middlewares.md#urlencodebodyparser): automatically parses HTTP requests with URL encoded body (typically the result of a form submit).
+ - [`s3KeyNormalizer`](/docs/middlewares.md#s3keynormalizer): Normalizes key names in s3 events.
+ - [`ssm`](/docs/middlewares.md#ssm): Fetches parameters from [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html).
+ - [`validator`](/docs/middlewares.md#validator): Automatically validates incoming events and outgoing responses against custom schemas
+ - [`urlEncodeBodyParser`](/docs/middlewares.md#urlencodebodyparser): Automatically parses HTTP requests with URL encoded body (typically the result of a form submit).
  - [`warmup`](/docs/middlewares.md#warmup): Warmup middleware that helps to reduce the [cold-start issue](https://serverless.com/blog/keep-your-lambdas-warm/)
 
 

--- a/README.md
+++ b/README.md
@@ -502,7 +502,7 @@ Currently available middlewares:
  - [`httpEventNormalizer`](/docs/middlewares.md#httpEventNormalizer): Normalizes HTTP events by adding an empty object for `queryStringParameters` and `pathParameters` if they are missing.
  - [`httpHeaderNormalizer`](/docs/middlewares.md#httpheadernormalizer): Normalizes HTTP header names to their canonical format
  - [`httpPartialResponse`](/docs/middlewares.md#httppartialresponse): Filter response objects attributes based on query string parameters.
- - [`jsonBodyParser`](/docs/middlewares.md#jsonbodyparser): Automatically parses HTTP requests with JSON body and converts the body into an object. Also handles gracefully broken JSON if used in combination of
+ - [`jsonBodyParser`](/docs/middlewares.md#jsonbodyparser): automatically parses HTTP requests with JSON body and converts the body into an object. Also handles gracefully broken JSON if used in combination of
  `httpErrorHanler`.
  - [`s3KeyNormalizer`](/docs/middlewares.md#s3keynormalizer): Normalizes key names in s3 events.
  - [`ssm`](/docs/middlewares.md#ssm): Fetches parameters from [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html).
@@ -593,9 +593,7 @@ Middy factory function. Use it to wrap your existing handler to enable middlewar
 
 ## middlewareFunction ⇒ <code>void</code> \| <code>Promise</code>
 **Kind**: global typedef  
-**Returns**: <code>void</code> \| <code>Promise</code> - - A middleware can return a Promise instead of using the `next` function as a callback.
-                         In this case middy will wait for the promise to resolve (or reject) and it will automatically
-                         propagate the result to the next middleware.  
+**Returns**: <code>void</code> \| <code>Promise</code> - - A middleware can return a Promise instead of using the `next` function as a callback.                         In this case middy will wait for the promise to resolve (or reject) and it will automatically                         propagate the result to the next middleware.  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -502,7 +502,7 @@ Currently available middlewares:
  - [`httpEventNormalizer`](/docs/middlewares.md#httpEventNormalizer): Normalizes HTTP events by adding an empty object for `queryStringParameters` and `pathParameters` if they are missing.
  - [`httpHeaderNormalizer`](/docs/middlewares.md#httpheadernormalizer): Normalizes HTTP header names to their canonical format
  - [`httpPartialResponse`](/docs/middlewares.md#httppartialresponse): Filter response objects attributes based on query string parameters.
- - [`jsonBodyParser`](/docs/middlewares.md#jsonbodyparser): automatically parses HTTP requests with JSON body and converts the body into an object. Also handles gracefully broken JSON if used in combination of
+ - [`jsonBodyParser`](/docs/middlewares.md#jsonbodyparser): Automatically parses HTTP requests with JSON body and converts the body into an object. Also handles gracefully broken JSON if used in combination of
  `httpErrorHanler`.
  - [`s3KeyNormalizer`](/docs/middlewares.md#s3keynormalizer): Normalizes key names in s3 events.
  - [`ssm`](/docs/middlewares.md#ssm): Fetches parameters from [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html).

--- a/README.md.hb
+++ b/README.md.hb
@@ -494,19 +494,20 @@ on how to write a middleware.
 
 Currently available middlewares:
 
- - [`cache`](/docs/middlewares.md#cache): a simple but flexible caching layer
- - [`cors`](/docs/middlewares.md#cors): sets CORS headers on response
- - [`doNotWaitForEmptyEventLoop`](/docs/middlewares.md#donotwaitforemptyeventloop): sets callbackWaitsForEmptyEventLoop property to false
+ - [`cache`](/docs/middlewares.md#cache): A simple but flexible caching layer
+ - [`cors`](/docs/middlewares.md#cors): Sets CORS headers on response
+ - [`doNotWaitForEmptyEventLoop`](/docs/middlewares.md#donotwaitforemptyeventloop): Sets callbackWaitsForEmptyEventLoop property to false
  - [`httpContentNegotiation`](/docs/middlewares.md#httpcontentnegotiation): Parses `Accept-*` headers and provides utilities for content negotiation (charset, encoding, language and media type) for HTTP requests
- - [`httpErrorHandler`](/docs/middlewares.md#httperrorhandler): creates a proper HTTP response for errors that are created with the [http-errors](https://www.npmjs.com/package/http-errors) module and represents proper HTTP errors.
+ - [`httpErrorHandler`](/docs/middlewares.md#httperrorhandler): Creates a proper HTTP response for errors that are created with the [http-errors](https://www.npmjs.com/package/http-errors) module and represents proper HTTP errors.
  - [`httpEventNormalizer`](/docs/middlewares.md#httpEventNormalizer): Normalizes HTTP events by adding an empty object for `queryStringParameters` and `pathParameters` if they are missing.
  - [`httpHeaderNormalizer`](/docs/middlewares.md#httpheadernormalizer): Normalizes HTTP header names to their canonical format
  - [`httpPartialResponse`](/docs/middlewares.md#httppartialresponse): Filter response objects attributes based on query string parameters.
  - [`jsonBodyParser`](/docs/middlewares.md#jsonbodyparser): automatically parses HTTP requests with JSON body and converts the body into an object. Also handles gracefully broken JSON if used in combination of
  `httpErrorHanler`.
- - [`s3KeyNormalizer`](/docs/middlewares.md#s3keynormalizer): normalizes key names in s3 events.
- - [`validator`](/docs/middlewares.md#validator): automatically validates incoming events and outgoing responses against custom schemas
- - [`urlEncodeBodyParser`](/docs/middlewares.md#urlencodebodyparser): automatically parses HTTP requests with URL encoded body (typically the result of a form submit).
+ - [`s3KeyNormalizer`](/docs/middlewares.md#s3keynormalizer): Normalizes key names in s3 events.
+ - [`ssm`](/docs/middlewares.md#ssm): Fetches parameters from [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html).
+ - [`validator`](/docs/middlewares.md#validator): Automatically validates incoming events and outgoing responses against custom schemas
+ - [`urlEncodeBodyParser`](/docs/middlewares.md#urlencodebodyparser): Automatically parses HTTP requests with URL encoded body (typically the result of a form submit).
  - [`warmup`](/docs/middlewares.md#warmup): Warmup middleware that helps to reduce the [cold-start issue](https://serverless.com/blog/keep-your-lambdas-warm/)
 
 

--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -481,7 +481,7 @@ const handler = middy((event, context, cb) => {
 handler.use(ssm({
   cache: true,
   paths: {
-    SOME_PREFIX_
+    SOME_PREFIX_: '/dev/db'
   },
   names: {
     SOME_ACCESS_TOKEN: '/dev/service_name/access_token'
@@ -489,9 +489,10 @@ handler.use(ssm({
 }))
 
 // Before running function handler, middleware will fetch SSM params
-
+// The '/dev/db' path contains the CONNECTION_STRING parameter
 handler(event, context, (_, response) => {
   expect(process.env.SOME_ACCESS_TOKEN).toEqual('some-access-token')
+  expect(process.env.SOME_PREFIX_CONNECTION_STRING).toEqual('some-connection-string')
 })
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
   "files": [

--- a/src/middlewares/__tests__/ssm.js
+++ b/src/middlewares/__tests__/ssm.js
@@ -188,7 +188,7 @@ describe('🔒 SSM Middleware', () => {
         Parameters: [{Name: '/dev/service_name/mongo_url', Value: 'my-mongo-url'}]
       },
       middlewareOptions: {
-        paths: {'': '/dev/service_name', 'prefix': '/dev'}
+        paths: {'': ['/dev/service_name'], 'prefix': '/dev'}
       },
       cb () {
         expect(process.env.MONGO_URL).toEqual('my-mongo-url')

--- a/src/middlewares/__tests__/ssm.js
+++ b/src/middlewares/__tests__/ssm.js
@@ -167,45 +167,17 @@ describe('🔒 SSM Middleware', () => {
     })
   })
 
-  test(`It should not throw error when empty paths array passed`, (done) => {
-    testScenario({
-      ssmMockResponse: {},
-      middlewareOptions: {paths: []},
-      cb (error) {
-        expect(error).toBeFalsy()
-        done()
-      }
-    })
-  })
-
   test('It should set properties on target with names equal to full parameter name sans specified path', (done) => {
     testScenario({
       ssmMockResponse: {
         Parameters: [{Name: '/dev/service_name/mongo_url', Value: 'my-mongo-url'}]
       },
       middlewareOptions: {
-        paths: ['/dev/service_name']
+        params: {'': '/dev/service_name'},
+        usePaths: true
       },
       cb () {
         expect(process.env.MONGO_URL).toEqual('my-mongo-url')
-        done()
-      }
-    })
-  })
-
-  test('It should call SSMParamsByPath if path is specified', (done) => {
-    testScenario({
-      ssmMockResponse: {
-        Parameters: [ {Name: '/dev/service_name/mongo_url', Value: 'my-mongo-url'} ]
-      },
-      middlewareOptions: {
-        params: {
-          MONGO_URL_BY_NAME: '/dev/service_name/mongo_url'
-        },
-        paths: '/dev/service_name'
-      },
-      cb () {
-        expect(process.env.MONGO_URL_BY_NAME).toBeUndefined()
         done()
       }
     })
@@ -217,11 +189,12 @@ describe('🔒 SSM Middleware', () => {
         Parameters: [{Name: '/dev/service_name/mongo_url', Value: 'my-mongo-url'}]
       },
       middlewareOptions: {
-        paths: ['/dev/service_name', '/dev']
+        params: {'': '/dev/service_name', 'prefix': '/dev'},
+        usePaths: true
       },
       cb () {
         expect(process.env.MONGO_URL).toEqual('my-mongo-url')
-        expect(process.env.SERVICE_NAME_MONGO_URL).toEqual('my-mongo-url')
+        expect(process.env.PREFIX_SERVICE_NAME_MONGO_URL).toEqual('my-mongo-url')
         done()
       }
     })

--- a/src/middlewares/__tests__/ssm.js
+++ b/src/middlewares/__tests__/ssm.js
@@ -46,7 +46,7 @@ describe('🔒 SSM Middleware', () => {
         Parameters: [{Name: '/dev/service_name/mongo_url', Value: 'my-mongo-url'}]
       },
       middlewareOptions: {
-        params: {
+        names: {
           MONGO_URL: '/dev/service_name/mongo_url'
         }
       },
@@ -66,7 +66,7 @@ describe('🔒 SSM Middleware', () => {
         Parameters: [{Name: '/dev/service_name/mongo_url', Value: 'my-mongo-url'}]
       },
       middlewareOptions: {
-        params: {
+        names: {
           MONGO_URL: '/dev/service_name/mongo_url'
         },
         cache: true
@@ -88,7 +88,7 @@ describe('🔒 SSM Middleware', () => {
         secureValue: '/dev/service_name/secure_param'
       },
       middlewareOptions: {
-        params: {
+        names: {
           secureValue: '/dev/service_name/secure_param'
         },
         cache: true,
@@ -107,7 +107,7 @@ describe('🔒 SSM Middleware', () => {
         Parameters: [{Name: '/dev/service_name/secure_param', Value: 'something-secure'}]
       },
       middlewareOptions: {
-        params: {
+        names: {
           secureValue: '/dev/service_name/secure_param'
         },
         cache: true,
@@ -126,7 +126,7 @@ describe('🔒 SSM Middleware', () => {
         Parameters: [{Name: '/dev/service_name/secure_param', Value: 'something-secure'}]
       },
       middlewareOptions: {
-        params: {
+        names: {
           secureValue: '/dev/service_name/secure_param'
         },
         setToContext: true
@@ -144,7 +144,7 @@ describe('🔒 SSM Middleware', () => {
         InvalidParameters: ['invalid-smm-param-name', 'another-invalid-ssm-param']
       },
       middlewareOptions: {
-        params: {
+        names: {
           invalidParam: 'invalid-smm-param-name',
           anotherInvalidParam: 'another-invalid-ssm-param'
         }
@@ -173,8 +173,7 @@ describe('🔒 SSM Middleware', () => {
         Parameters: [{Name: '/dev/service_name/mongo_url', Value: 'my-mongo-url'}]
       },
       middlewareOptions: {
-        params: {'': '/dev/service_name'},
-        usePaths: true
+        paths: {'': '/dev/service_name'}
       },
       cb () {
         expect(process.env.MONGO_URL).toEqual('my-mongo-url')
@@ -189,8 +188,7 @@ describe('🔒 SSM Middleware', () => {
         Parameters: [{Name: '/dev/service_name/mongo_url', Value: 'my-mongo-url'}]
       },
       middlewareOptions: {
-        params: {'': '/dev/service_name', 'prefix': '/dev'},
-        usePaths: true
+        paths: {'': '/dev/service_name', 'prefix': '/dev'}
       },
       cb () {
         expect(process.env.MONGO_URL).toEqual('my-mongo-url')

--- a/src/middlewares/__tests__/ssm.js
+++ b/src/middlewares/__tests__/ssm.js
@@ -220,7 +220,6 @@ describe('🔒 SSM Middleware', () => {
         paths: ['/dev/service_name', '/dev']
       },
       cb () {
-        // console.log(process.env)
         expect(process.env.MONGO_URL).toEqual('my-mongo-url')
         expect(process.env.SERVICE_NAME_MONGO_URL).toEqual('my-mongo-url')
         done()

--- a/src/middlewares/__tests__/ssm.js
+++ b/src/middlewares/__tests__/ssm.js
@@ -111,7 +111,8 @@ describe('🔒 SSM Middleware', () => {
           secureValue: '/dev/service_name/secure_param'
         },
         cache: true,
-        setToContext: true
+        setToContext: true,
+        paramsLoaded: false
       },
       cb () {
         expect(getParametersMock).toBeCalledWith({'Names': ['/dev/service_name/secure_param'], 'WithDecryption': true})

--- a/src/middlewares/__tests__/ssm.js
+++ b/src/middlewares/__tests__/ssm.js
@@ -165,6 +165,17 @@ describe('🔒 SSM Middleware', () => {
     })
   })
 
+  test(`It should not throw error when empty path passed`, (done) => {
+    testScenario({
+      ssmMockResponse: {},
+      middlewareOptions: {path: ''},
+      cb (error) {
+        expect(error).toBeFalsy()
+        done()
+      }
+    })
+  })
+
   test('It should set properties on target with names equal to full parameter name sans specified path', (done) => {
     testScenario({
       ssmMockResponse: {
@@ -175,6 +186,25 @@ describe('🔒 SSM Middleware', () => {
       },
       cb () {
         expect(process.env.MONGO_URL).toEqual('my-mongo-url')
+        done()
+      }
+    })
+  })
+
+  test('It should call SSMParamsByPath if path is specified', (done) => {
+    testScenario({
+      ssmMockResponse: {
+        Parameters: [{Name: '/dev/service_name/mongo_url', Value: 'my-mongo-url'}, {Name: '/dev/other_service/mongo_url', Value: 'my-other-mongo-url'}]
+      },
+      middlewareOptions: {
+        params: {
+          MONGO_URL: '/dev/service_name/mongo_url',
+          OTHER_MONGO_URL: '/dev/other_service/mongo_url'
+        },
+        path: '/dev/service_name'
+      },
+      cb () {
+        expect(process.env.OTHER_MONGO_URL).toBeUndefined()
         done()
       }
     })

--- a/src/middlewares/ssm.js
+++ b/src/middlewares/ssm.js
@@ -76,6 +76,7 @@ function getParamNameFromPathDefault (path, name) {
     .split(`/`)
     .splice(1) // remove starting slash
     .join(`_`) // replace remaining slashes with underscores
+    .toUpperCase()
 }
 
 function getTargetObjectToAssign (handler, options) {

--- a/src/middlewares/ssm.js
+++ b/src/middlewares/ssm.js
@@ -24,7 +24,7 @@ module.exports = opts => {
 
       lazilyLoadSSMInstance(options.awsSdkOptions)
 
-      const ssmPromises = Object.keys(options.paths || {}).reduce((aggregator, prefix) => {
+      const ssmPromises = Object.keys(options.paths).reduce((aggregator, prefix) => {
         const pathsData = options.paths[prefix]
         const paths = Array.isArray(pathsData) ? pathsData : [pathsData]
         return paths.reduce((subAggregator, path) => {
@@ -81,7 +81,7 @@ const getTargetObjectToAssign = (handler, options) => (options.setToContext ? ha
 const areParamsStillCached = (options, targetParamsObject) =>
   options.cache ? !Object.keys(options.names).some(p => typeof targetParamsObject[p] === 'undefined') : false
 
-const getSSMParamValues = userParamsMap => Object.keys(userParamsMap || {}).map(key => userParamsMap[key])
+const getSSMParamValues = userParamsMap => Object.keys(userParamsMap).map(key => userParamsMap[key])
 
 /**
  * Lazily load aws-sdk and initialize SSM constructor

--- a/src/middlewares/ssm.js
+++ b/src/middlewares/ssm.js
@@ -6,8 +6,8 @@ module.exports = opts => {
       maxRetries: 6, // lowers a chance to hit service rate limits, default is 3
       retryDelayOptions: { base: 200 }
     },
-    params: {},
-    usePaths: false,
+    paths: {},
+    names: {},
     getParamNameFromPath: getParamNameFromPathDefault,
     setToContext: false,
     cache: false
@@ -24,36 +24,45 @@ module.exports = opts => {
 
       lazilyLoadSSMInstance(options.awsSdkOptions)
 
-      const ssmParamValues = getSSMParamValues(options.params)
+      const ssmPromises = Object.keys(options.paths || {}).reduce((aggregator, prefix) => {
+        const pathsData = options.paths[prefix]
+        const paths = Array.isArray(pathsData) ? pathsData : [pathsData]
+        return paths.reduce((subAggregator, path) => {
+          subAggregator.push(
+            ssmInstance
+              .getParametersByPath({ Path: path, Recursive: true, WithDecryption: true })
+              .promise()
+              .then(handleInvalidParams)
+              .then(ssmResponse => getParamsToAssignByPath(path, ssmResponse, prefix, options.getParamNameFromPath))
+          )
 
-      if (!ssmParamValues.length) return Promise.resolve()
+          return subAggregator
+        }, aggregator)
+      }, [])
 
-      if (!options.usePaths) {
-        return ssmInstance
-          .getParameters({ Names: ssmParamValues, WithDecryption: true })
-          .promise()
-          .then(handleInvalidParams)
-          .then(ssmResponse => getParamsToAssignByName(options.params, ssmResponse))
-          .then(paramsToAssign => Object.assign(targetParamsObject, paramsToAssign))
+      const ssmParamNames = getSSMParamValues(options.names)
+      if (ssmParamNames.length) {
+        ssmPromises.push(
+          ssmInstance
+            .getParameters({ Names: ssmParamNames, WithDecryption: true })
+            .promise()
+            .then(handleInvalidParams)
+            .then(ssmResponse => getParamsToAssignByName(options.names, ssmResponse))
+        )
       }
 
-      const paramArrays = Object.keys(options.params).map(prefix => {
-        const path = options.params[prefix]
-        return ssmInstance
-          .getParametersByPath({ Path: path, Recursive: true, WithDecryption: true })
-          .promise()
-          .then(handleInvalidParams)
-          .then(ssmResponse => getParamsToAssignByPath(path, ssmResponse, prefix, options.getParamNameFromPath))
-          .then(paramsToAssign => Object.assign(targetParamsObject, paramsToAssign))
-      })
-
-      return Promise.all(paramArrays).then(() => {})
+      return Promise.all(ssmPromises).then(objectsToMap =>
+        objectsToMap.forEach(object => {
+          Object.assign(targetParamsObject, object)
+        })
+      )
     }
   }
 }
 
-// returns full parameter name sans the path as specified, with slashes replaced with underscores
-// e.g. if path is '/dev/myApi/', the parameter '/dev/myApi/connString/default' will be returned with the name 'conString_default'
+// returns full parameter name sans the path as specified, with slashes replaced with underscores and any prefix applied
+// everything gets upper cased
+// e.g. if path is '/dev/myApi/', the parameter '/dev/myApi/connString/default' will be returned with the name 'CONNSTRING_DEFAULT'
 // see: https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-su-organize.html
 const getParamNameFromPathDefault = (path, name, prefix) => {
   const localName = name
@@ -67,13 +76,12 @@ const getParamNameFromPathDefault = (path, name, prefix) => {
   return fullLocalName.toUpperCase()
 }
 
-const getTargetObjectToAssign = (handler, options) => options.setToContext ? handler.context : process.env
+const getTargetObjectToAssign = (handler, options) => (options.setToContext ? handler.context : process.env)
 
-const areParamsStillCached = (options, targetParamsObject) => !options.cache
-  ? false
-  : !Object.keys(options.params).some(p => typeof targetParamsObject[p] === 'undefined')
+const areParamsStillCached = (options, targetParamsObject) =>
+  options.cache ? !Object.keys(options.names).some(p => typeof targetParamsObject[p] === 'undefined') : false
 
-const getSSMParamValues = userParamsMap => Object.keys(userParamsMap).map(key => userParamsMap[key])
+const getSSMParamValues = userParamsMap => Object.keys(userParamsMap || {}).map(key => userParamsMap[key])
 
 /**
  * Lazily load aws-sdk and initialize SSM constructor
@@ -82,7 +90,7 @@ const getSSMParamValues = userParamsMap => Object.keys(userParamsMap).map(key =>
  * or returns if it's already initialized
  * @param {Object} awsSdkOptions Options to use to initialize aws sdk constructor
  */
-const lazilyLoadSSMInstance = (awsSdkOptions) => {
+const lazilyLoadSSMInstance = awsSdkOptions => {
   // lazy load aws-sdk and SSM constructor to avoid performance
   // penalties if you don't use this middleware
 
@@ -127,6 +135,8 @@ const getParamsToAssignByName = (userParamsMap, ssmParams) => {
  * Get object of user param names as keys and SSM param values as value
  * @param {String} userParamsPath Path string from middleware options
  * @param {Object[]} ssmParams Array of parameters from SSM returned by aws-sdk
+ * @param {String} prefix String to prefix to param values from a given path
+ * @param {Function} nameMapper function to build the local name for a param based on path, prefix, and name in SSM
  * @return {Object} Merged object for assignment to target object
  */
 const getParamsToAssignByPath = (userParamsPath, ssmParams, prefix, nameMapper) =>

--- a/src/middlewares/ssm.js
+++ b/src/middlewares/ssm.js
@@ -138,21 +138,10 @@ function getSSMParamsByName (ssmParamNames) {
  * @return {Promise.<Object[]>} Array of SSM params from aws-sdk
  */
 function getSSMParamsByPath (ssmParamPath) {
-  // prevents throwing error from aws-sdk when empty params passed
-  if (!ssmParamPath.length) {
-    return Promise.resolve([])
-  }
-
   return ssmInstance
     .getParametersByPath({ Path: ssmParamPath, Recursive: true, WithDecryption: true })
     .promise()
-    .then(({ Parameters, InvalidParameters }) => {
-      if (InvalidParameters && InvalidParameters.length) {
-        throw new Error(`InvalidParameters present: ${InvalidParameters.join(', ')}`)
-      }
-
-      return Parameters
-    })
+    .then(({ Parameters }) => Parameters)
 }
 
 /**

--- a/src/middlewares/ssm.js
+++ b/src/middlewares/ssm.js
@@ -184,11 +184,16 @@ function getParamsToAssignByName (userParamsMap, ssmParams) {
  * @return {Object} Merged object for assignment to target object
  */
 function getParamsToAssignByPath (userParamsPath, ssmParams, nameMapper) {
-  const targetObject = {}
-  for (let { Name: ssmParamName, Value: ssmParamValue } of ssmParams) {
-    const userParamName = nameMapper(userParamsPath, ssmParamName)
-    targetObject[userParamName] = ssmParamValue
+  const initialValue = {}
+  const reducer = (targetObject, {ssmParamName, ssmParamValue}) => {
+    targetObject[nameMapper(userParamsPath, ssmParamName)] = ssmParamValue
   }
+
+  const targetObject = ssmParams.map(reducer, initialValue)
+  // for (let { Name: ssmParamName, Value: ssmParamValue } of ssmParams) {
+  //   const userParamName = nameMapper(userParamsPath, ssmParamName)
+  //   targetObject[userParamName] = ssmParamValue
+  // }
   return targetObject
 }
 


### PR DESCRIPTION
Introduces functionality discussed in #142. I thought a working example might help!

With this version of the ssm middleware, you can specify both a `names` object and a `paths` object in `config`. (I.e. a map of `LOCAL_NAME -> PARAMETER_NAME` and `LOCAL_NAME -> PARAMETER_PATH` respectively.

This is currently closer to @lmammino's suggested approach. 