### PR TITLE
Adds error details if there

### DIFF
--- a/src/middlewares/__tests__/httpErrorHandler.js
+++ b/src/middlewares/__tests__/httpErrorHandler.js
@@ -20,6 +20,25 @@ describe('📦 Middleware Http Error Handler', () => {
     })
   })
 
+  test('It should create a response for HTTP errors, with details', () => {
+    const handler = middy((event, context, cb) => {
+      const error = new createError.UnprocessableEntity()
+      error.details = 'Try writing tests that pass'
+      throw error
+    })
+
+    handler
+      .use(httpErrorHandler())
+
+    // run the handler
+    handler({}, {}, (_, response) => {
+      expect(response).toEqual({
+        statusCode: 422,
+        body: 'Unprocessable Entity: Try writing tests that pass'
+      })
+    })
+  })
+
   test('It should NOT handle non HTTP errors', () => {
     const handler = middy((event, context, cb) => {
       throw new Error('non-http error')

--- a/src/middlewares/httpErrorHandler.js
+++ b/src/middlewares/httpErrorHandler.js
@@ -3,9 +3,14 @@ const { HttpError } = require('http-errors')
 module.exports = () => ({
   onError: (handler, next) => {
     if (handler.error instanceof HttpError) {
+      let body = handler.error.message
+      if (handler.error.details) {
+        body += `: ${handler.error.details}`
+      }
+
       handler.response = {
         statusCode: handler.error.statusCode,
-        body: handler.error.message
+        body: body
       }
 
       return next()


### PR DESCRIPTION
Using the validation middleware, when validation fails you get this error:

    Event object failed validation

But the error message is added to the error, but just not returned. This adds it to the end of the string, if it’s there.