### PR TITLE
1.0.0 alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "middy-monorepo",
-	"version": "1.0.0-alpha.1",
+	"version": "1.0.0-alpha.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -19,9 +19,9 @@
 			"integrity": "sha512-r4snW6Q8ICL3Y8hGzYJRvyG/+sc+kvkewXNedG9tQjoHmUFMwMSv/o45GWQUQswevGnWghiGkpRPivFfOuMsOA==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.0",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.0"
+				"chalk": "2.4.1",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -30,7 +30,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -39,9 +39,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"supports-color": {
@@ -50,7 +50,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -61,8 +61,8 @@
 			"integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
 			"dev": true,
 			"requires": {
-				"jsonparse": "^1.2.0",
-				"through": ">=2.2.7 <3"
+				"jsonparse": "1.3.1",
+				"through": "2.3.8"
 			}
 		},
 		"abab": {
@@ -83,7 +83,7 @@
 			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
 			"dev": true,
 			"requires": {
-				"acorn": "^5.0.0"
+				"acorn": "5.5.3"
 			}
 		},
 		"acorn-jsx": {
@@ -92,7 +92,7 @@
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
 			"dev": true,
 			"requires": {
-				"acorn": "^3.0.4"
+				"acorn": "3.3.0"
 			},
 			"dependencies": {
 				"acorn": {
@@ -115,9 +115,9 @@
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2",
-				"longest": "^1.0.1",
-				"repeat-string": "^1.5.2"
+				"kind-of": "3.2.2",
+				"longest": "1.0.1",
+				"repeat-string": "1.6.1"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -126,7 +126,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -161,8 +161,8 @@
 			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 			"dev": true,
 			"requires": {
-				"micromatch": "^3.1.4",
-				"normalize-path": "^2.1.1"
+				"micromatch": "3.1.10",
+				"normalize-path": "2.1.1"
 			},
 			"dependencies": {
 				"normalize-path": {
@@ -171,7 +171,7 @@
 					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 					"dev": true,
 					"requires": {
-						"remove-trailing-separator": "^1.0.1"
+						"remove-trailing-separator": "1.1.0"
 					}
 				}
 			}
@@ -182,7 +182,7 @@
 			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
 			"dev": true,
 			"requires": {
-				"default-require-extensions": "^1.0.0"
+				"default-require-extensions": "1.0.0"
 			}
 		},
 		"aproba": {
@@ -197,8 +197,8 @@
 			"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
 			"dev": true,
 			"requires": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^2.0.6"
+				"delegates": "1.0.0",
+				"readable-stream": "2.3.6"
 			}
 		},
 		"argparse": {
@@ -207,7 +207,7 @@
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "~1.0.2"
+				"sprintf-js": "1.0.3"
 			}
 		},
 		"arr-diff": {
@@ -252,7 +252,7 @@
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 			"dev": true,
 			"requires": {
-				"array-uniq": "^1.0.1"
+				"array-uniq": "1.0.3"
 			}
 		},
 		"array-uniq": {
@@ -303,7 +303,7 @@
 			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.14.0"
+				"lodash": "4.17.10"
 			}
 		},
 		"async-limiter": {
@@ -360,9 +360,9 @@
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.3",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.2"
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
 			}
 		},
 		"babel-core": {
@@ -371,25 +371,25 @@
 			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-generator": "^6.26.0",
-				"babel-helpers": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-register": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"convert-source-map": "^1.5.1",
-				"debug": "^2.6.9",
-				"json5": "^0.5.1",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.4",
-				"path-is-absolute": "^1.0.1",
-				"private": "^0.1.8",
-				"slash": "^1.0.0",
-				"source-map": "^0.5.7"
+				"babel-code-frame": "6.26.0",
+				"babel-generator": "6.26.1",
+				"babel-helpers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-register": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"convert-source-map": "1.5.1",
+				"debug": "2.6.9",
+				"json5": "0.5.1",
+				"lodash": "4.17.10",
+				"minimatch": "3.0.4",
+				"path-is-absolute": "1.0.1",
+				"private": "0.1.8",
+				"slash": "1.0.0",
+				"source-map": "0.5.7"
 			}
 		},
 		"babel-generator": {
@@ -398,14 +398,14 @@
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
 			"dev": true,
 			"requires": {
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"detect-indent": "^4.0.0",
-				"jsesc": "^1.3.0",
-				"lodash": "^4.17.4",
-				"source-map": "^0.5.7",
-				"trim-right": "^1.0.1"
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"detect-indent": "4.0.0",
+				"jsesc": "1.3.0",
+				"lodash": "4.17.10",
+				"source-map": "0.5.7",
+				"trim-right": "1.0.1"
 			}
 		},
 		"babel-helper-builder-binary-assignment-operator-visitor": {
@@ -414,9 +414,9 @@
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
 			"dev": true,
 			"requires": {
-				"babel-helper-explode-assignable-expression": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-helper-explode-assignable-expression": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-call-delegate": {
@@ -425,10 +425,10 @@
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
 			"dev": true,
 			"requires": {
-				"babel-helper-hoist-variables": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-hoist-variables": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-define-map": {
@@ -437,10 +437,10 @@
 			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.10"
 			}
 		},
 		"babel-helper-explode-assignable-expression": {
@@ -449,9 +449,9 @@
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-function-name": {
@@ -460,11 +460,11 @@
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
 			"dev": true,
 			"requires": {
-				"babel-helper-get-function-arity": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-get-function-arity": {
@@ -473,8 +473,8 @@
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-hoist-variables": {
@@ -483,8 +483,8 @@
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-optimise-call-expression": {
@@ -493,8 +493,8 @@
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-regex": {
@@ -503,9 +503,9 @@
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.10"
 			}
 		},
 		"babel-helper-remap-async-to-generator": {
@@ -514,11 +514,11 @@
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-replace-supers": {
@@ -527,12 +527,12 @@
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
 			"dev": true,
 			"requires": {
-				"babel-helper-optimise-call-expression": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-optimise-call-expression": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helpers": {
@@ -541,8 +541,8 @@
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-jest": {
@@ -551,8 +551,8 @@
 			"integrity": "sha512-BgSjmtl3mW3i+VeVHEr9d2zFSAT66G++pJcHQiUjd00pkW+voYXFctIm/indcqOWWXw5a1nUpR1XWszD9fJ1qg==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-istanbul": "^4.1.5",
-				"babel-preset-jest": "^22.4.3"
+				"babel-plugin-istanbul": "4.1.6",
+				"babel-preset-jest": "22.4.3"
 			}
 		},
 		"babel-messages": {
@@ -561,7 +561,7 @@
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-check-es2015-constants": {
@@ -570,7 +570,7 @@
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-istanbul": {
@@ -579,10 +579,10 @@
 			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "^6.13.0",
-				"find-up": "^2.1.0",
-				"istanbul-lib-instrument": "^1.10.1",
-				"test-exclude": "^4.2.1"
+				"babel-plugin-syntax-object-rest-spread": "6.13.0",
+				"find-up": "2.1.0",
+				"istanbul-lib-instrument": "1.10.1",
+				"test-exclude": "4.2.1"
 			}
 		},
 		"babel-plugin-jest-hoist": {
@@ -621,9 +621,9 @@
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
 			"dev": true,
 			"requires": {
-				"babel-helper-remap-async-to-generator": "^6.24.1",
-				"babel-plugin-syntax-async-functions": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-remap-async-to-generator": "6.24.1",
+				"babel-plugin-syntax-async-functions": "6.13.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-arrow-functions": {
@@ -632,7 +632,7 @@
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoped-functions": {
@@ -641,7 +641,7 @@
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoping": {
@@ -650,11 +650,11 @@
 			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.10"
 			}
 		},
 		"babel-plugin-transform-es2015-classes": {
@@ -663,15 +663,15 @@
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
 			"dev": true,
 			"requires": {
-				"babel-helper-define-map": "^6.24.1",
-				"babel-helper-function-name": "^6.24.1",
-				"babel-helper-optimise-call-expression": "^6.24.1",
-				"babel-helper-replace-supers": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-define-map": "6.26.0",
+				"babel-helper-function-name": "6.24.1",
+				"babel-helper-optimise-call-expression": "6.24.1",
+				"babel-helper-replace-supers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-computed-properties": {
@@ -680,8 +680,8 @@
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-destructuring": {
@@ -690,7 +690,7 @@
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-duplicate-keys": {
@@ -699,8 +699,8 @@
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-for-of": {
@@ -709,7 +709,7 @@
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-function-name": {
@@ -718,9 +718,9 @@
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-literals": {
@@ -729,7 +729,7 @@
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-amd": {
@@ -738,9 +738,9 @@
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
@@ -749,10 +749,10 @@
 			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-strict-mode": "^6.24.1",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-types": "^6.26.0"
+				"babel-plugin-transform-strict-mode": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-systemjs": {
@@ -761,9 +761,9 @@
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
 			"dev": true,
 			"requires": {
-				"babel-helper-hoist-variables": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-helper-hoist-variables": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-umd": {
@@ -772,9 +772,9 @@
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-object-super": {
@@ -783,8 +783,8 @@
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
 			"dev": true,
 			"requires": {
-				"babel-helper-replace-supers": "^6.24.1",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-replace-supers": "6.24.1",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-parameters": {
@@ -793,12 +793,12 @@
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
 			"dev": true,
 			"requires": {
-				"babel-helper-call-delegate": "^6.24.1",
-				"babel-helper-get-function-arity": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-call-delegate": "6.24.1",
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-shorthand-properties": {
@@ -807,8 +807,8 @@
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-spread": {
@@ -817,7 +817,7 @@
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-sticky-regex": {
@@ -826,9 +826,9 @@
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
 			"dev": true,
 			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-template-literals": {
@@ -837,7 +837,7 @@
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-typeof-symbol": {
@@ -846,7 +846,7 @@
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-unicode-regex": {
@@ -855,9 +855,9 @@
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
 			"dev": true,
 			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"regexpu-core": "^2.0.0"
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"regexpu-core": "2.0.0"
 			}
 		},
 		"babel-plugin-transform-exponentiation-operator": {
@@ -866,9 +866,9 @@
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
 			"dev": true,
 			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-regenerator": {
@@ -877,7 +877,7 @@
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
 			"dev": true,
 			"requires": {
-				"regenerator-transform": "^0.10.0"
+				"regenerator-transform": "0.10.1"
 			}
 		},
 		"babel-plugin-transform-strict-mode": {
@@ -886,8 +886,8 @@
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-preset-env": {
@@ -896,36 +896,36 @@
 			"integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-check-es2015-constants": "^6.22.0",
-				"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-				"babel-plugin-transform-async-to-generator": "^6.22.0",
-				"babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-				"babel-plugin-transform-es2015-classes": "^6.23.0",
-				"babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-				"babel-plugin-transform-es2015-destructuring": "^6.23.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-				"babel-plugin-transform-es2015-for-of": "^6.23.0",
-				"babel-plugin-transform-es2015-function-name": "^6.22.0",
-				"babel-plugin-transform-es2015-literals": "^6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-				"babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-				"babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-				"babel-plugin-transform-es2015-object-super": "^6.22.0",
-				"babel-plugin-transform-es2015-parameters": "^6.23.0",
-				"babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-				"babel-plugin-transform-es2015-spread": "^6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-				"babel-plugin-transform-es2015-template-literals": "^6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-				"babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-				"babel-plugin-transform-exponentiation-operator": "^6.22.0",
-				"babel-plugin-transform-regenerator": "^6.22.0",
-				"browserslist": "^3.2.6",
-				"invariant": "^2.2.2",
-				"semver": "^5.3.0"
+				"babel-plugin-check-es2015-constants": "6.22.0",
+				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
+				"babel-plugin-transform-async-to-generator": "6.24.1",
+				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
+				"babel-plugin-transform-es2015-classes": "6.24.1",
+				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "6.23.0",
+				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+				"babel-plugin-transform-es2015-for-of": "6.23.0",
+				"babel-plugin-transform-es2015-function-name": "6.24.1",
+				"babel-plugin-transform-es2015-literals": "6.22.0",
+				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
+				"babel-plugin-transform-es2015-object-super": "6.24.1",
+				"babel-plugin-transform-es2015-parameters": "6.24.1",
+				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+				"babel-plugin-transform-es2015-spread": "6.22.0",
+				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+				"babel-plugin-transform-es2015-template-literals": "6.22.0",
+				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+				"babel-plugin-transform-exponentiation-operator": "6.24.1",
+				"babel-plugin-transform-regenerator": "6.26.0",
+				"browserslist": "3.2.7",
+				"invariant": "2.2.4",
+				"semver": "5.5.0"
 			}
 		},
 		"babel-preset-jest": {
@@ -934,8 +934,8 @@
 			"integrity": "sha512-a+M3LTEXTq3gxv0uBN9Qm6ahUl7a8pj923nFbCUdqFUSsf3YrX8Uc+C3MEwji5Af3LiQjSC7w4ooYewlz8HRTA==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-jest-hoist": "^22.4.3",
-				"babel-plugin-syntax-object-rest-spread": "^6.13.0"
+				"babel-plugin-jest-hoist": "22.4.3",
+				"babel-plugin-syntax-object-rest-spread": "6.13.0"
 			}
 		},
 		"babel-register": {
@@ -944,13 +944,13 @@
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
 			"dev": true,
 			"requires": {
-				"babel-core": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"core-js": "^2.5.0",
-				"home-or-tmp": "^2.0.0",
-				"lodash": "^4.17.4",
-				"mkdirp": "^0.5.1",
-				"source-map-support": "^0.4.15"
+				"babel-core": "6.26.3",
+				"babel-runtime": "6.26.0",
+				"core-js": "2.5.6",
+				"home-or-tmp": "2.0.0",
+				"lodash": "4.17.10",
+				"mkdirp": "0.5.1",
+				"source-map-support": "0.4.18"
 			},
 			"dependencies": {
 				"source-map-support": {
@@ -959,7 +959,7 @@
 					"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
 					"dev": true,
 					"requires": {
-						"source-map": "^0.5.6"
+						"source-map": "0.5.7"
 					}
 				}
 			}
@@ -970,8 +970,8 @@
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"dev": true,
 			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
+				"core-js": "2.5.6",
+				"regenerator-runtime": "0.11.1"
 			}
 		},
 		"babel-template": {
@@ -980,11 +980,11 @@
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"lodash": "^4.17.4"
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"lodash": "4.17.10"
 			}
 		},
 		"babel-traverse": {
@@ -993,15 +993,15 @@
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"debug": "^2.6.8",
-				"globals": "^9.18.0",
-				"invariant": "^2.2.2",
-				"lodash": "^4.17.4"
+				"babel-code-frame": "6.26.0",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"debug": "2.6.9",
+				"globals": "9.18.0",
+				"invariant": "2.2.4",
+				"lodash": "4.17.10"
 			}
 		},
 		"babel-types": {
@@ -1010,10 +1010,10 @@
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.4",
-				"to-fast-properties": "^1.0.3"
+				"babel-runtime": "6.26.0",
+				"esutils": "2.0.2",
+				"lodash": "4.17.10",
+				"to-fast-properties": "1.0.3"
 			}
 		},
 		"babylon": {
@@ -1034,13 +1034,13 @@
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 			"dev": true,
 			"requires": {
-				"cache-base": "^1.0.1",
-				"class-utils": "^0.3.5",
-				"component-emitter": "^1.2.1",
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.1",
-				"mixin-deep": "^1.2.0",
-				"pascalcase": "^0.1.1"
+				"cache-base": "1.0.1",
+				"class-utils": "0.3.6",
+				"component-emitter": "1.2.1",
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"mixin-deep": "1.3.1",
+				"pascalcase": "0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -1049,7 +1049,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -1058,7 +1058,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -1067,7 +1067,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -1076,9 +1076,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				}
 			}
@@ -1096,7 +1096,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"tweetnacl": "^0.14.3"
+				"tweetnacl": "0.14.5"
 			}
 		},
 		"boom": {
@@ -1105,7 +1105,7 @@
 			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
 			"dev": true,
 			"requires": {
-				"hoek": "4.x.x"
+				"hoek": "4.2.1"
 			}
 		},
 		"brace-expansion": {
@@ -1114,7 +1114,7 @@
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
 			"requires": {
-				"balanced-match": "^1.0.0",
+				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -1124,16 +1124,16 @@
 			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 			"dev": true,
 			"requires": {
-				"arr-flatten": "^1.1.0",
-				"array-unique": "^0.3.2",
-				"extend-shallow": "^2.0.1",
-				"fill-range": "^4.0.0",
-				"isobject": "^3.0.1",
-				"repeat-element": "^1.1.2",
-				"snapdragon": "^0.8.1",
-				"snapdragon-node": "^2.0.1",
-				"split-string": "^3.0.2",
-				"to-regex": "^3.0.1"
+				"arr-flatten": "1.1.0",
+				"array-unique": "0.3.2",
+				"extend-shallow": "2.0.1",
+				"fill-range": "4.0.0",
+				"isobject": "3.0.1",
+				"repeat-element": "1.1.2",
+				"snapdragon": "0.8.2",
+				"snapdragon-node": "2.1.1",
+				"split-string": "3.1.0",
+				"to-regex": "3.0.2"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -1142,7 +1142,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -1176,8 +1176,8 @@
 			"integrity": "sha512-oYVLxFVqpX9uMhOIQBLtZL+CX4uY8ZpWcjNTaxyWl5rO8yA9SSNikFnAfvk8J3P/7z3BZwNmEqFKaJoYltj3MQ==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30000835",
-				"electron-to-chromium": "^1.3.45"
+				"caniuse-lite": "1.0.30000839",
+				"electron-to-chromium": "1.3.45"
 			}
 		},
 		"bser": {
@@ -1186,7 +1186,7 @@
 			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
 			"dev": true,
 			"requires": {
-				"node-int64": "^0.4.0"
+				"node-int64": "0.4.0"
 			}
 		},
 		"buffer": {
@@ -1195,9 +1195,9 @@
 			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
 			"dev": true,
 			"requires": {
-				"base64-js": "^1.0.2",
-				"ieee754": "^1.1.4",
-				"isarray": "^1.0.0"
+				"base64-js": "1.3.0",
+				"ieee754": "1.1.8",
+				"isarray": "1.0.0"
 			}
 		},
 		"buffer-from": {
@@ -1224,15 +1224,15 @@
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
 			"dev": true,
 			"requires": {
-				"collection-visit": "^1.0.0",
-				"component-emitter": "^1.2.1",
-				"get-value": "^2.0.6",
-				"has-value": "^1.0.0",
-				"isobject": "^3.0.1",
-				"set-value": "^2.0.0",
-				"to-object-path": "^0.3.0",
-				"union-value": "^1.0.0",
-				"unset-value": "^1.0.0"
+				"collection-visit": "1.0.0",
+				"component-emitter": "1.2.1",
+				"get-value": "2.0.6",
+				"has-value": "1.0.0",
+				"isobject": "3.0.1",
+				"set-value": "2.0.0",
+				"to-object-path": "0.3.0",
+				"union-value": "1.0.0",
+				"unset-value": "1.0.0"
 			}
 		},
 		"caller-path": {
@@ -1241,7 +1241,7 @@
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
 			"dev": true,
 			"requires": {
-				"callsites": "^0.2.0"
+				"callsites": "0.2.0"
 			}
 		},
 		"callsites": {
@@ -1263,9 +1263,9 @@
 			"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
 			"dev": true,
 			"requires": {
-				"camelcase": "^4.1.0",
-				"map-obj": "^2.0.0",
-				"quick-lru": "^1.0.0"
+				"camelcase": "4.1.0",
+				"map-obj": "2.0.0",
+				"quick-lru": "1.1.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -1288,7 +1288,7 @@
 			"integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
 			"dev": true,
 			"requires": {
-				"rsvp": "^3.3.3"
+				"rsvp": "3.6.2"
 			}
 		},
 		"capture-stack-trace": {
@@ -1310,8 +1310,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"align-text": "^0.1.3",
-				"lazy-cache": "^1.0.3"
+				"align-text": "0.1.4",
+				"lazy-cache": "1.0.4"
 			}
 		},
 		"chalk": {
@@ -1320,11 +1320,11 @@
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^2.2.1",
-				"escape-string-regexp": "^1.0.2",
-				"has-ansi": "^2.0.0",
-				"strip-ansi": "^3.0.0",
-				"supports-color": "^2.0.0"
+				"ansi-styles": "2.2.1",
+				"escape-string-regexp": "1.0.5",
+				"has-ansi": "2.0.0",
+				"strip-ansi": "3.0.1",
+				"supports-color": "2.0.0"
 			}
 		},
 		"chardet": {
@@ -1351,10 +1351,10 @@
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 			"dev": true,
 			"requires": {
-				"arr-union": "^3.1.0",
-				"define-property": "^0.2.5",
-				"isobject": "^3.0.0",
-				"static-extend": "^0.1.1"
+				"arr-union": "3.1.0",
+				"define-property": "0.2.5",
+				"isobject": "3.0.1",
+				"static-extend": "0.1.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -1363,7 +1363,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				}
 			}
@@ -1374,7 +1374,7 @@
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"dev": true,
 			"requires": {
-				"restore-cursor": "^2.0.0"
+				"restore-cursor": "2.0.0"
 			}
 		},
 		"cli-width": {
@@ -1390,8 +1390,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"center-align": "^0.1.1",
-				"right-align": "^0.1.1",
+				"center-align": "0.1.3",
+				"right-align": "0.1.3",
 				"wordwrap": "0.0.2"
 			},
 			"dependencies": {
@@ -1416,8 +1416,8 @@
 			"integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"mkdirp": "~0.5.0"
+				"graceful-fs": "4.1.11",
+				"mkdirp": "0.5.1"
 			}
 		},
 		"co": {
@@ -1438,8 +1438,8 @@
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 			"dev": true,
 			"requires": {
-				"map-visit": "^1.0.0",
-				"object-visit": "^1.0.0"
+				"map-visit": "1.0.0",
+				"object-visit": "1.0.1"
 			}
 		},
 		"color-convert": {
@@ -1448,7 +1448,7 @@
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
 			"dev": true,
 			"requires": {
-				"color-name": "^1.1.1"
+				"color-name": "1.1.3"
 			}
 		},
 		"color-name": {
@@ -1463,8 +1463,8 @@
 			"integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
 			"dev": true,
 			"requires": {
-				"strip-ansi": "^3.0.0",
-				"wcwidth": "^1.0.0"
+				"strip-ansi": "3.0.1",
+				"wcwidth": "1.0.1"
 			}
 		},
 		"combined-stream": {
@@ -1473,7 +1473,7 @@
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 			"dev": true,
 			"requires": {
-				"delayed-stream": "~1.0.0"
+				"delayed-stream": "1.0.0"
 			}
 		},
 		"command-join": {
@@ -1494,8 +1494,8 @@
 			"integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
 			"dev": true,
 			"requires": {
-				"array-ify": "^1.0.0",
-				"dot-prop": "^3.0.0"
+				"array-ify": "1.0.0",
+				"dot-prop": "3.0.0"
 			}
 		},
 		"compare-versions": {
@@ -1522,10 +1522,10 @@
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 			"dev": true,
 			"requires": {
-				"buffer-from": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^2.2.2",
-				"typedarray": "^0.0.6"
+				"buffer-from": "1.0.0",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.6",
+				"typedarray": "0.0.6"
 			}
 		},
 		"console-control-strings": {
@@ -1546,17 +1546,17 @@
 			"integrity": "sha512-2WcSUst4Y3Z4hHvoMTWXMJr/DmgVdLiMOVY1Kak2LfFz+GIz2KDp5naqbFesYbfXPmaZ5p491dO0FWZIJoJw1Q==",
 			"dev": true,
 			"requires": {
-				"conventional-changelog-angular": "^1.6.6",
-				"conventional-changelog-atom": "^0.2.8",
-				"conventional-changelog-codemirror": "^0.3.8",
-				"conventional-changelog-core": "^2.0.11",
-				"conventional-changelog-ember": "^0.3.12",
-				"conventional-changelog-eslint": "^1.0.9",
-				"conventional-changelog-express": "^0.3.6",
-				"conventional-changelog-jquery": "^0.1.0",
-				"conventional-changelog-jscs": "^0.1.0",
-				"conventional-changelog-jshint": "^0.3.8",
-				"conventional-changelog-preset-loader": "^1.1.8"
+				"conventional-changelog-angular": "1.6.6",
+				"conventional-changelog-atom": "0.2.8",
+				"conventional-changelog-codemirror": "0.3.8",
+				"conventional-changelog-core": "2.0.11",
+				"conventional-changelog-ember": "0.3.12",
+				"conventional-changelog-eslint": "1.0.9",
+				"conventional-changelog-express": "0.3.6",
+				"conventional-changelog-jquery": "0.1.0",
+				"conventional-changelog-jscs": "0.1.0",
+				"conventional-changelog-jshint": "0.3.8",
+				"conventional-changelog-preset-loader": "1.1.8"
 			}
 		},
 		"conventional-changelog-angular": {
@@ -1565,8 +1565,8 @@
 			"integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
 			"dev": true,
 			"requires": {
-				"compare-func": "^1.3.1",
-				"q": "^1.5.1"
+				"compare-func": "1.3.2",
+				"q": "1.5.1"
 			}
 		},
 		"conventional-changelog-atom": {
@@ -1575,7 +1575,7 @@
 			"integrity": "sha512-8pPZqhMbrnltNBizjoDCb/Sz85KyUXNDQxuAEYAU5V/eHn0okMBVjqc8aHWYpHrytyZWvMGbayOlDv7i8kEf6g==",
 			"dev": true,
 			"requires": {
-				"q": "^1.5.1"
+				"q": "1.5.1"
 			}
 		},
 		"conventional-changelog-cli": {
@@ -1584,11 +1584,11 @@
 			"integrity": "sha512-pnjdIJbxjkZ5VdAX/H1wndr1G10CY8MuZgnXuJhIHglOXfIrXygb7KZC836GW9uo1u8PjEIvIw/bKX0lOmOzZg==",
 			"dev": true,
 			"requires": {
-				"add-stream": "^1.0.0",
-				"conventional-changelog": "^1.1.24",
-				"lodash": "^4.2.1",
-				"meow": "^4.0.0",
-				"tempfile": "^1.1.1"
+				"add-stream": "1.0.0",
+				"conventional-changelog": "1.1.24",
+				"lodash": "4.17.10",
+				"meow": "4.0.1",
+				"tempfile": "1.1.1"
 			}
 		},
 		"conventional-changelog-codemirror": {
@@ -1597,7 +1597,7 @@
 			"integrity": "sha512-3HFZKtBXTaUCHvz7ai6nk2+psRIkldDoNzCsom0egDtVmPsvvHZkzjynhdQyULfacRSsBTaiQ0ol6nBOL4dDiQ==",
 			"dev": true,
 			"requires": {
-				"q": "^1.5.1"
+				"q": "1.5.1"
 			}
 		},
 		"conventional-changelog-core": {
@@ -1606,19 +1606,19 @@
 			"integrity": "sha512-HvTE6RlqeEZ/NFPtQeFLsIDOLrGP3bXYr7lFLMhCVsbduF1MXIe8OODkwMFyo1i9ku9NWBwVnVn0jDmIFXjDRg==",
 			"dev": true,
 			"requires": {
-				"conventional-changelog-writer": "^3.0.9",
-				"conventional-commits-parser": "^2.1.7",
-				"dateformat": "^3.0.0",
-				"get-pkg-repo": "^1.0.0",
-				"git-raw-commits": "^1.3.6",
-				"git-remote-origin-url": "^2.0.0",
-				"git-semver-tags": "^1.3.6",
-				"lodash": "^4.2.1",
-				"normalize-package-data": "^2.3.5",
-				"q": "^1.5.1",
-				"read-pkg": "^1.1.0",
-				"read-pkg-up": "^1.0.1",
-				"through2": "^2.0.0"
+				"conventional-changelog-writer": "3.0.9",
+				"conventional-commits-parser": "2.1.7",
+				"dateformat": "3.0.3",
+				"get-pkg-repo": "1.4.0",
+				"git-raw-commits": "1.3.6",
+				"git-remote-origin-url": "2.0.0",
+				"git-semver-tags": "1.3.6",
+				"lodash": "4.17.10",
+				"normalize-package-data": "2.4.0",
+				"q": "1.5.1",
+				"read-pkg": "1.1.0",
+				"read-pkg-up": "1.0.1",
+				"through2": "2.0.3"
 			}
 		},
 		"conventional-changelog-ember": {
@@ -1627,7 +1627,7 @@
 			"integrity": "sha512-mmJzA7uzbrOqeF89dMMi6z17O07ORTXlTMArnLG9ZTX4oLaKNolUlxFUFlFm9JUoVWajVpaHQWjxH1EOQ+ARoQ==",
 			"dev": true,
 			"requires": {
-				"q": "^1.5.1"
+				"q": "1.5.1"
 			}
 		},
 		"conventional-changelog-eslint": {
@@ -1636,7 +1636,7 @@
 			"integrity": "sha512-h87nfVh2fdk9fJIvz26wCBsbDC/KxqCc5wSlNMZbXcARtbgNbNDIF7Y7ctokFdnxkzVdaHsbINkh548T9eBA7Q==",
 			"dev": true,
 			"requires": {
-				"q": "^1.5.1"
+				"q": "1.5.1"
 			}
 		},
 		"conventional-changelog-express": {
@@ -1645,7 +1645,7 @@
 			"integrity": "sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==",
 			"dev": true,
 			"requires": {
-				"q": "^1.5.1"
+				"q": "1.5.1"
 			}
 		},
 		"conventional-changelog-jquery": {
@@ -1654,7 +1654,7 @@
 			"integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
 			"dev": true,
 			"requires": {
-				"q": "^1.4.1"
+				"q": "1.5.1"
 			}
 		},
 		"conventional-changelog-jscs": {
@@ -1663,7 +1663,7 @@
 			"integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
 			"dev": true,
 			"requires": {
-				"q": "^1.4.1"
+				"q": "1.5.1"
 			}
 		},
 		"conventional-changelog-jshint": {
@@ -1672,8 +1672,8 @@
 			"integrity": "sha512-hn9QU4ZI/5V50wKPJNPGT4gEWgiBFpV6adieILW4MaUFynuDYOvQ71EMSj3EznJyKi/KzuXpc9dGmX8njZMjig==",
 			"dev": true,
 			"requires": {
-				"compare-func": "^1.3.1",
-				"q": "^1.5.1"
+				"compare-func": "1.3.2",
+				"q": "1.5.1"
 			}
 		},
 		"conventional-changelog-preset-loader": {
@@ -1688,16 +1688,16 @@
 			"integrity": "sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==",
 			"dev": true,
 			"requires": {
-				"compare-func": "^1.3.1",
-				"conventional-commits-filter": "^1.1.6",
-				"dateformat": "^3.0.0",
-				"handlebars": "^4.0.2",
-				"json-stringify-safe": "^5.0.1",
-				"lodash": "^4.2.1",
-				"meow": "^4.0.0",
-				"semver": "^5.5.0",
-				"split": "^1.0.0",
-				"through2": "^2.0.0"
+				"compare-func": "1.3.2",
+				"conventional-commits-filter": "1.1.6",
+				"dateformat": "3.0.3",
+				"handlebars": "4.0.11",
+				"json-stringify-safe": "5.0.1",
+				"lodash": "4.17.10",
+				"meow": "4.0.1",
+				"semver": "5.5.0",
+				"split": "1.0.1",
+				"through2": "2.0.3"
 			}
 		},
 		"conventional-commits-filter": {
@@ -1706,8 +1706,8 @@
 			"integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
 			"dev": true,
 			"requires": {
-				"is-subset": "^0.1.1",
-				"modify-values": "^1.0.0"
+				"is-subset": "0.1.1",
+				"modify-values": "1.0.1"
 			}
 		},
 		"conventional-commits-parser": {
@@ -1716,13 +1716,13 @@
 			"integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
 			"dev": true,
 			"requires": {
-				"JSONStream": "^1.0.4",
-				"is-text-path": "^1.0.0",
-				"lodash": "^4.2.1",
-				"meow": "^4.0.0",
-				"split2": "^2.0.0",
-				"through2": "^2.0.0",
-				"trim-off-newlines": "^1.0.0"
+				"JSONStream": "1.3.2",
+				"is-text-path": "1.0.1",
+				"lodash": "4.17.10",
+				"meow": "4.0.1",
+				"split2": "2.2.0",
+				"through2": "2.0.3",
+				"trim-off-newlines": "1.0.1"
 			}
 		},
 		"conventional-recommended-bump": {
@@ -1731,13 +1731,13 @@
 			"integrity": "sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==",
 			"dev": true,
 			"requires": {
-				"concat-stream": "^1.4.10",
-				"conventional-commits-filter": "^1.1.1",
-				"conventional-commits-parser": "^2.1.1",
-				"git-raw-commits": "^1.3.0",
-				"git-semver-tags": "^1.3.0",
-				"meow": "^3.3.0",
-				"object-assign": "^4.0.1"
+				"concat-stream": "1.6.2",
+				"conventional-commits-filter": "1.1.6",
+				"conventional-commits-parser": "2.1.7",
+				"git-raw-commits": "1.3.6",
+				"git-semver-tags": "1.3.6",
+				"meow": "3.7.0",
+				"object-assign": "4.1.1"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -1752,8 +1752,8 @@
 					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 					"dev": true,
 					"requires": {
-						"camelcase": "^2.0.0",
-						"map-obj": "^1.0.0"
+						"camelcase": "2.1.1",
+						"map-obj": "1.0.1"
 					}
 				},
 				"indent-string": {
@@ -1762,7 +1762,7 @@
 					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 					"dev": true,
 					"requires": {
-						"repeating": "^2.0.0"
+						"repeating": "2.0.1"
 					}
 				},
 				"map-obj": {
@@ -1777,16 +1777,16 @@
 					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 					"dev": true,
 					"requires": {
-						"camelcase-keys": "^2.0.0",
-						"decamelize": "^1.1.2",
-						"loud-rejection": "^1.0.0",
-						"map-obj": "^1.0.1",
-						"minimist": "^1.1.3",
-						"normalize-package-data": "^2.3.4",
-						"object-assign": "^4.0.1",
-						"read-pkg-up": "^1.0.1",
-						"redent": "^1.0.0",
-						"trim-newlines": "^1.0.0"
+						"camelcase-keys": "2.1.0",
+						"decamelize": "1.2.0",
+						"loud-rejection": "1.6.0",
+						"map-obj": "1.0.1",
+						"minimist": "1.2.0",
+						"normalize-package-data": "2.4.0",
+						"object-assign": "4.1.1",
+						"read-pkg-up": "1.0.1",
+						"redent": "1.0.0",
+						"trim-newlines": "1.0.0"
 					}
 				},
 				"minimist": {
@@ -1801,8 +1801,8 @@
 					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
 					"dev": true,
 					"requires": {
-						"indent-string": "^2.1.0",
-						"strip-indent": "^1.0.1"
+						"indent-string": "2.1.0",
+						"strip-indent": "1.0.1"
 					}
 				},
 				"strip-indent": {
@@ -1811,7 +1811,7 @@
 					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
 					"dev": true,
 					"requires": {
-						"get-stdin": "^4.0.1"
+						"get-stdin": "4.0.1"
 					}
 				},
 				"trim-newlines": {
@@ -1852,7 +1852,7 @@
 			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
 			"dev": true,
 			"requires": {
-				"capture-stack-trace": "^1.0.0"
+				"capture-stack-trace": "1.0.0"
 			}
 		},
 		"cross-spawn": {
@@ -1861,9 +1861,9 @@
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"dev": true,
 			"requires": {
-				"lru-cache": "^4.0.1",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
+				"lru-cache": "4.1.3",
+				"shebang-command": "1.2.0",
+				"which": "1.3.0"
 			}
 		},
 		"cryptiles": {
@@ -1872,7 +1872,7 @@
 			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
 			"dev": true,
 			"requires": {
-				"boom": "5.x.x"
+				"boom": "5.2.0"
 			},
 			"dependencies": {
 				"boom": {
@@ -1881,7 +1881,7 @@
 					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
 					"dev": true,
 					"requires": {
-						"hoek": "4.x.x"
+						"hoek": "4.2.1"
 					}
 				}
 			}
@@ -1898,7 +1898,7 @@
 			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
 			"dev": true,
 			"requires": {
-				"cssom": "0.3.x"
+				"cssom": "0.3.2"
 			}
 		},
 		"currently-unhandled": {
@@ -1907,7 +1907,7 @@
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 			"dev": true,
 			"requires": {
-				"array-find-index": "^1.0.1"
+				"array-find-index": "1.0.2"
 			}
 		},
 		"dargs": {
@@ -1916,7 +1916,7 @@
 			"integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "^1.0.0"
+				"number-is-nan": "1.0.1"
 			}
 		},
 		"dashdash": {
@@ -1925,7 +1925,7 @@
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0"
+				"assert-plus": "1.0.0"
 			}
 		},
 		"data-urls": {
@@ -1934,9 +1934,9 @@
 			"integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
 			"dev": true,
 			"requires": {
-				"abab": "^1.0.4",
-				"whatwg-mimetype": "^2.0.0",
-				"whatwg-url": "^6.4.0"
+				"abab": "1.0.4",
+				"whatwg-mimetype": "2.1.0",
+				"whatwg-url": "6.4.1"
 			}
 		},
 		"dateformat": {
@@ -1966,8 +1966,8 @@
 			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
 			"dev": true,
 			"requires": {
-				"decamelize": "^1.1.0",
-				"map-obj": "^1.0.0"
+				"decamelize": "1.2.0",
+				"map-obj": "1.0.1"
 			},
 			"dependencies": {
 				"map-obj": {
@@ -2008,7 +2008,7 @@
 			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
 			"dev": true,
 			"requires": {
-				"strip-bom": "^2.0.0"
+				"strip-bom": "2.0.0"
 			}
 		},
 		"defaults": {
@@ -2017,7 +2017,7 @@
 			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
 			"dev": true,
 			"requires": {
-				"clone": "^1.0.2"
+				"clone": "1.0.4"
 			}
 		},
 		"define-properties": {
@@ -2026,8 +2026,8 @@
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
 			"dev": true,
 			"requires": {
-				"foreach": "^2.0.5",
-				"object-keys": "^1.0.8"
+				"foreach": "2.0.5",
+				"object-keys": "1.0.11"
 			}
 		},
 		"define-property": {
@@ -2036,8 +2036,8 @@
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 			"dev": true,
 			"requires": {
-				"is-descriptor": "^1.0.2",
-				"isobject": "^3.0.1"
+				"is-descriptor": "1.0.2",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"is-accessor-descriptor": {
@@ -2046,7 +2046,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -2055,7 +2055,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -2064,9 +2064,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				}
 			}
@@ -2077,13 +2077,13 @@
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
 			"dev": true,
 			"requires": {
-				"globby": "^5.0.0",
-				"is-path-cwd": "^1.0.0",
-				"is-path-in-cwd": "^1.0.0",
-				"object-assign": "^4.0.1",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0",
-				"rimraf": "^2.2.8"
+				"globby": "5.0.0",
+				"is-path-cwd": "1.0.0",
+				"is-path-in-cwd": "1.0.1",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"rimraf": "2.6.2"
 			}
 		},
 		"delayed-stream": {
@@ -2104,7 +2104,7 @@
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 			"dev": true,
 			"requires": {
-				"repeating": "^2.0.0"
+				"repeating": "2.0.1"
 			}
 		},
 		"detect-newline": {
@@ -2125,7 +2125,7 @@
 			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
 			"dev": true,
 			"requires": {
-				"esutils": "^2.0.2"
+				"esutils": "2.0.2"
 			}
 		},
 		"domexception": {
@@ -2134,7 +2134,7 @@
 			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
 			"dev": true,
 			"requires": {
-				"webidl-conversions": "^4.0.2"
+				"webidl-conversions": "4.0.2"
 			}
 		},
 		"dot-prop": {
@@ -2143,7 +2143,7 @@
 			"integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
 			"dev": true,
 			"requires": {
-				"is-obj": "^1.0.0"
+				"is-obj": "1.0.1"
 			}
 		},
 		"duplexer": {
@@ -2165,7 +2165,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"jsbn": "~0.1.0"
+				"jsbn": "0.1.1"
 			}
 		},
 		"electron-to-chromium": {
@@ -2180,7 +2180,7 @@
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
 			"dev": true,
 			"requires": {
-				"is-arrayish": "^0.2.1"
+				"is-arrayish": "0.2.1"
 			}
 		},
 		"es-abstract": {
@@ -2189,11 +2189,11 @@
 			"integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
 			"dev": true,
 			"requires": {
-				"es-to-primitive": "^1.1.1",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.1",
-				"is-callable": "^1.1.3",
-				"is-regex": "^1.0.4"
+				"es-to-primitive": "1.1.1",
+				"function-bind": "1.1.1",
+				"has": "1.0.1",
+				"is-callable": "1.1.3",
+				"is-regex": "1.0.4"
 			}
 		},
 		"es-to-primitive": {
@@ -2202,9 +2202,9 @@
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
 			"dev": true,
 			"requires": {
-				"is-callable": "^1.1.1",
-				"is-date-object": "^1.0.1",
-				"is-symbol": "^1.0.1"
+				"is-callable": "1.1.3",
+				"is-date-object": "1.0.1",
+				"is-symbol": "1.0.1"
 			}
 		},
 		"escape-string-regexp": {
@@ -2219,11 +2219,11 @@
 			"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
 			"dev": true,
 			"requires": {
-				"esprima": "^3.1.3",
-				"estraverse": "^4.2.0",
-				"esutils": "^2.0.2",
-				"optionator": "^0.8.1",
-				"source-map": "~0.6.1"
+				"esprima": "3.1.3",
+				"estraverse": "4.2.0",
+				"esutils": "2.0.2",
+				"optionator": "0.8.2",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"esprima": {
@@ -2247,44 +2247,44 @@
 			"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.3.0",
-				"babel-code-frame": "^6.22.0",
-				"chalk": "^2.1.0",
-				"concat-stream": "^1.6.0",
-				"cross-spawn": "^5.1.0",
-				"debug": "^3.1.0",
-				"doctrine": "^2.1.0",
-				"eslint-scope": "^3.7.1",
-				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^3.5.4",
-				"esquery": "^1.0.0",
-				"esutils": "^2.0.2",
-				"file-entry-cache": "^2.0.0",
-				"functional-red-black-tree": "^1.0.1",
-				"glob": "^7.1.2",
-				"globals": "^11.0.1",
-				"ignore": "^3.3.3",
-				"imurmurhash": "^0.1.4",
-				"inquirer": "^3.0.6",
-				"is-resolvable": "^1.0.0",
-				"js-yaml": "^3.9.1",
-				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"levn": "^0.3.0",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.2",
-				"mkdirp": "^0.5.1",
-				"natural-compare": "^1.4.0",
-				"optionator": "^0.8.2",
-				"path-is-inside": "^1.0.2",
-				"pluralize": "^7.0.0",
-				"progress": "^2.0.0",
-				"regexpp": "^1.0.1",
-				"require-uncached": "^1.0.3",
-				"semver": "^5.3.0",
-				"strip-ansi": "^4.0.0",
-				"strip-json-comments": "~2.0.1",
+				"ajv": "5.5.2",
+				"babel-code-frame": "6.26.0",
+				"chalk": "2.4.1",
+				"concat-stream": "1.6.2",
+				"cross-spawn": "5.1.0",
+				"debug": "3.1.0",
+				"doctrine": "2.1.0",
+				"eslint-scope": "3.7.1",
+				"eslint-visitor-keys": "1.0.0",
+				"espree": "3.5.4",
+				"esquery": "1.0.1",
+				"esutils": "2.0.2",
+				"file-entry-cache": "2.0.0",
+				"functional-red-black-tree": "1.0.1",
+				"glob": "7.1.2",
+				"globals": "11.5.0",
+				"ignore": "3.3.8",
+				"imurmurhash": "0.1.4",
+				"inquirer": "3.3.0",
+				"is-resolvable": "1.1.0",
+				"js-yaml": "3.11.0",
+				"json-stable-stringify-without-jsonify": "1.0.1",
+				"levn": "0.3.0",
+				"lodash": "4.17.10",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"optionator": "0.8.2",
+				"path-is-inside": "1.0.2",
+				"pluralize": "7.0.0",
+				"progress": "2.0.0",
+				"regexpp": "1.1.0",
+				"require-uncached": "1.0.3",
+				"semver": "5.5.0",
+				"strip-ansi": "4.0.0",
+				"strip-json-comments": "2.0.1",
 				"table": "4.0.2",
-				"text-table": "~0.2.0"
+				"text-table": "0.2.0"
 			},
 			"dependencies": {
 				"ajv": {
@@ -2293,10 +2293,10 @@
 					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 					"dev": true,
 					"requires": {
-						"co": "^4.6.0",
-						"fast-deep-equal": "^1.0.0",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.3.0"
+						"co": "4.6.0",
+						"fast-deep-equal": "1.1.0",
+						"fast-json-stable-stringify": "2.0.0",
+						"json-schema-traverse": "0.3.1"
 					}
 				},
 				"ansi-regex": {
@@ -2311,7 +2311,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -2320,9 +2320,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"debug": {
@@ -2352,7 +2352,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				},
 				"supports-color": {
@@ -2361,7 +2361,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -2378,8 +2378,8 @@
 			"integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
 			"dev": true,
 			"requires": {
-				"debug": "^2.6.9",
-				"resolve": "^1.5.0"
+				"debug": "2.6.9",
+				"resolve": "1.7.1"
 			}
 		},
 		"eslint-module-utils": {
@@ -2388,8 +2388,8 @@
 			"integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
 			"dev": true,
 			"requires": {
-				"debug": "^2.6.8",
-				"pkg-dir": "^1.0.0"
+				"debug": "2.6.9",
+				"pkg-dir": "1.0.0"
 			}
 		},
 		"eslint-plugin-import": {
@@ -2398,16 +2398,16 @@
 			"integrity": "sha1-Fa7qN6Z0mdhI6OmBgG1GJ7VQOBY=",
 			"dev": true,
 			"requires": {
-				"contains-path": "^0.1.0",
-				"debug": "^2.6.8",
+				"contains-path": "0.1.0",
+				"debug": "2.6.9",
 				"doctrine": "1.5.0",
-				"eslint-import-resolver-node": "^0.3.1",
-				"eslint-module-utils": "^2.2.0",
-				"has": "^1.0.1",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.3",
-				"read-pkg-up": "^2.0.0",
-				"resolve": "^1.6.0"
+				"eslint-import-resolver-node": "0.3.2",
+				"eslint-module-utils": "2.2.0",
+				"has": "1.0.1",
+				"lodash": "4.17.10",
+				"minimatch": "3.0.4",
+				"read-pkg-up": "2.0.0",
+				"resolve": "1.7.1"
 			},
 			"dependencies": {
 				"doctrine": {
@@ -2416,8 +2416,8 @@
 					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
 					"dev": true,
 					"requires": {
-						"esutils": "^2.0.2",
-						"isarray": "^1.0.0"
+						"esutils": "2.0.2",
+						"isarray": "1.0.0"
 					}
 				},
 				"load-json-file": {
@@ -2426,10 +2426,10 @@
 					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"strip-bom": "^3.0.0"
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"strip-bom": "3.0.0"
 					}
 				},
 				"path-type": {
@@ -2438,7 +2438,7 @@
 					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
 					"dev": true,
 					"requires": {
-						"pify": "^2.0.0"
+						"pify": "2.3.0"
 					}
 				},
 				"read-pkg": {
@@ -2447,9 +2447,9 @@
 					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "^2.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^2.0.0"
+						"load-json-file": "2.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "2.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -2458,8 +2458,8 @@
 					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
 					"dev": true,
 					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^2.0.0"
+						"find-up": "2.1.0",
+						"read-pkg": "2.0.0"
 					}
 				},
 				"strip-bom": {
@@ -2476,10 +2476,10 @@
 			"integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
 			"dev": true,
 			"requires": {
-				"ignore": "^3.3.6",
-				"minimatch": "^3.0.4",
-				"resolve": "^1.3.3",
-				"semver": "^5.4.1"
+				"ignore": "3.3.8",
+				"minimatch": "3.0.4",
+				"resolve": "1.7.1",
+				"semver": "5.5.0"
 			}
 		},
 		"eslint-plugin-promise": {
@@ -2500,8 +2500,8 @@
 			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
 			"dev": true,
 			"requires": {
-				"esrecurse": "^4.1.0",
-				"estraverse": "^4.1.1"
+				"esrecurse": "4.2.1",
+				"estraverse": "4.2.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -2516,8 +2516,8 @@
 			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
 			"dev": true,
 			"requires": {
-				"acorn": "^5.5.0",
-				"acorn-jsx": "^3.0.0"
+				"acorn": "5.5.3",
+				"acorn-jsx": "3.0.1"
 			}
 		},
 		"esprima": {
@@ -2532,7 +2532,7 @@
 			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
 			"dev": true,
 			"requires": {
-				"estraverse": "^4.0.0"
+				"estraverse": "4.2.0"
 			}
 		},
 		"esrecurse": {
@@ -2541,7 +2541,7 @@
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
 			"dev": true,
 			"requires": {
-				"estraverse": "^4.1.0"
+				"estraverse": "4.2.0"
 			}
 		},
 		"estraverse": {
@@ -2568,7 +2568,7 @@
 			"integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
 			"dev": true,
 			"requires": {
-				"merge": "^1.1.3"
+				"merge": "1.2.0"
 			}
 		},
 		"execa": {
@@ -2577,13 +2577,13 @@
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "^5.0.1",
-				"get-stream": "^3.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
+				"cross-spawn": "5.1.0",
+				"get-stream": "3.0.0",
+				"is-stream": "1.1.0",
+				"npm-run-path": "2.0.2",
+				"p-finally": "1.0.0",
+				"signal-exit": "3.0.2",
+				"strip-eof": "1.0.0"
 			}
 		},
 		"exit": {
@@ -2598,13 +2598,13 @@
 			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 			"dev": true,
 			"requires": {
-				"debug": "^2.3.3",
-				"define-property": "^0.2.5",
-				"extend-shallow": "^2.0.1",
-				"posix-character-classes": "^0.1.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"debug": "2.6.9",
+				"define-property": "0.2.5",
+				"extend-shallow": "2.0.1",
+				"posix-character-classes": "0.1.1",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -2613,7 +2613,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"extend-shallow": {
@@ -2622,7 +2622,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -2633,7 +2633,7 @@
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"dev": true,
 			"requires": {
-				"fill-range": "^2.1.0"
+				"fill-range": "2.2.4"
 			},
 			"dependencies": {
 				"fill-range": {
@@ -2642,11 +2642,11 @@
 					"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
 					"dev": true,
 					"requires": {
-						"is-number": "^2.1.0",
-						"isobject": "^2.0.0",
-						"randomatic": "^3.0.0",
-						"repeat-element": "^1.1.2",
-						"repeat-string": "^1.5.2"
+						"is-number": "2.1.0",
+						"isobject": "2.1.0",
+						"randomatic": "3.0.0",
+						"repeat-element": "1.1.2",
+						"repeat-string": "1.6.1"
 					}
 				},
 				"is-number": {
@@ -2655,7 +2655,7 @@
 					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					}
 				},
 				"isobject": {
@@ -2673,7 +2673,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -2684,12 +2684,12 @@
 			"integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^3.2.0",
-				"jest-diff": "^22.4.3",
-				"jest-get-type": "^22.4.3",
-				"jest-matcher-utils": "^22.4.3",
-				"jest-message-util": "^22.4.3",
-				"jest-regex-util": "^22.4.3"
+				"ansi-styles": "3.2.1",
+				"jest-diff": "22.4.3",
+				"jest-get-type": "22.4.3",
+				"jest-matcher-utils": "22.4.3",
+				"jest-message-util": "22.4.3",
+				"jest-regex-util": "22.4.3"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -2698,7 +2698,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				}
 			}
@@ -2715,8 +2715,8 @@
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 			"dev": true,
 			"requires": {
-				"assign-symbols": "^1.0.0",
-				"is-extendable": "^1.0.1"
+				"assign-symbols": "1.0.0",
+				"is-extendable": "1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -2725,7 +2725,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				}
 			}
@@ -2736,9 +2736,9 @@
 			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
 			"dev": true,
 			"requires": {
-				"chardet": "^0.4.0",
-				"iconv-lite": "^0.4.17",
-				"tmp": "^0.0.33"
+				"chardet": "0.4.2",
+				"iconv-lite": "0.4.23",
+				"tmp": "0.0.33"
 			}
 		},
 		"extglob": {
@@ -2747,14 +2747,14 @@
 			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 			"dev": true,
 			"requires": {
-				"array-unique": "^0.3.2",
-				"define-property": "^1.0.0",
-				"expand-brackets": "^2.1.4",
-				"extend-shallow": "^2.0.1",
-				"fragment-cache": "^0.2.1",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"array-unique": "0.3.2",
+				"define-property": "1.0.0",
+				"expand-brackets": "2.1.4",
+				"extend-shallow": "2.0.1",
+				"fragment-cache": "0.2.1",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -2763,7 +2763,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"extend-shallow": {
@@ -2772,7 +2772,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -2781,7 +2781,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -2790,7 +2790,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -2799,9 +2799,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				}
 			}
@@ -2830,7 +2830,7 @@
 			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
 			"dev": true,
 			"requires": {
-				"bser": "^2.0.0"
+				"bser": "2.0.0"
 			}
 		},
 		"figures": {
@@ -2839,7 +2839,7 @@
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "^1.0.5"
+				"escape-string-regexp": "1.0.5"
 			}
 		},
 		"file-entry-cache": {
@@ -2848,8 +2848,8 @@
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
 			"dev": true,
 			"requires": {
-				"flat-cache": "^1.2.1",
-				"object-assign": "^4.0.1"
+				"flat-cache": "1.3.0",
+				"object-assign": "4.1.1"
 			}
 		},
 		"filename-regex": {
@@ -2864,8 +2864,8 @@
 			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.3",
-				"minimatch": "^3.0.3"
+				"glob": "7.1.2",
+				"minimatch": "3.0.4"
 			}
 		},
 		"fill-range": {
@@ -2874,10 +2874,10 @@
 			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^2.0.1",
-				"is-number": "^3.0.0",
-				"repeat-string": "^1.6.1",
-				"to-regex-range": "^2.1.0"
+				"extend-shallow": "2.0.1",
+				"is-number": "3.0.0",
+				"repeat-string": "1.6.1",
+				"to-regex-range": "2.1.1"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -2886,7 +2886,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -2897,7 +2897,7 @@
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"dev": true,
 			"requires": {
-				"locate-path": "^2.0.0"
+				"locate-path": "2.0.0"
 			}
 		},
 		"flat-cache": {
@@ -2906,10 +2906,10 @@
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
 			"dev": true,
 			"requires": {
-				"circular-json": "^0.3.1",
-				"del": "^2.0.2",
-				"graceful-fs": "^4.1.2",
-				"write": "^0.2.1"
+				"circular-json": "0.3.3",
+				"del": "2.2.2",
+				"graceful-fs": "4.1.11",
+				"write": "0.2.1"
 			}
 		},
 		"for-in": {
@@ -2924,7 +2924,7 @@
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 			"dev": true,
 			"requires": {
-				"for-in": "^1.0.1"
+				"for-in": "1.0.2"
 			}
 		},
 		"foreach": {
@@ -2945,9 +2945,9 @@
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"dev": true,
 			"requires": {
-				"asynckit": "^0.4.0",
+				"asynckit": "0.4.0",
 				"combined-stream": "1.0.6",
-				"mime-types": "^2.1.12"
+				"mime-types": "2.1.18"
 			}
 		},
 		"fragment-cache": {
@@ -2956,7 +2956,7 @@
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
 			"dev": true,
 			"requires": {
-				"map-cache": "^0.2.2"
+				"map-cache": "0.2.2"
 			}
 		},
 		"fs-extra": {
@@ -2965,9 +2965,9 @@
 			"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
+				"graceful-fs": "4.1.11",
+				"jsonfile": "4.0.0",
+				"universalify": "0.1.1"
 			}
 		},
 		"fs.realpath": {
@@ -2983,8 +2983,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "^2.9.2",
-				"node-pre-gyp": "^0.9.0"
+				"nan": "2.10.0",
+				"node-pre-gyp": "0.9.1"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -3010,8 +3010,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
+						"delegates": "1.0.0",
+						"readable-stream": "2.3.6"
 					}
 				},
 				"balanced-match": {
@@ -3024,7 +3024,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"balanced-match": "^1.0.0",
+						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -3088,7 +3088,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "2.2.4"
 					}
 				},
 				"fs.realpath": {
@@ -3103,14 +3103,14 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
+						"aproba": "1.2.0",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.2"
 					}
 				},
 				"glob": {
@@ -3119,12 +3119,12 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
 					}
 				},
 				"has-unicode": {
@@ -3139,7 +3139,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safer-buffer": "^2.1.0"
+						"safer-buffer": "2.1.2"
 					}
 				},
 				"ignore-walk": {
@@ -3148,7 +3148,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minimatch": "^3.0.4"
+						"minimatch": "3.0.4"
 					}
 				},
 				"inflight": {
@@ -3157,8 +3157,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
 					}
 				},
 				"inherits": {
@@ -3177,7 +3177,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"isarray": {
@@ -3191,7 +3191,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"brace-expansion": "^1.1.7"
+						"brace-expansion": "1.1.11"
 					}
 				},
 				"minimist": {
@@ -3204,8 +3204,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"safe-buffer": "^5.1.1",
-						"yallist": "^3.0.0"
+						"safe-buffer": "5.1.1",
+						"yallist": "3.0.2"
 					}
 				},
 				"minizlib": {
@@ -3214,7 +3214,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "2.2.4"
 					}
 				},
 				"mkdirp": {
@@ -3237,9 +3237,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "^2.1.2",
-						"iconv-lite": "^0.4.4",
-						"sax": "^1.2.4"
+						"debug": "2.6.9",
+						"iconv-lite": "0.4.21",
+						"sax": "1.2.4"
 					}
 				},
 				"node-pre-gyp": {
@@ -3248,16 +3248,16 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"detect-libc": "^1.0.2",
-						"mkdirp": "^0.5.1",
-						"needle": "^2.2.0",
-						"nopt": "^4.0.1",
-						"npm-packlist": "^1.1.6",
-						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
-						"rimraf": "^2.6.1",
-						"semver": "^5.3.0",
-						"tar": "^4"
+						"detect-libc": "1.0.3",
+						"mkdirp": "0.5.1",
+						"needle": "2.2.0",
+						"nopt": "4.0.1",
+						"npm-packlist": "1.1.10",
+						"npmlog": "4.1.2",
+						"rc": "1.2.6",
+						"rimraf": "2.6.2",
+						"semver": "5.5.0",
+						"tar": "4.4.1"
 					}
 				},
 				"nopt": {
@@ -3266,8 +3266,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
+						"abbrev": "1.1.1",
+						"osenv": "0.1.5"
 					}
 				},
 				"npm-bundled": {
@@ -3282,8 +3282,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1"
+						"ignore-walk": "3.0.1",
+						"npm-bundled": "1.0.3"
 					}
 				},
 				"npmlog": {
@@ -3292,10 +3292,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -3314,7 +3314,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"wrappy": "1"
+						"wrappy": "1.0.2"
 					}
 				},
 				"os-homedir": {
@@ -3335,8 +3335,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
 					}
 				},
 				"path-is-absolute": {
@@ -3357,10 +3357,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "~0.4.0",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
+						"deep-extend": "0.4.2",
+						"ini": "1.3.5",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -3377,13 +3377,13 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.0",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"rimraf": {
@@ -3392,7 +3392,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "7.1.2"
 					}
 				},
 				"safe-buffer": {
@@ -3435,9 +3435,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				},
 				"string_decoder": {
@@ -3446,7 +3446,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.1"
 					}
 				},
 				"strip-ansi": {
@@ -3454,7 +3454,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				},
 				"strip-json-comments": {
@@ -3469,13 +3469,13 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"chownr": "^1.0.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.2.4",
-						"minizlib": "^1.1.0",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.1",
-						"yallist": "^3.0.2"
+						"chownr": "1.0.1",
+						"fs-minipass": "1.2.5",
+						"minipass": "2.2.4",
+						"minizlib": "1.1.0",
+						"mkdirp": "0.5.1",
+						"safe-buffer": "5.1.1",
+						"yallist": "3.0.2"
 					}
 				},
 				"util-deprecate": {
@@ -3490,7 +3490,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"string-width": "^1.0.2"
+						"string-width": "1.0.2"
 					}
 				},
 				"wrappy": {
@@ -3523,14 +3523,14 @@
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 			"dev": true,
 			"requires": {
-				"aproba": "^1.0.3",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.0",
-				"object-assign": "^4.1.0",
-				"signal-exit": "^3.0.0",
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wide-align": "^1.1.0"
+				"aproba": "1.2.0",
+				"console-control-strings": "1.1.0",
+				"has-unicode": "2.0.1",
+				"object-assign": "4.1.1",
+				"signal-exit": "3.0.2",
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1",
+				"wide-align": "1.1.2"
 			},
 			"dependencies": {
 				"is-fullwidth-code-point": {
@@ -3539,7 +3539,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"string-width": {
@@ -3548,9 +3548,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				}
 			}
@@ -3567,11 +3567,11 @@
 			"integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "^2.1.4",
-				"meow": "^3.3.0",
-				"normalize-package-data": "^2.3.0",
-				"parse-github-repo-url": "^1.3.0",
-				"through2": "^2.0.0"
+				"hosted-git-info": "2.6.0",
+				"meow": "3.7.0",
+				"normalize-package-data": "2.4.0",
+				"parse-github-repo-url": "1.4.1",
+				"through2": "2.0.3"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -3586,8 +3586,8 @@
 					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 					"dev": true,
 					"requires": {
-						"camelcase": "^2.0.0",
-						"map-obj": "^1.0.0"
+						"camelcase": "2.1.1",
+						"map-obj": "1.0.1"
 					}
 				},
 				"indent-string": {
@@ -3596,7 +3596,7 @@
 					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 					"dev": true,
 					"requires": {
-						"repeating": "^2.0.0"
+						"repeating": "2.0.1"
 					}
 				},
 				"map-obj": {
@@ -3611,16 +3611,16 @@
 					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 					"dev": true,
 					"requires": {
-						"camelcase-keys": "^2.0.0",
-						"decamelize": "^1.1.2",
-						"loud-rejection": "^1.0.0",
-						"map-obj": "^1.0.1",
-						"minimist": "^1.1.3",
-						"normalize-package-data": "^2.3.4",
-						"object-assign": "^4.0.1",
-						"read-pkg-up": "^1.0.1",
-						"redent": "^1.0.0",
-						"trim-newlines": "^1.0.0"
+						"camelcase-keys": "2.1.0",
+						"decamelize": "1.2.0",
+						"loud-rejection": "1.6.0",
+						"map-obj": "1.0.1",
+						"minimist": "1.2.0",
+						"normalize-package-data": "2.4.0",
+						"object-assign": "4.1.1",
+						"read-pkg-up": "1.0.1",
+						"redent": "1.0.0",
+						"trim-newlines": "1.0.0"
 					}
 				},
 				"minimist": {
@@ -3635,8 +3635,8 @@
 					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
 					"dev": true,
 					"requires": {
-						"indent-string": "^2.1.0",
-						"strip-indent": "^1.0.1"
+						"indent-string": "2.1.0",
+						"strip-indent": "1.0.1"
 					}
 				},
 				"strip-indent": {
@@ -3645,7 +3645,7 @@
 					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
 					"dev": true,
 					"requires": {
-						"get-stdin": "^4.0.1"
+						"get-stdin": "4.0.1"
 					}
 				},
 				"trim-newlines": {
@@ -3686,7 +3686,7 @@
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0"
+				"assert-plus": "1.0.0"
 			}
 		},
 		"git-raw-commits": {
@@ -3695,11 +3695,11 @@
 			"integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
 			"dev": true,
 			"requires": {
-				"dargs": "^4.0.1",
-				"lodash.template": "^4.0.2",
-				"meow": "^4.0.0",
-				"split2": "^2.0.0",
-				"through2": "^2.0.0"
+				"dargs": "4.1.0",
+				"lodash.template": "4.4.0",
+				"meow": "4.0.1",
+				"split2": "2.2.0",
+				"through2": "2.0.3"
 			}
 		},
 		"git-remote-origin-url": {
@@ -3708,8 +3708,8 @@
 			"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
 			"dev": true,
 			"requires": {
-				"gitconfiglocal": "^1.0.0",
-				"pify": "^2.3.0"
+				"gitconfiglocal": "1.0.0",
+				"pify": "2.3.0"
 			}
 		},
 		"git-semver-tags": {
@@ -3718,8 +3718,8 @@
 			"integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
 			"dev": true,
 			"requires": {
-				"meow": "^4.0.0",
-				"semver": "^5.5.0"
+				"meow": "4.0.1",
+				"semver": "5.5.0"
 			}
 		},
 		"gitconfiglocal": {
@@ -3728,7 +3728,7 @@
 			"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
 			"dev": true,
 			"requires": {
-				"ini": "^1.3.2"
+				"ini": "1.3.5"
 			}
 		},
 		"glob": {
@@ -3737,12 +3737,12 @@
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
 			}
 		},
 		"glob-base": {
@@ -3751,8 +3751,8 @@
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 			"dev": true,
 			"requires": {
-				"glob-parent": "^2.0.0",
-				"is-glob": "^2.0.0"
+				"glob-parent": "2.0.0",
+				"is-glob": "2.0.1"
 			}
 		},
 		"glob-parent": {
@@ -3761,7 +3761,7 @@
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 			"dev": true,
 			"requires": {
-				"is-glob": "^2.0.0"
+				"is-glob": "2.0.1"
 			}
 		},
 		"globals": {
@@ -3776,12 +3776,12 @@
 			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
 			"dev": true,
 			"requires": {
-				"array-union": "^1.0.1",
-				"arrify": "^1.0.0",
-				"glob": "^7.0.3",
-				"object-assign": "^4.0.1",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
+				"array-union": "1.0.2",
+				"arrify": "1.0.1",
+				"glob": "7.1.2",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
 			}
 		},
 		"got": {
@@ -3790,17 +3790,17 @@
 			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
 			"dev": true,
 			"requires": {
-				"create-error-class": "^3.0.0",
-				"duplexer3": "^0.1.4",
-				"get-stream": "^3.0.0",
-				"is-redirect": "^1.0.0",
-				"is-retry-allowed": "^1.0.0",
-				"is-stream": "^1.0.0",
-				"lowercase-keys": "^1.0.0",
-				"safe-buffer": "^5.0.1",
-				"timed-out": "^4.0.0",
-				"unzip-response": "^2.0.1",
-				"url-parse-lax": "^1.0.0"
+				"create-error-class": "3.0.2",
+				"duplexer3": "0.1.4",
+				"get-stream": "3.0.0",
+				"is-redirect": "1.0.0",
+				"is-retry-allowed": "1.1.0",
+				"is-stream": "1.1.0",
+				"lowercase-keys": "1.0.1",
+				"safe-buffer": "5.1.2",
+				"timed-out": "4.0.1",
+				"unzip-response": "2.0.1",
+				"url-parse-lax": "1.0.0"
 			}
 		},
 		"graceful-fs": {
@@ -3821,10 +3821,10 @@
 			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
 			"dev": true,
 			"requires": {
-				"async": "^1.4.0",
-				"optimist": "^0.6.1",
-				"source-map": "^0.4.4",
-				"uglify-js": "^2.6"
+				"async": "1.5.2",
+				"optimist": "0.6.1",
+				"source-map": "0.4.4",
+				"uglify-js": "2.8.29"
 			},
 			"dependencies": {
 				"async": {
@@ -3839,7 +3839,7 @@
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
 					"dev": true,
 					"requires": {
-						"amdefine": ">=0.0.4"
+						"amdefine": "1.0.1"
 					}
 				}
 			}
@@ -3856,8 +3856,8 @@
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.1.0",
-				"har-schema": "^2.0.0"
+				"ajv": "5.5.2",
+				"har-schema": "2.0.0"
 			},
 			"dependencies": {
 				"ajv": {
@@ -3866,10 +3866,10 @@
 					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 					"dev": true,
 					"requires": {
-						"co": "^4.6.0",
-						"fast-deep-equal": "^1.0.0",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.3.0"
+						"co": "4.6.0",
+						"fast-deep-equal": "1.1.0",
+						"fast-json-stable-stringify": "2.0.0",
+						"json-schema-traverse": "0.3.1"
 					}
 				},
 				"fast-deep-equal": {
@@ -3886,7 +3886,7 @@
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
 			"dev": true,
 			"requires": {
-				"function-bind": "^1.0.2"
+				"function-bind": "1.1.1"
 			}
 		},
 		"has-ansi": {
@@ -3895,7 +3895,7 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "2.1.1"
 			}
 		},
 		"has-flag": {
@@ -3916,9 +3916,9 @@
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 			"dev": true,
 			"requires": {
-				"get-value": "^2.0.6",
-				"has-values": "^1.0.0",
-				"isobject": "^3.0.0"
+				"get-value": "2.0.6",
+				"has-values": "1.0.0",
+				"isobject": "3.0.1"
 			}
 		},
 		"has-values": {
@@ -3927,8 +3927,8 @@
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
 			"dev": true,
 			"requires": {
-				"is-number": "^3.0.0",
-				"kind-of": "^4.0.0"
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -3937,7 +3937,7 @@
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -3948,10 +3948,10 @@
 			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
 			"dev": true,
 			"requires": {
-				"boom": "4.x.x",
-				"cryptiles": "3.x.x",
-				"hoek": "4.x.x",
-				"sntp": "2.x.x"
+				"boom": "4.3.1",
+				"cryptiles": "3.1.2",
+				"hoek": "4.2.1",
+				"sntp": "2.1.0"
 			}
 		},
 		"hoek": {
@@ -3966,8 +3966,8 @@
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
 			"dev": true,
 			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.1"
+				"os-homedir": "1.0.2",
+				"os-tmpdir": "1.0.2"
 			}
 		},
 		"hosted-git-info": {
@@ -3982,7 +3982,7 @@
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
 			"dev": true,
 			"requires": {
-				"whatwg-encoding": "^1.0.1"
+				"whatwg-encoding": "1.0.3"
 			}
 		},
 		"http-signature": {
@@ -3991,9 +3991,9 @@
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
+				"assert-plus": "1.0.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.14.1"
 			}
 		},
 		"iconv-lite": {
@@ -4002,7 +4002,7 @@
 			"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
 			"dev": true,
 			"requires": {
-				"safer-buffer": ">= 2.1.2 < 3"
+				"safer-buffer": "2.1.2"
 			}
 		},
 		"ieee754": {
@@ -4023,8 +4023,8 @@
 			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
 			"dev": true,
 			"requires": {
-				"pkg-dir": "^2.0.0",
-				"resolve-cwd": "^2.0.0"
+				"pkg-dir": "2.0.0",
+				"resolve-cwd": "2.0.0"
 			},
 			"dependencies": {
 				"pkg-dir": {
@@ -4033,7 +4033,7 @@
 					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 					"dev": true,
 					"requires": {
-						"find-up": "^2.1.0"
+						"find-up": "2.1.0"
 					}
 				}
 			}
@@ -4056,8 +4056,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
 			}
 		},
 		"inherits": {
@@ -4078,20 +4078,20 @@
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.0",
-				"cli-cursor": "^2.1.0",
-				"cli-width": "^2.0.0",
-				"external-editor": "^2.0.4",
-				"figures": "^2.0.0",
-				"lodash": "^4.3.0",
+				"ansi-escapes": "3.1.0",
+				"chalk": "2.4.1",
+				"cli-cursor": "2.1.0",
+				"cli-width": "2.2.0",
+				"external-editor": "2.2.0",
+				"figures": "2.0.0",
+				"lodash": "4.17.10",
 				"mute-stream": "0.0.7",
-				"run-async": "^2.2.0",
-				"rx-lite": "^4.0.8",
-				"rx-lite-aggregates": "^4.0.8",
-				"string-width": "^2.1.0",
-				"strip-ansi": "^4.0.0",
-				"through": "^2.3.6"
+				"run-async": "2.3.0",
+				"rx-lite": "4.0.8",
+				"rx-lite-aggregates": "4.0.8",
+				"string-width": "2.1.1",
+				"strip-ansi": "4.0.0",
+				"through": "2.3.8"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -4106,7 +4106,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -4115,9 +4115,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"strip-ansi": {
@@ -4126,7 +4126,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				},
 				"supports-color": {
@@ -4135,7 +4135,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -4146,7 +4146,7 @@
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"dev": true,
 			"requires": {
-				"loose-envify": "^1.0.0"
+				"loose-envify": "1.3.1"
 			}
 		},
 		"invert-kv": {
@@ -4161,7 +4161,7 @@
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -4170,7 +4170,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -4193,7 +4193,7 @@
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"dev": true,
 			"requires": {
-				"builtin-modules": "^1.0.0"
+				"builtin-modules": "1.1.1"
 			}
 		},
 		"is-callable": {
@@ -4208,7 +4208,7 @@
 			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
 			"dev": true,
 			"requires": {
-				"ci-info": "^1.0.0"
+				"ci-info": "1.1.3"
 			}
 		},
 		"is-data-descriptor": {
@@ -4217,7 +4217,7 @@
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -4226,7 +4226,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -4243,9 +4243,9 @@
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 			"dev": true,
 			"requires": {
-				"is-accessor-descriptor": "^0.1.6",
-				"is-data-descriptor": "^0.1.4",
-				"kind-of": "^5.0.0"
+				"is-accessor-descriptor": "0.1.6",
+				"is-data-descriptor": "0.1.4",
+				"kind-of": "5.1.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -4268,7 +4268,7 @@
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"dev": true,
 			"requires": {
-				"is-primitive": "^2.0.0"
+				"is-primitive": "2.0.0"
 			}
 		},
 		"is-extendable": {
@@ -4289,7 +4289,7 @@
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "^1.0.0"
+				"number-is-nan": "1.0.1"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -4310,7 +4310,7 @@
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"is-extglob": "1.0.0"
 			}
 		},
 		"is-number": {
@@ -4319,7 +4319,7 @@
 			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -4328,7 +4328,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -4345,7 +4345,7 @@
 			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
 			"dev": true,
 			"requires": {
-				"is-number": "^4.0.0"
+				"is-number": "4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -4368,7 +4368,7 @@
 			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
 			"dev": true,
 			"requires": {
-				"is-path-inside": "^1.0.0"
+				"is-path-inside": "1.0.1"
 			}
 		},
 		"is-path-inside": {
@@ -4377,7 +4377,7 @@
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
 			"dev": true,
 			"requires": {
-				"path-is-inside": "^1.0.1"
+				"path-is-inside": "1.0.2"
 			}
 		},
 		"is-plain-obj": {
@@ -4392,7 +4392,7 @@
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.1"
+				"isobject": "3.0.1"
 			}
 		},
 		"is-posix-bracket": {
@@ -4425,7 +4425,7 @@
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.1"
+				"has": "1.0.1"
 			}
 		},
 		"is-resolvable": {
@@ -4464,7 +4464,7 @@
 			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
 			"dev": true,
 			"requires": {
-				"text-extensions": "^1.0.0"
+				"text-extensions": "1.7.0"
 			}
 		},
 		"is-typedarray": {
@@ -4515,18 +4515,18 @@
 			"integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
 			"dev": true,
 			"requires": {
-				"async": "^2.1.4",
-				"compare-versions": "^3.1.0",
-				"fileset": "^2.0.2",
-				"istanbul-lib-coverage": "^1.2.0",
-				"istanbul-lib-hook": "^1.2.0",
-				"istanbul-lib-instrument": "^1.10.1",
-				"istanbul-lib-report": "^1.1.4",
-				"istanbul-lib-source-maps": "^1.2.4",
-				"istanbul-reports": "^1.3.0",
-				"js-yaml": "^3.7.0",
-				"mkdirp": "^0.5.1",
-				"once": "^1.4.0"
+				"async": "2.6.0",
+				"compare-versions": "3.1.0",
+				"fileset": "2.0.3",
+				"istanbul-lib-coverage": "1.2.0",
+				"istanbul-lib-hook": "1.2.0",
+				"istanbul-lib-instrument": "1.10.1",
+				"istanbul-lib-report": "1.1.4",
+				"istanbul-lib-source-maps": "1.2.4",
+				"istanbul-reports": "1.3.0",
+				"js-yaml": "3.11.0",
+				"mkdirp": "0.5.1",
+				"once": "1.4.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -4544,11 +4544,11 @@
 					"integrity": "sha512-UzuK0g1wyQijiaYQxj/CdNycFhAd2TLtO2obKQMTZrZ1jzEMRY3rvpASEKkaxbRR6brvdovfA03znPa/pXcejg==",
 					"dev": true,
 					"requires": {
-						"debug": "^3.1.0",
-						"istanbul-lib-coverage": "^1.2.0",
-						"mkdirp": "^0.5.1",
-						"rimraf": "^2.6.1",
-						"source-map": "^0.5.3"
+						"debug": "3.1.0",
+						"istanbul-lib-coverage": "1.2.0",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.2",
+						"source-map": "0.5.7"
 					}
 				}
 			}
