### PR TITLE
Fix middy import in definition file

### DIFF
--- a/middlewares.d.ts
+++ b/middlewares.d.ts
@@ -1,7 +1,7 @@
 import { SSM } from 'aws-sdk'
 import { Options as AjvOptions } from 'ajv'
 import { HttpError } from 'http-errors'
-import middy from './'
+import * as middy from './'
 
 interface ICorsOptions {
   origin: string;


### PR DESCRIPTION
Allow to use middy with Typescript imports