### PR TITLE
Refer to root module to correctly bring in types

### DIFF
--- a/middlewares.d.ts
+++ b/middlewares.d.ts
@@ -1,7 +1,7 @@
 import { SSM } from 'aws-sdk'
 import { Options as AjvOptions } from 'ajv'
 import { HttpError } from 'http-errors'
-import middy from './src/middy'
+import middy from './'
 
 interface ICorsOptions {
   origin: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
   "files": [


### PR DESCRIPTION
Hey there,

Currently when I build a project using middy I get the following reported back from `tsc`:

```
$ tsc -p .
node_modules/middy/middlewares.d.ts(4,19): error TS7016: Could not find a declaration file for module './src/middy'. '/Users/ossareh/dev/src/code.famfi.co/mono/famfi.co/mailchimp/node_modules/middy/src/middy.js' implicitly has an 'any' type.
  Try `npm install @types/middy` if it exists or add a new declaration (.d.ts) file containing `declare module 'middy';`
```

This patch fixes this issue:

 - middleware.d.ts references middy using the relative reference `./src/middy`;
 - this bypasses the types defined in `index.d.ts`; and thus causes the issue