@@ -4565,7 +4565,7 @@
 			"integrity": "sha512-p3En6/oGkFQV55Up8ZPC2oLxvgSxD8CzA0yBrhRZSh3pfv3OFj9aSGVC0yoerAi/O4u7jUVnOGVX1eVFM+0tmQ==",
 			"dev": true,
 			"requires": {
-				"append-transform": "^0.4.0"
+				"append-transform": "0.4.0"
 			}
 		},
 		"istanbul-lib-instrument": {
@@ -4574,13 +4574,13 @@
 			"integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
 			"dev": true,
 			"requires": {
-				"babel-generator": "^6.18.0",
-				"babel-template": "^6.16.0",
-				"babel-traverse": "^6.18.0",
-				"babel-types": "^6.18.0",
-				"babylon": "^6.18.0",
-				"istanbul-lib-coverage": "^1.2.0",
-				"semver": "^5.3.0"
+				"babel-generator": "6.26.1",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"istanbul-lib-coverage": "1.2.0",
+				"semver": "5.5.0"
 			}
 		},
 		"istanbul-lib-report": {
@@ -4589,10 +4589,10 @@
 			"integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
 			"dev": true,
 			"requires": {
-				"istanbul-lib-coverage": "^1.2.0",
-				"mkdirp": "^0.5.1",
-				"path-parse": "^1.0.5",
-				"supports-color": "^3.1.2"
+				"istanbul-lib-coverage": "1.2.0",
+				"mkdirp": "0.5.1",
+				"path-parse": "1.0.5",
+				"supports-color": "3.2.3"
 			},
 			"dependencies": {
 				"has-flag": {
@@ -4607,7 +4607,7 @@
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"dev": true,
 					"requires": {
-						"has-flag": "^1.0.0"
+						"has-flag": "1.0.0"
 					}
 				}
 			}
@@ -4618,11 +4618,11 @@
 			"integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
 			"dev": true,
 			"requires": {
-				"debug": "^3.1.0",
-				"istanbul-lib-coverage": "^1.1.2",
-				"mkdirp": "^0.5.1",
-				"rimraf": "^2.6.1",
-				"source-map": "^0.5.3"
+				"debug": "3.1.0",
+				"istanbul-lib-coverage": "1.2.0",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"source-map": "0.5.7"
 			},
 			"dependencies": {
 				"debug": {
@@ -4642,7 +4642,7 @@
 			"integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
 			"dev": true,
 			"requires": {
-				"handlebars": "^4.0.3"
+				"handlebars": "4.0.11"
 			}
 		},
 		"jest": {
@@ -4651,8 +4651,8 @@
 			"integrity": "sha512-FFCdU/pXOEASfHxFDOWUysI/+FFoqiXJADEIXgDKuZyqSmBD3tZ4BEGH7+M79v7czj7bbkhwtd2LaEDcJiM/GQ==",
 			"dev": true,
 			"requires": {
-				"import-local": "^1.0.0",
-				"jest-cli": "^22.4.3"
+				"import-local": "1.0.0",
+				"jest-cli": "22.4.3"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -4667,7 +4667,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"arr-diff": {
@@ -4676,7 +4676,7 @@
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.0.1"
+						"arr-flatten": "1.1.0"
 					}
 				},
 				"array-unique": {
@@ -4691,9 +4691,9 @@
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 					"dev": true,
 					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
+						"expand-range": "1.8.2",
+						"preserve": "0.2.0",
+						"repeat-element": "1.1.2"
 					}
 				},
 				"chalk": {
@@ -4702,9 +4702,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"expand-brackets": {
@@ -4713,7 +4713,7 @@
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 					"dev": true,
 					"requires": {
-						"is-posix-bracket": "^0.1.0"
+						"is-posix-bracket": "0.1.1"
 					}
 				},
 				"extglob": {
@@ -4722,7 +4722,7 @@
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"jest-cli": {
@@ -4731,40 +4731,40 @@
 					"integrity": "sha512-IiHybF0DJNqZPsbjn4Cy4vcqcmImpoFwNFnkehzVw8lTUSl4axZh5DHewu5bdpZF2Y5gUqFKYzH0FH4Qx2k+UA==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "^3.0.0",
-						"chalk": "^2.0.1",
-						"exit": "^0.1.2",
-						"glob": "^7.1.2",
-						"graceful-fs": "^4.1.11",
-						"import-local": "^1.0.0",
-						"is-ci": "^1.0.10",
-						"istanbul-api": "^1.1.14",
-						"istanbul-lib-coverage": "^1.1.1",
-						"istanbul-lib-instrument": "^1.8.0",
-						"istanbul-lib-source-maps": "^1.2.1",
-						"jest-changed-files": "^22.4.3",
-						"jest-config": "^22.4.3",
-						"jest-environment-jsdom": "^22.4.3",
-						"jest-get-type": "^22.4.3",
-						"jest-haste-map": "^22.4.3",
-						"jest-message-util": "^22.4.3",
-						"jest-regex-util": "^22.4.3",
-						"jest-resolve-dependencies": "^22.4.3",
-						"jest-runner": "^22.4.3",
-						"jest-runtime": "^22.4.3",
-						"jest-snapshot": "^22.4.3",
-						"jest-util": "^22.4.3",
-						"jest-validate": "^22.4.3",
-						"jest-worker": "^22.4.3",
-						"micromatch": "^2.3.11",
-						"node-notifier": "^5.2.1",
-						"realpath-native": "^1.0.0",
-						"rimraf": "^2.5.4",
-						"slash": "^1.0.0",
-						"string-length": "^2.0.0",
-						"strip-ansi": "^4.0.0",
-						"which": "^1.2.12",
-						"yargs": "^10.0.3"
+						"ansi-escapes": "3.1.0",
+						"chalk": "2.4.1",
+						"exit": "0.1.2",
+						"glob": "7.1.2",
+						"graceful-fs": "4.1.11",
+						"import-local": "1.0.0",
+						"is-ci": "1.1.0",
+						"istanbul-api": "1.3.1",
+						"istanbul-lib-coverage": "1.2.0",
+						"istanbul-lib-instrument": "1.10.1",
+						"istanbul-lib-source-maps": "1.2.3",
+						"jest-changed-files": "22.4.3",
+						"jest-config": "22.4.3",
+						"jest-environment-jsdom": "22.4.3",
+						"jest-get-type": "22.4.3",
+						"jest-haste-map": "22.4.3",
+						"jest-message-util": "22.4.3",
+						"jest-regex-util": "22.4.3",
+						"jest-resolve-dependencies": "22.4.3",
+						"jest-runner": "22.4.3",
+						"jest-runtime": "22.4.3",
+						"jest-snapshot": "22.4.3",
+						"jest-util": "22.4.3",
+						"jest-validate": "22.4.3",
+						"jest-worker": "22.4.3",
+						"micromatch": "2.3.11",
+						"node-notifier": "5.2.1",
+						"realpath-native": "1.0.0",
+						"rimraf": "2.6.2",
+						"slash": "1.0.0",
+						"string-length": "2.0.0",
+						"strip-ansi": "4.0.0",
+						"which": "1.3.0",
+						"yargs": "10.1.2"
 					}
 				},
 				"kind-of": {
@@ -4773,7 +4773,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				},
 				"micromatch": {
@@ -4782,19 +4782,19 @@
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
+						"arr-diff": "2.0.0",
+						"array-unique": "0.2.1",
+						"braces": "1.8.5",
+						"expand-brackets": "0.1.5",
+						"extglob": "0.3.2",
+						"filename-regex": "2.0.1",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1",
+						"kind-of": "3.2.2",
+						"normalize-path": "2.1.1",
+						"object.omit": "2.0.1",
+						"parse-glob": "3.0.4",
+						"regex-cache": "0.4.4"
 					}
 				},
 				"normalize-path": {
@@ -4803,7 +4803,7 @@
 					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 					"dev": true,
 					"requires": {
-						"remove-trailing-separator": "^1.0.1"
+						"remove-trailing-separator": "1.1.0"
 					}
 				},
 				"strip-ansi": {
@@ -4812,7 +4812,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				},
 				"supports-color": {
@@ -4821,7 +4821,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -4832,7 +4832,7 @@
 			"integrity": "sha512-83Dh0w1aSkUNFhy5d2dvqWxi/y6weDwVVLU6vmK0cV9VpRxPzhTeGimbsbRDSnEoszhF937M4sDLLeS7Cu/Tmw==",
 			"dev": true,
 			"requires": {
-				"throat": "^4.0.0"
+				"throat": "4.1.0"
 			}
 		},
 		"jest-config": {
@@ -4841,17 +4841,17 @@
 			"integrity": "sha512-KSg3EOToCgkX+lIvenKY7J8s426h6ahXxaUFJxvGoEk0562Z6inWj1TnKoGycTASwiLD+6kSYFALcjdosq9KIQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"glob": "^7.1.1",
-				"jest-environment-jsdom": "^22.4.3",
-				"jest-environment-node": "^22.4.3",
-				"jest-get-type": "^22.4.3",
-				"jest-jasmine2": "^22.4.3",
-				"jest-regex-util": "^22.4.3",
-				"jest-resolve": "^22.4.3",
-				"jest-util": "^22.4.3",
-				"jest-validate": "^22.4.3",
-				"pretty-format": "^22.4.3"
+				"chalk": "2.4.1",
+				"glob": "7.1.2",
+				"jest-environment-jsdom": "22.4.3",
+				"jest-environment-node": "22.4.3",
+				"jest-get-type": "22.4.3",
+				"jest-jasmine2": "22.4.3",
+				"jest-regex-util": "22.4.3",
+				"jest-resolve": "22.4.3",
+				"jest-util": "22.4.3",
+				"jest-validate": "22.4.3",
+				"pretty-format": "22.4.3"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -4860,7 +4860,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -4869,9 +4869,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"supports-color": {
@@ -4880,7 +4880,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -4891,10 +4891,10 @@
 			"integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"diff": "^3.2.0",
-				"jest-get-type": "^22.4.3",
-				"pretty-format": "^22.4.3"
+				"chalk": "2.4.1",
+				"diff": "3.5.0",
+				"jest-get-type": "22.4.3",
+				"pretty-format": "22.4.3"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -4903,7 +4903,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -4912,9 +4912,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"supports-color": {
@@ -4923,7 +4923,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -4934,7 +4934,7 @@
 			"integrity": "sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==",
 			"dev": true,
 			"requires": {
-				"detect-newline": "^2.1.0"
+				"detect-newline": "2.1.0"
 			}
 		},
 		"jest-environment-jsdom": {
@@ -4943,9 +4943,9 @@
 			"integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
 			"dev": true,
 			"requires": {
-				"jest-mock": "^22.4.3",
-				"jest-util": "^22.4.3",
-				"jsdom": "^11.5.1"
+				"jest-mock": "22.4.3",
+				"jest-util": "22.4.3",
+				"jsdom": "11.10.0"
 			}
 		},
 		"jest-environment-node": {
@@ -4954,8 +4954,8 @@
 			"integrity": "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
 			"dev": true,
 			"requires": {
-				"jest-mock": "^22.4.3",
-				"jest-util": "^22.4.3"
+				"jest-mock": "22.4.3",
+				"jest-util": "22.4.3"
 			}
 		},
 		"jest-get-type": {
@@ -4970,13 +4970,13 @@
 			"integrity": "sha512-4Q9fjzuPVwnaqGKDpIsCSoTSnG3cteyk2oNVjBX12HHOaF1oxql+uUiqZb5Ndu7g/vTZfdNwwy4WwYogLh29DQ==",
 			"dev": true,
 			"requires": {
-				"fb-watchman": "^2.0.0",
-				"graceful-fs": "^4.1.11",
-				"jest-docblock": "^22.4.3",
-				"jest-serializer": "^22.4.3",
-				"jest-worker": "^22.4.3",
-				"micromatch": "^2.3.11",
-				"sane": "^2.0.0"
+				"fb-watchman": "2.0.0",
+				"graceful-fs": "4.1.11",
+				"jest-docblock": "22.4.3",
+				"jest-serializer": "22.4.3",
+				"jest-worker": "22.4.3",
+				"micromatch": "2.3.11",
+				"sane": "2.5.2"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -4985,7 +4985,7 @@
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.0.1"
+						"arr-flatten": "1.1.0"
 					}
 				},
 				"array-unique": {
@@ -5000,9 +5000,9 @@
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 					"dev": true,
 					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
+						"expand-range": "1.8.2",
+						"preserve": "0.2.0",
+						"repeat-element": "1.1.2"
 					}
 				},
 				"expand-brackets": {
@@ -5011,7 +5011,7 @@
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 					"dev": true,
 					"requires": {
-						"is-posix-bracket": "^0.1.0"
+						"is-posix-bracket": "0.1.1"
 					}
 				},
 				"extglob": {
@@ -5020,7 +5020,7 @@
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"kind-of": {
@@ -5029,7 +5029,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				},
 				"micromatch": {
@@ -5038,19 +5038,19 @@
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
+						"arr-diff": "2.0.0",
+						"array-unique": "0.2.1",
+						"braces": "1.8.5",
+						"expand-brackets": "0.1.5",
+						"extglob": "0.3.2",
+						"filename-regex": "2.0.1",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1",
+						"kind-of": "3.2.2",
+						"normalize-path": "2.1.1",
+						"object.omit": "2.0.1",
+						"parse-glob": "3.0.4",
+						"regex-cache": "0.4.4"
 					}
 				},
 				"normalize-path": {
@@ -5059,7 +5059,7 @@
 					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 					"dev": true,
 					"requires": {
-						"remove-trailing-separator": "^1.0.1"
+						"remove-trailing-separator": "1.1.0"
 					}
 				}
 			}
@@ -5070,17 +5070,17 @@
 			"integrity": "sha512-yZCPCJUcEY6R5KJB/VReo1AYI2b+5Ky+C+JA1v34jndJsRcLpU4IZX4rFJn7yDTtdNbO/nNqg+3SDIPNH2ecnw==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"co": "^4.6.0",
-				"expect": "^22.4.3",
-				"graceful-fs": "^4.1.11",
-				"is-generator-fn": "^1.0.0",
-				"jest-diff": "^22.4.3",
-				"jest-matcher-utils": "^22.4.3",
-				"jest-message-util": "^22.4.3",
-				"jest-snapshot": "^22.4.3",
-				"jest-util": "^22.4.3",
-				"source-map-support": "^0.5.0"
+				"chalk": "2.4.1",
+				"co": "4.6.0",
+				"expect": "22.4.3",
+				"graceful-fs": "4.1.11",
+				"is-generator-fn": "1.0.0",
+				"jest-diff": "22.4.3",
+				"jest-matcher-utils": "22.4.3",
+				"jest-message-util": "22.4.3",
+				"jest-snapshot": "22.4.3",
+				"jest-util": "22.4.3",
+				"source-map-support": "0.5.6"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5089,7 +5089,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -5098,9 +5098,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"supports-color": {
@@ -5109,7 +5109,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -5120,7 +5120,7 @@
 			"integrity": "sha512-NZpR/Ls7+ndO57LuXROdgCGz2RmUdC541tTImL9bdUtU3WadgFGm0yV+Ok4Fuia/1rLAn5KaJ+i76L6e3zGJYQ==",
 			"dev": true,
 			"requires": {
-				"pretty-format": "^22.4.3"
+				"pretty-format": "22.4.3"
 			}
 		},
 		"jest-matcher-utils": {
@@ -5129,9 +5129,9 @@
 			"integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"jest-get-type": "^22.4.3",
-				"pretty-format": "^22.4.3"
+				"chalk": "2.4.1",
+				"jest-get-type": "22.4.3",
+				"pretty-format": "22.4.3"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5140,7 +5140,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -5149,9 +5149,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"supports-color": {
@@ -5160,7 +5160,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -5171,11 +5171,11 @@
 			"integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0-beta.35",
-				"chalk": "^2.0.1",
-				"micromatch": "^2.3.11",
-				"slash": "^1.0.0",
-				"stack-utils": "^1.0.1"
+				"@babel/code-frame": "7.0.0-beta.46",
+				"chalk": "2.4.1",
+				"micromatch": "2.3.11",
+				"slash": "1.0.0",
+				"stack-utils": "1.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5184,7 +5184,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"arr-diff": {
@@ -5193,7 +5193,7 @@
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.0.1"
+						"arr-flatten": "1.1.0"
 					}
 				},
 				"array-unique": {
@@ -5208,9 +5208,9 @@
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 					"dev": true,
 					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
+						"expand-range": "1.8.2",
+						"preserve": "0.2.0",
+						"repeat-element": "1.1.2"
 					}
 				},
 				"chalk": {
@@ -5219,9 +5219,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"expand-brackets": {
@@ -5230,7 +5230,7 @@
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 					"dev": true,
 					"requires": {
-						"is-posix-bracket": "^0.1.0"
+						"is-posix-bracket": "0.1.1"
 					}
 				},
 				"extglob": {
@@ -5239,7 +5239,7 @@
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"kind-of": {
@@ -5248,7 +5248,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				},
 				"micromatch": {
@@ -5257,19 +5257,19 @@
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
+						"arr-diff": "2.0.0",
+						"array-unique": "0.2.1",
+						"braces": "1.8.5",
+						"expand-brackets": "0.1.5",
+						"extglob": "0.3.2",
+						"filename-regex": "2.0.1",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1",
+						"kind-of": "3.2.2",
+						"normalize-path": "2.1.1",
+						"object.omit": "2.0.1",
+						"parse-glob": "3.0.4",
+						"regex-cache": "0.4.4"
 					}
 				},
 				"normalize-path": {
@@ -5278,7 +5278,7 @@
 					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 					"dev": true,
 					"requires": {
-						"remove-trailing-separator": "^1.0.1"
+						"remove-trailing-separator": "1.1.0"
 					}
 				},
 				"supports-color": {
@@ -5287,7 +5287,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -5310,8 +5310,8 @@
 			"integrity": "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
 			"dev": true,
 			"requires": {
-				"browser-resolve": "^1.11.2",
-				"chalk": "^2.0.1"
+				"browser-resolve": "1.11.2",
+				"chalk": "2.4.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5320,7 +5320,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -5329,9 +5329,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"supports-color": {
@@ -5340,7 +5340,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -5351,7 +5351,7 @@
 			"integrity": "sha512-06czCMVToSN8F2U4EvgSB1Bv/56gc7MpCftZ9z9fBgUQM7dzHGCMBsyfVA6dZTx8v0FDcnALf7hupeQxaBCvpA==",
 			"dev": true,
 			"requires": {
-				"jest-regex-util": "^22.4.3"
+				"jest-regex-util": "22.4.3"
 			}
 		},
 		"jest-runner": {
@@ -5360,17 +5360,17 @@
 			"integrity": "sha512-U7PLlQPRlWNbvOHWOrrVay9sqhBJmiKeAdKIkvX4n1G2tsvzLlf77nBD28GL1N6tGv4RmuTfI8R8JrkvCa+IBg==",
 			"dev": true,
 			"requires": {
-				"exit": "^0.1.2",
-				"jest-config": "^22.4.3",
-				"jest-docblock": "^22.4.3",
-				"jest-haste-map": "^22.4.3",
-				"jest-jasmine2": "^22.4.3",
-				"jest-leak-detector": "^22.4.3",
-				"jest-message-util": "^22.4.3",
-				"jest-runtime": "^22.4.3",
-				"jest-util": "^22.4.3",
-				"jest-worker": "^22.4.3",
-				"throat": "^4.0.0"
+				"exit": "0.1.2",
+				"jest-config": "22.4.3",
+				"jest-docblock": "22.4.3",
+				"jest-haste-map": "22.4.3",
+				"jest-jasmine2": "22.4.3",
+				"jest-leak-detector": "22.4.3",
+				"jest-message-util": "22.4.3",
+				"jest-runtime": "22.4.3",
+				"jest-util": "22.4.3",
+				"jest-worker": "22.4.3",
+				"throat": "4.1.0"
 			}
 		},
 		"jest-runtime": {
@@ -5379,26 +5379,26 @@
 			"integrity": "sha512-Eat/esQjevhx9BgJEC8udye+FfoJ2qvxAZfOAWshYGS22HydHn5BgsvPdTtt9cp0fSl5LxYOFA1Pja9Iz2Zt8g==",
 			"dev": true,
 			"requires": {
-				"babel-core": "^6.0.0",
-				"babel-jest": "^22.4.3",
-				"babel-plugin-istanbul": "^4.1.5",
-				"chalk": "^2.0.1",
-				"convert-source-map": "^1.4.0",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.1.11",
-				"jest-config": "^22.4.3",
-				"jest-haste-map": "^22.4.3",
-				"jest-regex-util": "^22.4.3",
-				"jest-resolve": "^22.4.3",
-				"jest-util": "^22.4.3",
-				"jest-validate": "^22.4.3",
-				"json-stable-stringify": "^1.0.1",
-				"micromatch": "^2.3.11",
-				"realpath-native": "^1.0.0",
-				"slash": "^1.0.0",
+				"babel-core": "6.26.3",
+				"babel-jest": "22.4.3",
+				"babel-plugin-istanbul": "4.1.6",
+				"chalk": "2.4.1",
+				"convert-source-map": "1.5.1",
+				"exit": "0.1.2",
+				"graceful-fs": "4.1.11",
+				"jest-config": "22.4.3",
+				"jest-haste-map": "22.4.3",
+				"jest-regex-util": "22.4.3",
+				"jest-resolve": "22.4.3",
+				"jest-util": "22.4.3",
+				"jest-validate": "22.4.3",
+				"json-stable-stringify": "1.0.1",
+				"micromatch": "2.3.11",
+				"realpath-native": "1.0.0",
+				"slash": "1.0.0",
 				"strip-bom": "3.0.0",
-				"write-file-atomic": "^2.1.0",
-				"yargs": "^10.0.3"
+				"write-file-atomic": "2.3.0",
+				"yargs": "10.1.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5407,7 +5407,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"arr-diff": {
@@ -5416,7 +5416,7 @@
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.0.1"
+						"arr-flatten": "1.1.0"
 					}
 				},
 				"array-unique": {
@@ -5431,9 +5431,9 @@
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 					"dev": true,
 					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
+						"expand-range": "1.8.2",
+						"preserve": "0.2.0",
+						"repeat-element": "1.1.2"
 					}
 				},
 				"chalk": {
@@ -5442,9 +5442,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"expand-brackets": {
@@ -5453,7 +5453,7 @@
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 					"dev": true,
 					"requires": {
-						"is-posix-bracket": "^0.1.0"
+						"is-posix-bracket": "0.1.1"
 					}
 				},
 				"extglob": {
@@ -5462,7 +5462,7 @@
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"kind-of": {
@@ -5471,7 +5471,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				},
 				"micromatch": {
@@ -5480,19 +5480,19 @@
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
+						"arr-diff": "2.0.0",
+						"array-unique": "0.2.1",
+						"braces": "1.8.5",
+						"expand-brackets": "0.1.5",
+						"extglob": "0.3.2",
+						"filename-regex": "2.0.1",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1",
+						"kind-of": "3.2.2",
+						"normalize-path": "2.1.1",
+						"object.omit": "2.0.1",
+						"parse-glob": "3.0.4",
+						"regex-cache": "0.4.4"
 					}
 				},
 				"normalize-path": {
@@ -5501,7 +5501,7 @@
 					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 					"dev": true,
 					"requires": {
-						"remove-trailing-separator": "^1.0.1"
+						"remove-trailing-separator": "1.1.0"
 					}
 				},
 				"strip-bom": {
@@ -5516,7 +5516,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -5533,12 +5533,12 @@
 			"integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"jest-diff": "^22.4.3",
-				"jest-matcher-utils": "^22.4.3",
-				"mkdirp": "^0.5.1",
-				"natural-compare": "^1.4.0",
-				"pretty-format": "^22.4.3"
+				"chalk": "2.4.1",
+				"jest-diff": "22.4.3",
+				"jest-matcher-utils": "22.4.3",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"pretty-format": "22.4.3"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5547,7 +5547,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -5556,9 +5556,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"supports-color": {
@@ -5567,7 +5567,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -5578,13 +5578,13 @@
 			"integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
 			"dev": true,
 			"requires": {
-				"callsites": "^2.0.0",
-				"chalk": "^2.0.1",
-				"graceful-fs": "^4.1.11",
-				"is-ci": "^1.0.10",
-				"jest-message-util": "^22.4.3",
-				"mkdirp": "^0.5.1",
-				"source-map": "^0.6.0"
+				"callsites": "2.0.0",
+				"chalk": "2.4.1",
+				"graceful-fs": "4.1.11",
+				"is-ci": "1.1.0",
+				"jest-message-util": "22.4.3",
+				"mkdirp": "0.5.1",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5593,7 +5593,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"callsites": {
@@ -5608,9 +5608,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"source-map": {
@@ -5625,7 +5625,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -5636,11 +5636,11 @@
 			"integrity": "sha512-CfFM18W3GSP/xgmA4UouIx0ljdtfD2mjeBC6c89Gg17E44D4tQhAcTrZmf9djvipwU30kSTnk6CzcxdCCeSXfA==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"jest-config": "^22.4.3",
-				"jest-get-type": "^22.4.3",
-				"leven": "^2.1.0",
-				"pretty-format": "^22.4.3"
+				"chalk": "2.4.1",
+				"jest-config": "22.4.3",
+				"jest-get-type": "22.4.3",
+				"leven": "2.1.0",
+				"pretty-format": "22.4.3"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5649,7 +5649,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -5658,9 +5658,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"supports-color": {
@@ -5669,7 +5669,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -5680,7 +5680,7 @@
 			"integrity": "sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==",
 			"dev": true,
 			"requires": {
-				"merge-stream": "^1.0.1"
+				"merge-stream": "1.0.1"
 			}
 		},
 		"jmespath": {
@@ -5701,8 +5701,8 @@
 			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
 			"dev": true,
 			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
+				"argparse": "1.0.10",
+				"esprima": "4.0.0"
 			}
 		},
 		"jsbn": {
@@ -5718,32 +5718,32 @@
 			"integrity": "sha512-x5No5FpJgBg3j5aBwA8ka6eGuS5IxbC8FOkmyccKvObtFT0bDMict/LOxINZsZGZSfGdNomLZ/qRV9Bpq/GIBA==",
 			"dev": true,
 			"requires": {
-				"abab": "^1.0.4",
-				"acorn": "^5.3.0",
-				"acorn-globals": "^4.1.0",
-				"array-equal": "^1.0.0",
-				"cssom": ">= 0.3.2 < 0.4.0",
-				"cssstyle": ">= 0.2.37 < 0.3.0",
-				"data-urls": "^1.0.0",
-				"domexception": "^1.0.0",
-				"escodegen": "^1.9.0",
-				"html-encoding-sniffer": "^1.0.2",
-				"left-pad": "^1.2.0",
-				"nwmatcher": "^1.4.3",
+				"abab": "1.0.4",
+				"acorn": "5.5.3",
+				"acorn-globals": "4.1.0",
+				"array-equal": "1.0.0",
+				"cssom": "0.3.2",
+				"cssstyle": "0.2.37",
+				"data-urls": "1.0.0",
+				"domexception": "1.0.1",
+				"escodegen": "1.9.1",
+				"html-encoding-sniffer": "1.0.2",
+				"left-pad": "1.3.0",
+				"nwmatcher": "1.4.4",
 				"parse5": "4.0.0",
-				"pn": "^1.1.0",
-				"request": "^2.83.0",
-				"request-promise-native": "^1.0.5",
-				"sax": "^1.2.4",
-				"symbol-tree": "^3.2.2",
-				"tough-cookie": "^2.3.3",
-				"w3c-hr-time": "^1.0.1",
-				"webidl-conversions": "^4.0.2",
-				"whatwg-encoding": "^1.0.3",
-				"whatwg-mimetype": "^2.1.0",
-				"whatwg-url": "^6.4.0",
-				"ws": "^4.0.0",
-				"xml-name-validator": "^3.0.0"
+				"pn": "1.1.0",
+				"request": "2.85.0",
+				"request-promise-native": "1.0.5",
+				"sax": "1.2.4",
+				"symbol-tree": "3.2.2",
+				"tough-cookie": "2.3.4",
+				"w3c-hr-time": "1.0.1",
+				"webidl-conversions": "4.0.2",
+				"whatwg-encoding": "1.0.3",
+				"whatwg-mimetype": "2.1.0",
+				"whatwg-url": "6.4.1",
+				"ws": "4.1.0",
+				"xml-name-validator": "3.0.0"
 			},
 			"dependencies": {
 				"sax": {
@@ -5784,7 +5784,7 @@
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 			"dev": true,
 			"requires": {
-				"jsonify": "~0.0.0"
+				"jsonify": "0.0.0"
 			}
 		},
 		"json-stable-stringify-without-jsonify": {
@@ -5811,7 +5811,7 @@
 			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.6"
+				"graceful-fs": "4.1.11"
 			}
 		},
 		"jsonify": {
@@ -5857,7 +5857,7 @@
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 			"dev": true,
 			"requires": {
-				"invert-kv": "^1.0.0"
+				"invert-kv": "1.0.0"
 			}
 		},
 		"left-pad": {
@@ -5872,45 +5872,45 @@
 			"integrity": "sha512-kgM6zwe2P2tR30MYvgiLLW+9buFCm6E7o8HnRlhTgm70WVBvXVhydqv+q/MF2HrVZkCawfVtCfetyQmtd4oHhQ==",
 			"dev": true,
 			"requires": {
-				"async": "^1.5.0",
-				"chalk": "^2.1.0",
-				"cmd-shim": "^2.0.2",
-				"columnify": "^1.5.4",
-				"command-join": "^2.0.0",
-				"conventional-changelog-cli": "^1.3.13",
-				"conventional-recommended-bump": "^1.2.1",
-				"dedent": "^0.7.0",
-				"execa": "^0.8.0",
-				"find-up": "^2.1.0",
-				"fs-extra": "^4.0.1",
-				"get-port": "^3.2.0",
-				"glob": "^7.1.2",
-				"glob-parent": "^3.1.0",
-				"globby": "^6.1.0",
-				"graceful-fs": "^4.1.11",
-				"hosted-git-info": "^2.5.0",
-				"inquirer": "^3.2.2",
-				"is-ci": "^1.0.10",
-				"load-json-file": "^4.0.0",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.4",
-				"npmlog": "^4.1.2",
-				"p-finally": "^1.0.0",
-				"package-json": "^4.0.1",
-				"path-exists": "^3.0.0",
-				"read-cmd-shim": "^1.0.1",
-				"read-pkg": "^3.0.0",
-				"rimraf": "^2.6.1",
-				"safe-buffer": "^5.1.1",
-				"semver": "^5.4.1",
-				"signal-exit": "^3.0.2",
-				"slash": "^1.0.0",
-				"strong-log-transformer": "^1.0.6",
-				"temp-write": "^3.3.0",
-				"write-file-atomic": "^2.3.0",
-				"write-json-file": "^2.2.0",
-				"write-pkg": "^3.1.0",
-				"yargs": "^8.0.2"
+				"async": "1.5.2",
+				"chalk": "2.4.1",
+				"cmd-shim": "2.0.2",
+				"columnify": "1.5.4",
+				"command-join": "2.0.0",
+				"conventional-changelog-cli": "1.3.22",
+				"conventional-recommended-bump": "1.2.1",
+				"dedent": "0.7.0",
+				"execa": "0.8.0",
+				"find-up": "2.1.0",
+				"fs-extra": "4.0.3",
+				"get-port": "3.2.0",
+				"glob": "7.1.2",
+				"glob-parent": "3.1.0",
+				"globby": "6.1.0",
+				"graceful-fs": "4.1.11",
+				"hosted-git-info": "2.6.0",
+				"inquirer": "3.3.0",
+				"is-ci": "1.1.0",
+				"load-json-file": "4.0.0",
+				"lodash": "4.17.10",
+				"minimatch": "3.0.4",
+				"npmlog": "4.1.2",
+				"p-finally": "1.0.0",
+				"package-json": "4.0.1",
+				"path-exists": "3.0.0",
+				"read-cmd-shim": "1.0.1",
+				"read-pkg": "3.0.0",
+				"rimraf": "2.6.2",
+				"safe-buffer": "5.1.2",
+				"semver": "5.5.0",
+				"signal-exit": "3.0.2",
+				"slash": "1.0.0",
+				"strong-log-transformer": "1.0.6",
+				"temp-write": "3.4.0",
+				"write-file-atomic": "2.3.0",
+				"write-json-file": "2.3.0",
+				"write-pkg": "3.1.0",
+				"yargs": "8.0.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5919,7 +5919,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"async": {
@@ -5940,9 +5940,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"cliui": {
@@ -5951,9 +5951,9 @@
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 					"dev": true,
 					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wrap-ansi": "2.1.0"
 					},
 					"dependencies": {
 						"string-width": {
@@ -5962,9 +5962,9 @@
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"dev": true,
 							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
 							}
 						}
 					}
@@ -5975,13 +5975,13 @@
 					"integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "^5.0.1",
-						"get-stream": "^3.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
+						"cross-spawn": "5.1.0",
+						"get-stream": "3.0.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
 					}
 				},
 				"glob-parent": {
@@ -5990,8 +5990,8 @@
 					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 					"dev": true,
 					"requires": {
-						"is-glob": "^3.1.0",
-						"path-dirname": "^1.0.0"
+						"is-glob": "3.1.0",
+						"path-dirname": "1.0.2"
 					}
 				},
 				"globby": {
@@ -6000,11 +6000,11 @@
 					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 					"dev": true,
 					"requires": {
-						"array-union": "^1.0.1",
-						"glob": "^7.0.3",
-						"object-assign": "^4.0.1",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"array-union": "1.0.2",
+						"glob": "7.1.2",
+						"object-assign": "4.1.1",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"is-extglob": {
@@ -6019,7 +6019,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"is-glob": {
@@ -6028,7 +6028,7 @@
 					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^2.1.0"
+						"is-extglob": "2.1.1"
 					}
 				},
 				"load-json-file": {
@@ -6037,10 +6037,10 @@
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^4.0.0",
-						"pify": "^3.0.0",
-						"strip-bom": "^3.0.0"
+						"graceful-fs": "4.1.11",
+						"parse-json": "4.0.0",
+						"pify": "3.0.0",
+						"strip-bom": "3.0.0"
 					},
 					"dependencies": {
 						"pify": {
@@ -6057,8 +6057,8 @@
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"dev": true,
 					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
+						"error-ex": "1.3.1",
+						"json-parse-better-errors": "1.0.2"
 					}
 				},
 				"path-type": {
@@ -6067,7 +6067,7 @@
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"dev": true,
 					"requires": {
-						"pify": "^3.0.0"
+						"pify": "3.0.0"
 					},
 					"dependencies": {
 						"pify": {
@@ -6084,9 +6084,9 @@
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "^4.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^3.0.0"
+						"load-json-file": "4.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "3.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -6095,8 +6095,8 @@
 					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
 					"dev": true,
 					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^2.0.0"
+						"find-up": "2.1.0",
+						"read-pkg": "2.0.0"
 					},
 					"dependencies": {
 						"load-json-file": {
@@ -6105,10 +6105,10 @@
 							"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
 							"dev": true,
 							"requires": {
-								"graceful-fs": "^4.1.2",
-								"parse-json": "^2.2.0",
-								"pify": "^2.0.0",
-								"strip-bom": "^3.0.0"
+								"graceful-fs": "4.1.11",
+								"parse-json": "2.2.0",
+								"pify": "2.3.0",
+								"strip-bom": "3.0.0"
 							}
 						},
 						"parse-json": {
@@ -6117,7 +6117,7 @@
 							"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 							"dev": true,
 							"requires": {
-								"error-ex": "^1.2.0"
+								"error-ex": "1.3.1"
 							}
 						},
 						"path-type": {
@@ -6126,7 +6126,7 @@
 							"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
 							"dev": true,
 							"requires": {
-								"pify": "^2.0.0"
+								"pify": "2.3.0"
 							}
 						},
 						"read-pkg": {
@@ -6135,9 +6135,9 @@
 							"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
 							"dev": true,
 							"requires": {
-								"load-json-file": "^2.0.0",
-								"normalize-package-data": "^2.3.2",
-								"path-type": "^2.0.0"
+								"load-json-file": "2.0.0",
+								"normalize-package-data": "2.4.0",
+								"path-type": "2.0.0"
 							}
 						}
 					}
@@ -6154,7 +6154,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				},
 				"yargs": {
@@ -6163,19 +6163,19 @@
 					"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
 					"dev": true,
 					"requires": {
-						"camelcase": "^4.1.0",
-						"cliui": "^3.2.0",
-						"decamelize": "^1.1.1",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"read-pkg-up": "^2.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^7.0.0"
+						"camelcase": "4.1.0",
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"read-pkg-up": "2.0.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "7.0.0"
 					}
 				},
 				"yargs-parser": {
@@ -6184,7 +6184,7 @@
 					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
 					"dev": true,
 					"requires": {
-						"camelcase": "^4.1.0"
+						"camelcase": "4.1.0"
 					}
 				}
 			}
@@ -6201,8 +6201,8 @@
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2"
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
 			}
 		},
 		"load-json-file": {
@@ -6211,11 +6211,11 @@
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"parse-json": "^2.2.0",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0",
-				"strip-bom": "^2.0.0"
+				"graceful-fs": "4.1.11",
+				"parse-json": "2.2.0",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"strip-bom": "2.0.0"
 			}
 		},
 		"locate-path": {
@@ -6224,8 +6224,8 @@
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"dev": true,
 			"requires": {
-				"p-locate": "^2.0.0",
-				"path-exists": "^3.0.0"
+				"p-locate": "2.0.0",
+				"path-exists": "3.0.0"
 			}
 		},
 		"lodash": {
@@ -6252,8 +6252,8 @@
 			"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
 			"dev": true,
 			"requires": {
-				"lodash._reinterpolate": "~3.0.0",
-				"lodash.templatesettings": "^4.0.0"
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.templatesettings": "4.1.0"
 			}
 		},
 		"lodash.templatesettings": {
@@ -6262,7 +6262,7 @@
 			"integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
 			"dev": true,
 			"requires": {
-				"lodash._reinterpolate": "~3.0.0"
+				"lodash._reinterpolate": "3.0.0"
 			}
 		},
 		"longest": {
@@ -6277,7 +6277,7 @@
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
 			"dev": true,
 			"requires": {
-				"js-tokens": "^3.0.0"
+				"js-tokens": "3.0.2"
 			}
 		},
 		"loud-rejection": {
@@ -6286,8 +6286,8 @@
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
 			"dev": true,
 			"requires": {
-				"currently-unhandled": "^0.4.1",
-				"signal-exit": "^3.0.0"
+				"currently-unhandled": "0.4.1",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"lowercase-keys": {
@@ -6302,8 +6302,8 @@
 			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 			"dev": true,
 			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"pseudomap": "1.0.2",
+				"yallist": "2.1.2"
 			}
 		},
 		"make-dir": {
@@ -6312,7 +6312,7 @@
 			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
 			"dev": true,
 			"requires": {
-				"pify": "^3.0.0"
+				"pify": "3.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -6329,7 +6329,7 @@
 			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
 			"dev": true,
 			"requires": {
-				"tmpl": "1.0.x"
+				"tmpl": "1.0.4"
 			}
 		},
 		"map-cache": {
@@ -6350,7 +6350,7 @@
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
 			"dev": true,
 			"requires": {
-				"object-visit": "^1.0.0"
+				"object-visit": "1.0.1"
 			}
 		},
 		"math-random": {
@@ -6365,7 +6365,7 @@
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"mimic-fn": "1.2.0"
 			}
 		},
 		"meow": {
@@ -6374,15 +6374,15 @@
 			"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
 			"dev": true,
 			"requires": {
-				"camelcase-keys": "^4.0.0",
-				"decamelize-keys": "^1.0.0",
-				"loud-rejection": "^1.0.0",
-				"minimist": "^1.1.3",
-				"minimist-options": "^3.0.1",
-				"normalize-package-data": "^2.3.4",
-				"read-pkg-up": "^3.0.0",
-				"redent": "^2.0.0",
-				"trim-newlines": "^2.0.0"
+				"camelcase-keys": "4.2.0",
+				"decamelize-keys": "1.1.0",
+				"loud-rejection": "1.6.0",
+				"minimist": "1.2.0",
+				"minimist-options": "3.0.2",
+				"normalize-package-data": "2.4.0",
+				"read-pkg-up": "3.0.0",
+				"redent": "2.0.0",
+				"trim-newlines": "2.0.0"
 			},
 			"dependencies": {
 				"load-json-file": {
@@ -6391,10 +6391,10 @@
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^4.0.0",
-						"pify": "^3.0.0",
-						"strip-bom": "^3.0.0"
+						"graceful-fs": "4.1.11",
+						"parse-json": "4.0.0",
+						"pify": "3.0.0",
+						"strip-bom": "3.0.0"
 					}
 				},
 				"minimist": {
@@ -6409,8 +6409,8 @@
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"dev": true,
 					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
+						"error-ex": "1.3.1",
+						"json-parse-better-errors": "1.0.2"
 					}
 				},
 				"path-type": {
@@ -6419,7 +6419,7 @@
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"dev": true,
 					"requires": {
-						"pify": "^3.0.0"
+						"pify": "3.0.0"
 					}
 				},
 				"pify": {
@@ -6434,9 +6434,9 @@
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "^4.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^3.0.0"
+						"load-json-file": "4.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "3.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -6445,8 +6445,8 @@
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 					"dev": true,
 					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^3.0.0"
+						"find-up": "2.1.0",
+						"read-pkg": "3.0.0"
 					}
 				},
 				"strip-bom": {
@@ -6469,7 +6469,7 @@
 			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.0.1"
+				"readable-stream": "2.3.6"
 			}
 		},
 		"micromatch": {
@@ -6478,19 +6478,19 @@
 			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 			"dev": true,
 			"requires": {
-				"arr-diff": "^4.0.0",
-				"array-unique": "^0.3.2",
-				"braces": "^2.3.1",
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"extglob": "^2.0.4",
-				"fragment-cache": "^0.2.1",
-				"kind-of": "^6.0.2",
-				"nanomatch": "^1.2.9",
-				"object.pick": "^1.3.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.2"
+				"arr-diff": "4.0.0",
+				"array-unique": "0.3.2",
+				"braces": "2.3.2",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"extglob": "2.0.4",
+				"fragment-cache": "0.2.1",
+				"kind-of": "6.0.2",
+				"nanomatch": "1.2.9",
+				"object.pick": "1.3.0",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			}
 		},
 		"mime-db": {
@@ -6505,7 +6505,7 @@
 			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 			"dev": true,
 			"requires": {
-				"mime-db": "~1.33.0"
+				"mime-db": "1.33.0"
 			}
 		},
 		"mimic-fn": {
@@ -6520,7 +6520,7 @@
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "1.1.11"
 			}
 		},
 		"minimist": {
@@ -6535,8 +6535,8 @@
 			"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
 			"dev": true,
 			"requires": {
-				"arrify": "^1.0.1",
-				"is-plain-obj": "^1.1.0"
+				"arrify": "1.0.1",
+				"is-plain-obj": "1.1.0"
 			}
 		},
 		"mixin-deep": {
@@ -6545,8 +6545,8 @@
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
 			"dev": true,
 			"requires": {
-				"for-in": "^1.0.2",
-				"is-extendable": "^1.0.1"
+				"for-in": "1.0.2",
+				"is-extendable": "1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -6555,7 +6555,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				}
 			}
@@ -6606,18 +6606,18 @@
 			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
 			"dev": true,
 			"requires": {
-				"arr-diff": "^4.0.0",
-				"array-unique": "^0.3.2",
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"fragment-cache": "^0.2.1",
-				"is-odd": "^2.0.0",
-				"is-windows": "^1.0.2",
-				"kind-of": "^6.0.2",
-				"object.pick": "^1.3.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"arr-diff": "4.0.0",
+				"array-unique": "0.3.2",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"fragment-cache": "0.2.1",
+				"is-odd": "2.0.0",
+				"is-windows": "1.0.2",
+				"kind-of": "6.0.2",
+				"object.pick": "1.3.0",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			}
 		},
 		"natural-compare": {
@@ -6638,10 +6638,10 @@
 			"integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
 			"dev": true,
 			"requires": {
-				"growly": "^1.3.0",
-				"semver": "^5.4.1",
-				"shellwords": "^0.1.1",
-				"which": "^1.3.0"
+				"growly": "1.3.0",
+				"semver": "5.5.0",
+				"shellwords": "0.1.1",
+				"which": "1.3.0"
 			}
 		},
 		"normalize-package-data": {
@@ -6650,10 +6650,10 @@
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "^2.1.4",
-				"is-builtin-module": "^1.0.0",
-				"semver": "2 || 3 || 4 || 5",
-				"validate-npm-package-license": "^3.0.1"
+				"hosted-git-info": "2.6.0",
+				"is-builtin-module": "1.0.0",
+				"semver": "5.5.0",
+				"validate-npm-package-license": "3.0.3"
 			}
 		},
 		"npm-run-path": {
@@ -6662,7 +6662,7 @@
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"dev": true,
 			"requires": {
-				"path-key": "^2.0.0"
+				"path-key": "2.0.1"
 			}
 		},
 		"npmlog": {
@@ -6671,10 +6671,10 @@
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 			"dev": true,
 			"requires": {
-				"are-we-there-yet": "~1.1.2",
-				"console-control-strings": "~1.1.0",
-				"gauge": "~2.7.3",
-				"set-blocking": "~2.0.0"
+				"are-we-there-yet": "1.1.4",
+				"console-control-strings": "1.1.0",
+				"gauge": "2.7.4",
+				"set-blocking": "2.0.0"
 			}
 		},
 		"number-is-nan": {
@@ -6707,9 +6707,9 @@
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
 			"dev": true,
 			"requires": {
-				"copy-descriptor": "^0.1.0",
-				"define-property": "^0.2.5",
-				"kind-of": "^3.0.3"
+				"copy-descriptor": "0.1.1",
+				"define-property": "0.2.5",
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -6718,7 +6718,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"kind-of": {
@@ -6727,7 +6727,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -6744,7 +6744,7 @@
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.0"
+				"isobject": "3.0.1"
 			}
 		},
 		"object.getownpropertydescriptors": {
@@ -6753,8 +6753,8 @@
 			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.5.1"
+				"define-properties": "1.1.2",
+				"es-abstract": "1.11.0"
 			}
 		},
 		"object.omit": {
@@ -6763,8 +6763,8 @@
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"dev": true,
 			"requires": {
-				"for-own": "^0.1.4",
-				"is-extendable": "^0.1.1"
+				"for-own": "0.1.5",
+				"is-extendable": "0.1.1"
 			}
 		},
 		"object.pick": {
@@ -6773,7 +6773,7 @@
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.1"
+				"isobject": "3.0.1"
 			}
 		},
 		"once": {
@@ -6782,7 +6782,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1"
+				"wrappy": "1.0.2"
 			}
 		},
 		"onetime": {
@@ -6791,7 +6791,7 @@
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"mimic-fn": "1.2.0"
 			}
 		},
 		"optimist": {
@@ -6800,8 +6800,8 @@
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 			"dev": true,
 			"requires": {
-				"minimist": "~0.0.1",
-				"wordwrap": "~0.0.2"
+				"minimist": "0.0.8",
+				"wordwrap": "0.0.3"
 			},
 			"dependencies": {
 				"wordwrap": {
@@ -6818,12 +6818,12 @@
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"dev": true,
 			"requires": {
-				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.4",
-				"levn": "~0.3.0",
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2",
-				"wordwrap": "~1.0.0"
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
 			}
 		},
 		"os-homedir": {
@@ -6838,9 +6838,9 @@
 			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 			"dev": true,
 			"requires": {
-				"execa": "^0.7.0",
-				"lcid": "^1.0.0",
-				"mem": "^1.1.0"
+				"execa": "0.7.0",
+				"lcid": "1.0.0",
+				"mem": "1.1.0"
 			}
 		},
 		"os-tmpdir": {
@@ -6861,7 +6861,7 @@
 			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
 			"dev": true,
 			"requires": {
-				"p-try": "^1.0.0"
+				"p-try": "1.0.0"
 			}
 		},
 		"p-locate": {
@@ -6870,7 +6870,7 @@
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"dev": true,
 			"requires": {
-				"p-limit": "^1.1.0"
+				"p-limit": "1.2.0"
 			}
 		},
 		"p-try": {
@@ -6885,10 +6885,10 @@
 			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
 			"dev": true,
 			"requires": {
-				"got": "^6.7.1",
-				"registry-auth-token": "^3.0.1",
-				"registry-url": "^3.0.3",
-				"semver": "^5.1.0"
+				"got": "6.7.1",
+				"registry-auth-token": "3.3.2",
+				"registry-url": "3.1.0",
+				"semver": "5.5.0"
 			}
 		},
 		"parse-github-repo-url": {
@@ -6903,10 +6903,10 @@
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"dev": true,
 			"requires": {
-				"glob-base": "^0.3.0",
-				"is-dotfile": "^1.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.0"
+				"glob-base": "0.3.0",
+				"is-dotfile": "1.0.3",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1"
 			}
 		},
 		"parse-json": {
@@ -6915,7 +6915,7 @@
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 			"dev": true,
 			"requires": {
-				"error-ex": "^1.2.0"
+				"error-ex": "1.3.1"
 			}
 		},
 		"parse5": {
@@ -6972,9 +6972,9 @@
 			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
+				"graceful-fs": "4.1.11",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
 			}
 		},
 		"performance-now": {
@@ -7001,7 +7001,7 @@
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"dev": true,
 			"requires": {
-				"pinkie": "^2.0.0"
+				"pinkie": "2.0.4"
 			}
 		},
 		"pkg-dir": {
@@ -7010,7 +7010,7 @@
 			"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
 			"dev": true,
 			"requires": {
-				"find-up": "^1.0.0"
+				"find-up": "1.1.2"
 			},
 			"dependencies": {
 				"find-up": {
@@ -7019,8 +7019,8 @@
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"dev": true,
 					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"path-exists": {
@@ -7029,7 +7029,7 @@
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "^2.0.0"
+						"pinkie-promise": "2.0.1"
 					}
 				}
 			}
@@ -7076,8 +7076,8 @@
 			"integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^3.0.0",
-				"ansi-styles": "^3.2.0"
+				"ansi-regex": "3.0.0",
+				"ansi-styles": "3.2.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -7092,7 +7092,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				}
 			}
@@ -7157,9 +7157,9 @@
 			"integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
 			"dev": true,
 			"requires": {
-				"is-number": "^4.0.0",
-				"kind-of": "^6.0.0",
-				"math-random": "^1.0.1"
+				"is-number": "4.0.0",
+				"kind-of": "6.0.2",
+				"math-random": "1.0.1"
 			},
 			"dependencies": {
 				"is-number": {
@@ -7176,10 +7176,10 @@
 			"integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
 			"dev": true,
 			"requires": {
-				"deep-extend": "^0.5.1",
-				"ini": "~1.3.0",
-				"minimist": "^1.2.0",
-				"strip-json-comments": "~2.0.1"
+				"deep-extend": "0.5.1",
+				"ini": "1.3.5",
+				"minimist": "1.2.0",
+				"strip-json-comments": "2.0.1"
 			},
 			"dependencies": {
 				"minimist": {
@@ -7196,7 +7196,7 @@
 			"integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2"
+				"graceful-fs": "4.1.11"
 			}
 		},
 		"read-pkg": {
@@ -7205,9 +7205,9 @@
 			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "^1.0.0",
-				"normalize-package-data": "^2.3.2",
-				"path-type": "^1.0.0"
+				"load-json-file": "1.1.0",
+				"normalize-package-data": "2.4.0",
+				"path-type": "1.1.0"
 			}
 		},
 		"read-pkg-up": {
@@ -7216,8 +7216,8 @@
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 			"dev": true,
 			"requires": {
-				"find-up": "^1.0.0",
-				"read-pkg": "^1.0.0"
+				"find-up": "1.1.2",
+				"read-pkg": "1.1.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -7226,8 +7226,8 @@
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"dev": true,
 					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"path-exists": {
@@ -7236,7 +7236,7 @@
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "^2.0.0"
+						"pinkie-promise": "2.0.1"
 					}
 				}
 			}
@@ -7247,13 +7247,13 @@
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"dev": true,
 			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "1.0.0",
+				"process-nextick-args": "2.0.0",
+				"safe-buffer": "5.1.2",
+				"string_decoder": "1.1.1",
+				"util-deprecate": "1.0.2"
 			}
 		},
 		"realpath-native": {
@@ -7262,7 +7262,7 @@
 			"integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
 			"dev": true,
 			"requires": {
-				"util.promisify": "^1.0.0"
+				"util.promisify": "1.0.0"
 			}
 		},
 		"redent": {
@@ -7271,8 +7271,8 @@
 			"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
 			"dev": true,
 			"requires": {
-				"indent-string": "^3.0.0",
-				"strip-indent": "^2.0.0"
+				"indent-string": "3.2.0",
+				"strip-indent": "2.0.0"
 			}
 		},
 		"regenerate": {
@@ -7293,9 +7293,9 @@
 			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.18.0",
-				"babel-types": "^6.19.0",
-				"private": "^0.1.6"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"private": "0.1.8"
 			}
 		},
 		"regex-cache": {
@@ -7304,7 +7304,7 @@
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 			"dev": true,
 			"requires": {
-				"is-equal-shallow": "^0.1.3"
+				"is-equal-shallow": "0.1.3"
 			}
 		},
 		"regex-not": {
@@ -7313,8 +7313,8 @@
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^3.0.2",
-				"safe-regex": "^1.1.0"
+				"extend-shallow": "3.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"regexpp": {
@@ -7329,9 +7329,9 @@
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
 			"dev": true,
 			"requires": {
-				"regenerate": "^1.2.1",
-				"regjsgen": "^0.2.0",
-				"regjsparser": "^0.1.4"
+				"regenerate": "1.4.0",
+				"regjsgen": "0.2.0",
+				"regjsparser": "0.1.5"
 			}
 		},
 		"registry-auth-token": {
@@ -7340,8 +7340,8 @@
 			"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
 			"dev": true,
 			"requires": {
-				"rc": "^1.1.6",
-				"safe-buffer": "^5.0.1"
+				"rc": "1.2.7",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"registry-url": {
@@ -7350,7 +7350,7 @@
 			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
 			"dev": true,
 			"requires": {
-				"rc": "^1.0.1"
+				"rc": "1.2.7"
 			}
 		},
 		"regjsgen": {
@@ -7365,7 +7365,7 @@
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
 			"dev": true,
 			"requires": {
-				"jsesc": "~0.5.0"
+				"jsesc": "0.5.0"
 			},
 			"dependencies": {
 				"jsesc": {
@@ -7400,7 +7400,7 @@
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"dev": true,
 			"requires": {
-				"is-finite": "^1.0.0"
+				"is-finite": "1.0.2"
 			}
 		},
 		"request": {
@@ -7409,28 +7409,28 @@
 			"integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
 			"dev": true,
 			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.6.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.5",
-				"extend": "~3.0.1",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.1",
-				"har-validator": "~5.0.3",
-				"hawk": "~6.0.2",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.17",
-				"oauth-sign": "~0.8.2",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.1",
-				"safe-buffer": "^5.1.1",
-				"stringstream": "~0.0.5",
-				"tough-cookie": "~2.3.3",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.1.0"
+				"aws-sign2": "0.7.0",
+				"aws4": "1.7.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.6",
+				"extend": "3.0.1",
+				"forever-agent": "0.6.1",
+				"form-data": "2.3.2",
+				"har-validator": "5.0.3",
+				"hawk": "6.0.2",
+				"http-signature": "1.2.0",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.18",
+				"oauth-sign": "0.8.2",
+				"performance-now": "2.1.0",
+				"qs": "6.5.2",
+				"safe-buffer": "5.1.2",
+				"stringstream": "0.0.5",
+				"tough-cookie": "2.3.4",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.1.0"
 			}
 		},
 		"request-promise-core": {
@@ -7439,7 +7439,7 @@
 			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.13.1"
+				"lodash": "4.17.10"
 			}
 		},
 		"request-promise-native": {
@@ -7449,8 +7449,8 @@
 			"dev": true,
 			"requires": {
 				"request-promise-core": "1.1.1",
-				"stealthy-require": "^1.1.0",
-				"tough-cookie": ">=2.3.3"
+				"stealthy-require": "1.1.1",
+				"tough-cookie": "2.3.4"
 			}
 		},
 		"require-directory": {
@@ -7471,8 +7471,8 @@
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
 			"dev": true,
 			"requires": {
-				"caller-path": "^0.1.0",
-				"resolve-from": "^1.0.0"
+				"caller-path": "0.1.0",
+				"resolve-from": "1.0.1"
 			}
 		},
 		"resolve": {
@@ -7481,7 +7481,7 @@
 			"integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
 			"dev": true,
 			"requires": {
-				"path-parse": "^1.0.5"
+				"path-parse": "1.0.5"
 			}
 		},
 		"resolve-cwd": {
@@ -7490,7 +7490,7 @@
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 			"dev": true,
 			"requires": {
-				"resolve-from": "^3.0.0"
+				"resolve-from": "3.0.0"
 			},
 			"dependencies": {
 				"resolve-from": {
@@ -7519,8 +7519,8 @@
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 			"dev": true,
 			"requires": {
-				"onetime": "^2.0.0",
-				"signal-exit": "^3.0.2"
+				"onetime": "2.0.1",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"ret": {
@@ -7536,7 +7536,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"align-text": "^0.1.1"
+				"align-text": "0.1.4"
 			}
 		},
 		"rimraf": {
@@ -7545,7 +7545,7 @@
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.5"
+				"glob": "7.1.2"
 			}
 		},
 		"rsvp": {
@@ -7560,7 +7560,7 @@
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 			"dev": true,
 			"requires": {
-				"is-promise": "^2.1.0"
+				"is-promise": "2.1.0"
 			}
 		},
 		"rx-lite": {
@@ -7575,7 +7575,7 @@
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
 			"dev": true,
 			"requires": {
-				"rx-lite": "*"
+				"rx-lite": "4.0.8"
 			}
 		},
 		"safe-buffer": {
@@ -7590,7 +7590,7 @@
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"dev": true,
 			"requires": {
-				"ret": "~0.1.10"
+				"ret": "0.1.15"
 			}
 		},
 		"safer-buffer": {
@@ -7605,15 +7605,15 @@
 			"integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
 			"dev": true,
 			"requires": {
-				"anymatch": "^2.0.0",
-				"capture-exit": "^1.2.0",
-				"exec-sh": "^0.2.0",
-				"fb-watchman": "^2.0.0",
-				"fsevents": "^1.2.3",
-				"micromatch": "^3.1.4",
-				"minimist": "^1.1.1",
-				"walker": "~1.0.5",
-				"watch": "~0.18.0"
+				"anymatch": "2.0.0",
+				"capture-exit": "1.2.0",
+				"exec-sh": "0.2.1",
+				"fb-watchman": "2.0.0",
+				"fsevents": "1.2.3",
+				"micromatch": "3.1.10",
+				"minimist": "1.2.0",
+				"walker": "1.0.7",
+				"watch": "0.18.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -7648,10 +7648,10 @@
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^2.0.1",
-				"is-extendable": "^0.1.1",
-				"is-plain-object": "^2.0.3",
-				"split-string": "^3.0.1"
+				"extend-shallow": "2.0.1",
+				"is-extendable": "0.1.1",
+				"is-plain-object": "2.0.4",
+				"split-string": "3.1.0"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -7660,7 +7660,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -7671,7 +7671,7 @@
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"dev": true,
 			"requires": {
-				"shebang-regex": "^1.0.0"
+				"shebang-regex": "1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -7704,7 +7704,7 @@
 			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "^2.0.0"
+				"is-fullwidth-code-point": "2.0.0"
 			}
 		},
 		"snapdragon": {
@@ -7713,14 +7713,14 @@
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"dev": true,
 			"requires": {
-				"base": "^0.11.1",
-				"debug": "^2.2.0",
-				"define-property": "^0.2.5",
-				"extend-shallow": "^2.0.1",
-				"map-cache": "^0.2.2",
-				"source-map": "^0.5.6",
-				"source-map-resolve": "^0.5.0",
-				"use": "^3.1.0"
+				"base": "0.11.2",
+				"debug": "2.6.9",
+				"define-property": "0.2.5",
+				"extend-shallow": "2.0.1",
+				"map-cache": "0.2.2",
+				"source-map": "0.5.7",
+				"source-map-resolve": "0.5.2",
+				"use": "3.1.0"
 			},
 			"dependencies": {
 				"define-property": {
@@ -7729,7 +7729,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"extend-shallow": {
@@ -7738,7 +7738,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -7749,9 +7749,9 @@
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
 			"dev": true,
 			"requires": {
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.0",
-				"snapdragon-util": "^3.0.1"
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"snapdragon-util": "3.0.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -7760,7 +7760,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -7769,7 +7769,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -7778,7 +7778,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -7787,9 +7787,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				}
 			}
@@ -7800,7 +7800,7 @@
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.2.0"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -7809,7 +7809,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -7820,7 +7820,7 @@
 			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
 			"dev": true,
 			"requires": {
-				"hoek": "4.x.x"
+				"hoek": "4.2.1"
 			}
 		},
 		"sort-keys": {
@@ -7829,7 +7829,7 @@
 			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
 			"dev": true,
 			"requires": {
-				"is-plain-obj": "^1.0.0"
+				"is-plain-obj": "1.1.0"
 			}
 		},
 		"source-map": {
@@ -7844,11 +7844,11 @@
 			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
 			"dev": true,
 			"requires": {
-				"atob": "^2.1.1",
-				"decode-uri-component": "^0.2.0",
-				"resolve-url": "^0.2.1",
-				"source-map-url": "^0.4.0",
-				"urix": "^0.1.0"
+				"atob": "2.1.1",
+				"decode-uri-component": "0.2.0",
+				"resolve-url": "0.2.1",
+				"source-map-url": "0.4.0",
+				"urix": "0.1.0"
 			}
 		},
 		"source-map-support": {
@@ -7857,8 +7857,8 @@
 			"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
 			"dev": true,
 			"requires": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
+				"buffer-from": "1.0.0",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -7881,8 +7881,8 @@
 			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
 			"dev": true,
 			"requires": {
-				"spdx-expression-parse": "^3.0.0",
-				"spdx-license-ids": "^3.0.0"
+				"spdx-expression-parse": "3.0.0",
+				"spdx-license-ids": "3.0.0"
 			}
 		},
 		"spdx-exceptions": {
@@ -7897,8 +7897,8 @@
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 			"dev": true,
 			"requires": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
+				"spdx-exceptions": "2.1.0",
+				"spdx-license-ids": "3.0.0"
 			}
 		},
 		"spdx-license-ids": {
@@ -7913,7 +7913,7 @@
 			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
 			"dev": true,
 			"requires": {
-				"through": "2"
+				"through": "2.3.8"
 			}
 		},
 		"split-string": {
@@ -7922,7 +7922,7 @@
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^3.0.0"
+				"extend-shallow": "3.0.2"
 			}
 		},
 		"split2": {
@@ -7931,7 +7931,7 @@
 			"integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
 			"dev": true,
 			"requires": {
-				"through2": "^2.0.2"
+				"through2": "2.0.3"
 			}
 		},
 		"sprintf-js": {
@@ -7946,14 +7946,14 @@
 			"integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
 			"dev": true,
 			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"tweetnacl": "~0.14.0"
+				"asn1": "0.2.3",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.1",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.1",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"tweetnacl": "0.14.5"
 			}
 		},
 		"stack-utils": {
@@ -7968,8 +7968,8 @@
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
 			"dev": true,
 			"requires": {
-				"define-property": "^0.2.5",
-				"object-copy": "^0.1.0"
+				"define-property": "0.2.5",
+				"object-copy": "0.1.0"
 			},
 			"dependencies": {
 				"define-property": {
@@ -7978,7 +7978,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				}
 			}
@@ -7995,8 +7995,8 @@
 			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
 			"dev": true,
 			"requires": {
-				"astral-regex": "^1.0.0",
-				"strip-ansi": "^4.0.0"
+				"astral-regex": "1.0.0",
+				"strip-ansi": "4.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -8011,7 +8011,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				}
 			}
@@ -8022,8 +8022,8 @@
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
+				"is-fullwidth-code-point": "2.0.0",
+				"strip-ansi": "4.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -8038,7 +8038,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				}
 			}
@@ -8049,7 +8049,7 @@
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "~5.1.0"
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"stringstream": {
@@ -8064,7 +8064,7 @@
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "2.1.1"
 			}
 		},
 		"strip-bom": {
@@ -8073,7 +8073,7 @@
 			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 			"dev": true,
 			"requires": {
-				"is-utf8": "^0.2.0"
+				"is-utf8": "0.2.1"
 			}
 		},
 		"strip-eof": {
@@ -8100,11 +8100,11 @@
 			"integrity": "sha1-9/uTdYpppXEUAYEnfuoMLrEwH6M=",
 			"dev": true,
 			"requires": {
-				"byline": "^5.0.0",
-				"duplexer": "^0.1.1",
-				"minimist": "^0.1.0",
-				"moment": "^2.6.0",
-				"through": "^2.3.4"
+				"byline": "5.0.0",
+				"duplexer": "0.1.1",
+				"minimist": "0.1.0",
+				"moment": "2.22.1",
+				"through": "2.3.8"
 			},
 			"dependencies": {
 				"minimist": {
@@ -8133,12 +8133,12 @@
 			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.2.3",
-				"ajv-keywords": "^2.1.0",
-				"chalk": "^2.1.0",
-				"lodash": "^4.17.4",
+				"ajv": "5.5.2",
+				"ajv-keywords": "2.1.1",
+				"chalk": "2.4.1",
+				"lodash": "4.17.10",
 				"slice-ansi": "1.0.0",
-				"string-width": "^2.1.1"
+				"string-width": "2.1.1"
 			},
 			"dependencies": {
 				"ajv": {
@@ -8147,10 +8147,10 @@
 					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 					"dev": true,
 					"requires": {
-						"co": "^4.6.0",
-						"fast-deep-equal": "^1.0.0",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.3.0"
+						"co": "4.6.0",
+						"fast-deep-equal": "1.1.0",
+						"fast-json-stable-stringify": "2.0.0",
+						"json-schema-traverse": "0.3.1"
 					}
 				},
 				"ajv-keywords": {
@@ -8165,7 +8165,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -8174,9 +8174,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"fast-deep-equal": {
@@ -8191,7 +8191,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -8208,12 +8208,12 @@
 			"integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"is-stream": "^1.1.0",
-				"make-dir": "^1.0.0",
-				"pify": "^3.0.0",
-				"temp-dir": "^1.0.0",
-				"uuid": "^3.0.1"
+				"graceful-fs": "4.1.11",
+				"is-stream": "1.1.0",
+				"make-dir": "1.3.0",
+				"pify": "3.0.0",
+				"temp-dir": "1.0.0",
+				"uuid": "3.1.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -8230,8 +8230,8 @@
 			"integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
 			"dev": true,
 			"requires": {
-				"os-tmpdir": "^1.0.0",
-				"uuid": "^2.0.1"
+				"os-tmpdir": "1.0.2",
+				"uuid": "2.0.3"
 			},
 			"dependencies": {
 				"uuid": {
@@ -8248,11 +8248,11 @@
 			"integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
 			"dev": true,
 			"requires": {
-				"arrify": "^1.0.1",
-				"micromatch": "^3.1.8",
-				"object-assign": "^4.1.0",
-				"read-pkg-up": "^1.0.1",
-				"require-main-filename": "^1.0.1"
+				"arrify": "1.0.1",
+				"micromatch": "3.1.10",
+				"object-assign": "4.1.1",
+				"read-pkg-up": "1.0.1",
+				"require-main-filename": "1.0.1"
 			}
 		},
 		"text-extensions": {
@@ -8285,8 +8285,8 @@
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.1.5",
-				"xtend": "~4.0.1"
+				"readable-stream": "2.3.6",
+				"xtend": "4.0.1"
 			}
 		},
 		"timed-out": {
@@ -8301,7 +8301,7 @@
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 			"dev": true,
 			"requires": {
-				"os-tmpdir": "~1.0.2"
+				"os-tmpdir": "1.0.2"
 			}
 		},
 		"tmpl": {
@@ -8322,7 +8322,7 @@
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -8331,7 +8331,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -8342,10 +8342,10 @@
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 			"dev": true,
 			"requires": {
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"regex-not": "^1.0.2",
-				"safe-regex": "^1.1.0"
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"regex-not": "1.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"to-regex-range": {
@@ -8354,8 +8354,8 @@
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 			"dev": true,
 			"requires": {
-				"is-number": "^3.0.0",
-				"repeat-string": "^1.6.1"
+				"is-number": "3.0.0",
+				"repeat-string": "1.6.1"
 			}
 		},
 		"tough-cookie": {
@@ -8364,7 +8364,7 @@
 			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
 			"dev": true,
 			"requires": {
-				"punycode": "^1.4.1"
+				"punycode": "1.4.1"
 			},
 			"dependencies": {
 				"punycode": {
@@ -8381,7 +8381,7 @@
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
 			"dev": true,
 			"requires": {
-				"punycode": "^2.1.0"
+				"punycode": "2.1.0"
 			}
 		},
 		"trim-newlines": {
@@ -8408,7 +8408,7 @@
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "^5.0.1"
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"tweetnacl": {
@@ -8424,7 +8424,7 @@
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2"
+				"prelude-ls": "1.1.2"
 			}
 		},
 		"typedarray": {
@@ -8445,7 +8445,7 @@
 			"integrity": "sha512-KvsNMCKtPK87zn6xAVM+EAYBKt8UqfaajdtZv6GylHtmdfhjC4vRXXqfxO46lFeOgm7dfc8carJDjdd0wunNBw==",
 			"dev": true,
 			"requires": {
-				"commander": "^2.12.2"
+				"commander": "2.15.1"
 			}
 		},
 		"uglify-js": {
@@ -8455,9 +8455,9 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"source-map": "~0.5.1",
-				"uglify-to-browserify": "~1.0.0",
-				"yargs": "~3.10.0"
+				"source-map": "0.5.7",
+				"uglify-to-browserify": "1.0.2",
+				"yargs": "3.10.0"
 			},
 			"dependencies": {
 				"yargs": {
@@ -8467,9 +8467,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"camelcase": "^1.0.2",
-						"cliui": "^2.1.0",
-						"decamelize": "^1.0.0",
+						"camelcase": "1.2.1",
+						"cliui": "2.1.0",
+						"decamelize": "1.2.0",
 						"window-size": "0.1.0"
 					}
 				}
@@ -8488,10 +8488,10 @@
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
 			"dev": true,
 			"requires": {
-				"arr-union": "^3.1.0",
-				"get-value": "^2.0.6",
-				"is-extendable": "^0.1.1",
-				"set-value": "^0.4.3"
+				"arr-union": "3.1.0",
+				"get-value": "2.0.6",
+				"is-extendable": "0.1.1",
+				"set-value": "0.4.3"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -8500,7 +8500,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				},
 				"set-value": {
@@ -8509,10 +8509,10 @@
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.1",
-						"to-object-path": "^0.3.0"
+						"extend-shallow": "2.0.1",
+						"is-extendable": "0.1.1",
+						"is-plain-object": "2.0.4",
+						"to-object-path": "0.3.0"
 					}
 				}
 			}
@@ -8529,8 +8529,8 @@
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 			"dev": true,
 			"requires": {
-				"has-value": "^0.3.1",
-				"isobject": "^3.0.0"
+				"has-value": "0.3.1",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"has-value": {
@@ -8539,9 +8539,9 @@
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
 					"dev": true,
 					"requires": {
-						"get-value": "^2.0.3",
-						"has-values": "^0.1.4",
-						"isobject": "^2.0.0"
+						"get-value": "2.0.6",
+						"has-values": "0.1.4",
+						"isobject": "2.1.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -8599,7 +8599,7 @@
 			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
 			"dev": true,
 			"requires": {
-				"prepend-http": "^1.0.1"
+				"prepend-http": "1.0.4"
 			}
 		},
 		"use": {
@@ -8608,7 +8608,7 @@
 			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
 			"dev": true,
 			"requires": {
-				"kind-of": "^6.0.2"
+				"kind-of": "6.0.2"
 			}
 		},
 		"util-deprecate": {
@@ -8623,8 +8623,8 @@
 			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"object.getownpropertydescriptors": "^2.0.3"
+				"define-properties": "1.1.2",
+				"object.getownpropertydescriptors": "2.0.3"
 			}
 		},
 		"uuid": {
@@ -8639,8 +8639,8 @@
 			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
 			"dev": true,
 			"requires": {
-				"spdx-correct": "^3.0.0",
-				"spdx-expression-parse": "^3.0.0"
+				"spdx-correct": "3.0.0",
+				"spdx-expression-parse": "3.0.0"
 			}
 		},
 		"verror": {
@@ -8649,9 +8649,9 @@
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0",
+				"assert-plus": "1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
+				"extsprintf": "1.3.0"
 			}
 		},
 		"w3c-hr-time": {
@@ -8660,7 +8660,7 @@
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
 			"dev": true,
 			"requires": {
-				"browser-process-hrtime": "^0.1.2"
+				"browser-process-hrtime": "0.1.2"
 			}
 		},
 		"walker": {
@@ -8669,7 +8669,7 @@
 			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
 			"dev": true,
 			"requires": {
-				"makeerror": "1.0.x"
+				"makeerror": "1.0.11"
 			}
 		},
 		"watch": {
@@ -8678,8 +8678,8 @@
 			"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
 			"dev": true,
 			"requires": {
-				"exec-sh": "^0.2.0",
-				"minimist": "^1.2.0"
+				"exec-sh": "0.2.1",
+				"minimist": "1.2.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -8696,7 +8696,7 @@
 			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
 			"dev": true,
 			"requires": {
-				"defaults": "^1.0.3"
+				"defaults": "1.0.3"
 			}
 		},
 		"webidl-conversions": {
@@ -8734,9 +8734,9 @@
 			"integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
 			"dev": true,
 			"requires": {
-				"lodash.sortby": "^4.7.0",
-				"tr46": "^1.0.1",
-				"webidl-conversions": "^4.0.2"
+				"lodash.sortby": "4.7.0",
+				"tr46": "1.0.1",
+				"webidl-conversions": "4.0.2"
 			}
 		},
 		"which": {
@@ -8745,7 +8745,7 @@
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
 			"dev": true,
 			"requires": {
-				"isexe": "^2.0.0"
+				"isexe": "2.0.0"
 			}
 		},
 		"which-module": {
@@ -8760,7 +8760,7 @@
 			"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
 			"dev": true,
 			"requires": {
-				"string-width": "^1.0.2"
+				"string-width": "1.0.2"
 			},
 			"dependencies": {
 				"is-fullwidth-code-point": {
@@ -8769,7 +8769,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"string-width": {
@@ -8778,9 +8778,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				}
 			}
@@ -8804,8 +8804,8 @@
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1"
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1"
 			},
 			"dependencies": {
 				"is-fullwidth-code-point": {
@@ -8814,7 +8814,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"string-width": {
@@ -8823,9 +8823,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				}
 			}
@@ -8842,7 +8842,7 @@
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
 			"dev": true,
 			"requires": {
-				"mkdirp": "^0.5.1"
+				"mkdirp": "0.5.1"
 			}
 		},
 		"write-file-atomic": {
@@ -8851,9 +8851,9 @@
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.11",
-				"imurmurhash": "^0.1.4",
-				"signal-exit": "^3.0.2"
+				"graceful-fs": "4.1.11",
+				"imurmurhash": "0.1.4",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"write-json-file": {
@@ -8862,12 +8862,12 @@
 			"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
 			"dev": true,
 			"requires": {
-				"detect-indent": "^5.0.0",
-				"graceful-fs": "^4.1.2",
-				"make-dir": "^1.0.0",
-				"pify": "^3.0.0",
-				"sort-keys": "^2.0.0",
-				"write-file-atomic": "^2.0.0"
+				"detect-indent": "5.0.0",
+				"graceful-fs": "4.1.11",
+				"make-dir": "1.3.0",
+				"pify": "3.0.0",
+				"sort-keys": "2.0.0",
+				"write-file-atomic": "2.3.0"
 			},
 			"dependencies": {
 				"detect-indent": {
@@ -8890,8 +8890,8 @@
 			"integrity": "sha1-AwqZlMyZk9JbTnWp8aGSNgcpHOk=",
 			"dev": true,
 			"requires": {
-				"sort-keys": "^2.0.0",
-				"write-json-file": "^2.2.0"
+				"sort-keys": "2.0.0",
+				"write-json-file": "2.3.0"
 			}
 		},
 		"ws": {
@@ -8900,8 +8900,8 @@
 			"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
 			"dev": true,
 			"requires": {
-				"async-limiter": "~1.0.0",
-				"safe-buffer": "~5.1.0"
+				"async-limiter": "1.0.0",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"xml-name-validator": {
@@ -8916,8 +8916,8 @@
 			"integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
 			"dev": true,
 			"requires": {
-				"sax": ">=0.6.0",
-				"xmlbuilder": "^4.1.0"
+				"sax": "1.2.1",
+				"xmlbuilder": "4.2.1"
 			}
 		},
 		"xmlbuilder": {
@@ -8926,7 +8926,7 @@
 			"integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.0.0"
+				"lodash": "4.17.10"
 			}
 		},
 		"xtend": {
@@ -8953,18 +8953,18 @@
 			"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
 			"dev": true,
 			"requires": {
-				"cliui": "^4.0.0",
-				"decamelize": "^1.1.1",
-				"find-up": "^2.1.0",
-				"get-caller-file": "^1.0.1",
-				"os-locale": "^2.0.0",
-				"require-directory": "^2.1.1",
-				"require-main-filename": "^1.0.1",
-				"set-blocking": "^2.0.0",
-				"string-width": "^2.0.0",
-				"which-module": "^2.0.0",
-				"y18n": "^3.2.1",
-				"yargs-parser": "^8.1.0"
+				"cliui": "4.1.0",
+				"decamelize": "1.2.0",
+				"find-up": "2.1.0",
+				"get-caller-file": "1.0.2",
+				"os-locale": "2.1.0",
+				"require-directory": "2.1.1",
+				"require-main-filename": "1.0.1",
+				"set-blocking": "2.0.0",
+				"string-width": "2.1.1",
+				"which-module": "2.0.0",
+				"y18n": "3.2.1",
+				"yargs-parser": "8.1.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -8979,9 +8979,9 @@
 					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"dev": true,
 					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
+						"string-width": "2.1.1",
+						"strip-ansi": "4.0.0",
+						"wrap-ansi": "2.1.0"
 					}
 				},
 				"strip-ansi": {
@@ -8990,7 +8990,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				}
 			}
@@ -9001,7 +9001,7 @@
 			"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
 			"dev": true,
 			"requires": {
-				"camelcase": "^4.1.0"
+				"camelcase": "4.1.0"
 			},
 			"dependencies": {
 				"camelcase": {

--- a/packages/cors/__tests__/index.js
+++ b/packages/cors/__tests__/index.js
@@ -263,6 +263,34 @@ describe('📦 Middleware CORS', () => {
     })
   })
 
+  test('It should use change credentials as specified in options (true) with lowercase header', () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, {})
+    })
+
+    handler.use(
+      cors({
+        credentials: true
+      })
+    )
+
+    const event = {
+      httpMethod: 'GET',
+      headers: {
+        origin: 'http://example-lowercase.com'
+      }
+    }
+
+    handler(event, {}, (_, response) => {
+      expect(response).toEqual({
+        headers: {
+          'Access-Control-Allow-Credentials': 'true',
+          'Access-Control-Allow-Origin': 'http://example-lowercase.com'
+        }
+      })
+    })
+  })
+
   test('It should not change anything if HTTP method is not present in the request', () => {
     const handler = middy((event, context, cb) => {
       cb(null, {})

--- a/packages/cors/index.js
+++ b/packages/cors/index.js
@@ -7,8 +7,9 @@ const defaults = {
 const getOrigin = (options, handler) => {
   handler.event.headers = handler.event.headers || {}
 
-  if (options.credentials && options.origin === '*' && handler.event.headers.hasOwnProperty('Origin')) {
-    return handler.event.headers.Origin
+  const origin = handler.event.headers['origin'] || handler.event.headers['Origin']
+  if (options.credentials && options.origin === '*' && origin) {
+    return origin
   }
   return options.origin
 }

--- a/packages/http-content-negotiation/__tests__/index.js
+++ b/packages/http-content-negotiation/__tests__/index.js
@@ -34,6 +34,38 @@ describe('🤑  Middleware HTTP Content Negotiation', () => {
     })
   })
 
+  test('It should parse charset, encoding, language and media type with lowercase headers', (endTest) => {
+    const handler = middy((event, context, callback) => callback(null, event))
+    handler.use(httpContentNegotiation({
+      availableCharsets: ['utf-16'],
+      availableEncodings: undefined,
+      availableLanguages: ['en-gb'],
+      availableMediaTypes: ['text/plain', 'text/x-dvi']
+    }))
+
+    const event = {
+      headers: {
+        'accept-charset': 'utf-16, iso-8859-5, unicode-1-1;q=0.8',
+        'accept-encoding': '*/*',
+        'accept-language': 'da, en-gb;q=0.8, en;q=0.7',
+        'accept': 'text/plain; q=0.5, text/html, text/x-dvi; q=0.8, text/x-c'
+      }
+    }
+
+    handler(event, {}, (_, resultingEvent) => {
+      expect(resultingEvent.preferredCharsets).toEqual(['utf-16'])
+      expect(resultingEvent.preferredCharset).toEqual('utf-16')
+      expect(resultingEvent.preferredEncodings).toEqual(['*/*', 'identity'])
+      expect(resultingEvent.preferredEncoding).toEqual('*/*')
+      expect(resultingEvent.preferredLanguages).toEqual(['en-gb'])
+      expect(resultingEvent.preferredLanguage).toEqual('en-gb')
+      expect(resultingEvent.preferredMediaTypes).toEqual(['text/x-dvi', 'text/plain'])
+      expect(resultingEvent.preferredMediaType).toEqual('text/x-dvi')
+
+      endTest()
+    })
+  })
+
   test('It should skip the middleware if no headers are sent', (endTest) => {
     const handler = middy((event, context, callback) => callback(null, event))
     handler.use(httpContentNegotiation({

--- a/packages/http-content-negotiation/index.js
+++ b/packages/http-content-negotiation/index.js
@@ -21,7 +21,8 @@ module.exports = (opts) => {
     const plural = singular + 's'
     const resultsName = `preferred${plural}`
     const resultName = `preferred${singular}`
-    event[resultsName] = parseFn(event.headers[headerName], availableValues)
+    const headerValue = event.headers[headerName.toLowerCase()] || event.headers[headerName]
+    event[resultsName] = parseFn(headerValue, availableValues)
     event[resultName] = event[resultsName][0]
 
     if (typeof event[resultName] === 'undefined' && failOnMismatch) {

--- a/packages/http-header-normalizer/README.md
+++ b/packages/http-header-normalizer/README.md
@@ -53,6 +53,7 @@ npm install --save @middy/http-header-normalizer
 
  - `normalizeHeaderKey` (function) (optional): a function that accepts an header name as a parameter and returns its
   canonical representation.
+ - `camelCase` (bool) (optional): if true, modifies the headers to camelCase format, otherwise the headers are normalized to lowercase (default `false`)
 
 
 ## Sample usage

--- a/packages/http-header-normalizer/__tests__/index.js
+++ b/packages/http-header-normalizer/__tests__/index.js
@@ -2,11 +2,45 @@ const middy = require('../../core')
 const httpHeaderNormalizer = require('../')
 
 describe('👺 Middleware Http Header Normalizer', () => {
-  test('It should normalize all the headers and create a copy in rawHeaders', (endTest) => {
+  test('It should normalize (lowercase) all the headers and create a copy in rawHeaders', (endTest) => {
     const handler = middy((event, context, cb) => cb(null, event))
 
     handler
       .use(httpHeaderNormalizer())
+
+    const event = {
+      headers: {
+        'x-aPi-key': '123456',
+        'tcn': 'abc',
+        'te': 'cde',
+        'DNS': 'd',
+        'FOO': 'bar'
+      }
+    }
+
+    const expectedHeaders = {
+      'x-api-key': '123456',
+      'TCN': 'abc',
+      'TE': 'cde',
+      'dns': 'd',
+      'foo': 'bar'
+    }
+
+    const originalHeaders = Object.assign({}, event.headers)
+
+    // run the handler
+    handler(event, {}, (_, resultingEvent) => {
+      expect(resultingEvent.headers).toEqual(expectedHeaders)
+      expect(resultingEvent.rawHeaders).toEqual(originalHeaders)
+      endTest()
+    })
+  })
+
+  test('It should normalize (camelCase) all the headers and create a copy in rawHeaders', (endTest) => {
+    const handler = middy((event, context, cb) => cb(null, event))
+
+    handler
+      .use(httpHeaderNormalizer({camelCase: true}))
 
     const event = {
       headers: {

--- a/packages/http-header-normalizer/index.d.ts
+++ b/packages/http-header-normalizer/index.d.ts
@@ -2,6 +2,7 @@ import middy from '../core'
 
 interface IHTTPHeaderNormalizerOptions {
   normalizeHeaderKey?: (key: string) => string;
+  camelCase?: Boolean;
 }
 
 declare function httpHeaderNormalizer(opts?: IHTTPHeaderNormalizerOptions): middy.IMiddyMiddlewareObject;

--- a/packages/http-header-normalizer/index.js
+++ b/packages/http-header-normalizer/index.js
@@ -35,9 +35,13 @@ module.exports = (opts) => {
     return acc
   }, {})
 
-  const normalizeHeaderKey = (key) => {
+  const normalizeHeaderKey = (key, camelCase) => {
     if (exceptions[key.toLowerCase()]) {
       return exceptions[key.toLowerCase()]
+    }
+
+    if (!camelCase) {
+      return key.toLowerCase()
     }
 
     return key
@@ -49,7 +53,8 @@ module.exports = (opts) => {
   }
 
   const defaults = {
-    normalizeHeaderKey
+    normalizeHeaderKey,
+    camelCase: false
   }
 
   const options = Object.assign({}, defaults, opts)
@@ -62,7 +67,7 @@ module.exports = (opts) => {
 
         Object.keys(handler.event.headers).forEach((key) => {
           rawHeaders[key] = handler.event.headers[key]
-          headers[options.normalizeHeaderKey(key)] = handler.event.headers[key]
+          headers[options.normalizeHeaderKey(key, options.camelCase)] = handler.event.headers[key]
         })
 
         handler.event.headers = headers

--- a/packages/http-json-body-parser/__tests__/index.js
+++ b/packages/http-json-body-parser/__tests__/index.js
@@ -21,6 +21,25 @@ describe('📦  Middleware JSON Body Parser', () => {
     })
   })
 
+  test('It should parse a JSON request with lowercase header', () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, event.body) // propagates the body as a response
+    })
+
+    handler.use(jsonBodyParser())
+
+    // invokes the handler
+    const event = {
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({foo: 'bar'})
+    }
+    handler(event, {}, (_, body) => {
+      expect(body).toEqual({foo: 'bar'})
+    })
+  })
+
   test('It should handle invalid JSON as an UnprocessableEntity', () => {
     const handler = middy((event, context, cb) => {
       cb(null, event.body) // propagates the body as a response

--- a/packages/http-json-body-parser/index.js
+++ b/packages/http-json-body-parser/index.js
@@ -3,13 +3,16 @@ const contentType = require('content-type')
 
 module.exports = () => ({
   before: (handler, next) => {
-    if (handler.event.headers && handler.event.headers['Content-Type']) {
-      const { type } = contentType.parse(handler.event.headers['Content-Type'])
-      if (type === 'application/json') {
-        try {
-          handler.event.body = JSON.parse(handler.event.body)
-        } catch (err) {
-          throw new createError.UnprocessableEntity('Content type defined as JSON but an invalid JSON was provided')
+    if (handler.event.headers) {
+      const contentTypeHeader = handler.event.headers['content-type'] || handler.event.headers['Content-Type'];
+      if (contentTypeHeader) {
+        const { type } = contentType.parse(contentTypeHeader)
+        if (type === 'application/json') {
+          try {
+            handler.event.body = JSON.parse(handler.event.body)
+          } catch (err) {
+            throw new createError.UnprocessableEntity('Content type defined as JSON but an invalid JSON was provided')
+          }
         }
       }
     }

--- a/packages/http-urlencode-body-parser/__tests__/index.js
+++ b/packages/http-urlencode-body-parser/__tests__/index.js
@@ -26,6 +26,30 @@ describe('📦 Middleware URL Encoded Body Parser', () => {
     })
   })
 
+  test('It should decode simple url encoded requests with lowercase header', () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, event.body) // propagates the body as response
+    })
+
+    handler.use(urlEncodeBodyParser({extended: false}))
+
+    // invokes the handler
+    const event = {
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded; charset=UTF-8'
+      },
+      body: 'frappucino=muffin&goat%5B%5D=scone&pond=moose'
+    }
+
+    handler(event, {}, (_, body) => {
+      expect(body).toEqual({
+        frappucino: 'muffin',
+        'goat[]': 'scone',
+        pond: 'moose'
+      })
+    })
+  })
+
   test('It should decode complex url encoded requests using extended option', () => {
     const handler = middy((event, context, cb) => {
       cb(null, event.body) // propagates the body as response

--- a/packages/http-urlencode-body-parser/index.js
+++ b/packages/http-urlencode-body-parser/index.js
@@ -10,11 +10,14 @@ module.exports = (opts) => ({
 
     const parserFn = options.extended ? require('qs').parse : require('querystring').decode
 
-    if (handler.event.headers && handler.event.headers['Content-Type']) {
-      const { type } = contentType.parse(handler.event.headers['Content-Type'])
+    if (handler.event.headers) {
+      const contentTypeHeader = handler.event.headers['content-type'] || handler.event.headers['Content-Type']
+      if (contentTypeHeader) {
+        const { type } = contentType.parse(contentTypeHeader)
 
-      if (type === 'application/x-www-form-urlencoded') {
-        handler.event.body = parserFn(handler.event.body)
+        if (type === 'application/x-www-form-urlencoded') {
+          handler.event.body = parserFn(handler.event.body)
+        }
       }
     }
 


### PR DESCRIPTION
#166 Modified the middleware "http-header-normalizer" to normalise to lowercase. There is an extra options now in the middleware, so you can decide to normalise to camelCase.

Modified the other middleware:
- cors
- http-content-negotiation
- http-json-body-parser
- http-urlencode-body-parser

to handle headers in lowercase or camel case.

  - [x] I added tests for my changes
  - [x] I updated the documentation to reflect my changes
  - [x] I updated the Typescript typings to reflect my changes
 
I didn't updated the documentation of the middlewares about the handling of both format of header, but I don't think it's necessary.