### PR TITLE
Refactor SSM getParametersByPath to work recursively

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
   "files": [

--- a/src/middlewares/__tests__/ssm.js
+++ b/src/middlewares/__tests__/ssm.js
@@ -15,18 +15,18 @@ describe('🔒 SSM Middleware', () => {
     getParametersMock.mockClear()
     getParametersByPathMock.mockReset()
     getParametersByPathMock.mockClear()
-    delete process.env.MONGO_URL
-    delete process.env.OTHER_MONGO_URL
-    delete process.env.SERVICE_NAME_MONGO_URL
+    delete process.env.KEY_NAME
   })
 
-  function testScenario ({ssmMockResponse, middlewareOptions, context = {}, cb}) {
-    getParametersMock.mockReturnValueOnce({
-      promise: () => Promise.resolve(ssmMockResponse)
-    })
+  function testScenario ({ssmMockResponse, ssmMockResponses, middlewareOptions, context = {}, cb}) {
+    (ssmMockResponses || [ssmMockResponse]).forEach(ssmMockResponse => {
+      getParametersMock.mockReturnValueOnce({
+        promise: () => Promise.resolve(ssmMockResponse)
+      })
 
-    getParametersByPathMock.mockReturnValue({
-      promise: () => Promise.resolve(ssmMockResponse)
+      getParametersByPathMock.mockReturnValueOnce({
+        promise: () => Promise.resolve(ssmMockResponse)
+      })
     })
 
     const handler = middy((event, context, cb) => {
@@ -43,15 +43,15 @@ describe('🔒 SSM Middleware', () => {
   test(`It should set SSM param value to environment variable by default`, (done) => {
     testScenario({
       ssmMockResponse: {
-        Parameters: [{Name: '/dev/service_name/mongo_url', Value: 'my-mongo-url'}]
+        Parameters: [{Name: '/dev/service_name/key_name', Value: 'key-value'}]
       },
       middlewareOptions: {
         names: {
-          MONGO_URL: '/dev/service_name/mongo_url'
+          KEY_NAME: '/dev/service_name/key_name'
         }
       },
       cb () {
-        expect(process.env.MONGO_URL).toEqual('my-mongo-url')
+        expect(process.env.KEY_NAME).toEqual('key-value')
         done()
       }
     })
@@ -59,15 +59,15 @@ describe('🔒 SSM Middleware', () => {
 
   test(`It should not call aws-sdk again if parameter is cached in env`, (done) => {
     // simulate already cached value
-    process.env.MONGO_URL = 'some-value'
+    process.env.KEY_NAME = 'key-value'
 
     testScenario({
       ssmMockResponse: {
-        Parameters: [{Name: '/dev/service_name/mongo_url', Value: 'my-mongo-url'}]
+        Parameters: [{Name: '/dev/service_name/key_name', Value: 'key-value'}]
       },
       middlewareOptions: {
         names: {
-          MONGO_URL: '/dev/service_name/mongo_url'
+          KEY_NAME: '/dev/service_name/key-value'
         },
         cache: true
       },
@@ -171,29 +171,52 @@ describe('🔒 SSM Middleware', () => {
   test('It should set properties on target with names equal to full parameter name sans specified path', (done) => {
     testScenario({
       ssmMockResponse: {
-        Parameters: [{Name: '/dev/service_name/mongo_url', Value: 'my-mongo-url'}]
+        Parameters: [{Name: '/dev/service_name/key_name', Value: 'key-value'}]
       },
       middlewareOptions: {
         paths: {'': '/dev/service_name'}
       },
       cb () {
-        expect(process.env.MONGO_URL).toEqual('my-mongo-url')
+        expect(process.env.KEY_NAME).toEqual('key-value')
         done()
       }
     })
   })
 
   test('It should retrieve params from multiple paths', (done) => {
+    const ssmMockResponse = {
+      Parameters: [{Name: '/dev/service_name/key_name', Value: 'key-value'}]
+    }
     testScenario({
-      ssmMockResponse: {
-        Parameters: [{Name: '/dev/service_name/mongo_url', Value: 'my-mongo-url'}]
-      },
+      ssmMockResponses: [ssmMockResponse, ssmMockResponse],
       middlewareOptions: {
         paths: {'': ['/dev/service_name'], 'prefix': '/dev'}
       },
       cb () {
-        expect(process.env.MONGO_URL).toEqual('my-mongo-url')
-        expect(process.env.PREFIX_SERVICE_NAME_MONGO_URL).toEqual('my-mongo-url')
+        expect(process.env.KEY_NAME).toEqual('key-value')
+        expect(process.env.PREFIX_SERVICE_NAME_KEY_NAME).toEqual('key-value')
+        done()
+      }
+    })
+  })
+
+  test('It should make multiple API calls for a single path if the response contains a token for additional params', (done) => {
+    testScenario({
+      ssmMockResponses: [
+        {
+          Parameters: [{Name: '/dev/service_name/key_name1', Value: 'key-value1'}],
+          NextToken: 'token'
+        },
+        {
+          Parameters: [{Name: '/dev/service_name/key_name2', Value: 'key-value2'}]
+        }
+      ],
+      middlewareOptions: {
+        paths: {'': ['/dev/service_name']}
+      },
+      cb () {
+        expect(process.env.KEY_NAME1).toEqual('key-value1')
+        expect(process.env.KEY_NAME2).toEqual('key-value2')
         done()
       }
     })


### PR DESCRIPTION
Hello,

I found out today (the hard way) that [SSM.getParametersByPath](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SSM.html#getParametersByPath-property) only returns up to 10 parameters per call.

It has a MaxResults property but you can't set this to higher than 10.

Therefore I've refactored the middleware to work recursively if there's a NextToken in the response (indicating that there are additional results).

Let me know if you foresee any issues or need me to change anything.

Thanks in advance.