### PR TITLE
add SSM cache invalidation

### DIFF
--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -450,6 +450,7 @@ For each parameter defined by name, you also provide the name under which its va
 ### Options
 
 - `cache` (boolean) (optional): Defaults to `false`. Set it to `true` to skip further calls to AWS SSM
+- `cacheExpiryInMillis` (int) (optional): Defaults to `undefined`. Use this option to invalidate cached parameter values from SSM
 - `paths` (object) (optional*): Map of SSM paths to fetch parameters from, where the key is the prefix for the destination name, and value is the SSM path. Example: `{paths: {DB_: '/dev/service/db'}}`
 - `names` (object) (optional*): Map of parameters to fetch from SSM, where the key is the destination, and value is param name in SSM.
   Example: `{names: {DB_URL: '/dev/service/db_url'}}`

--- a/middlewares.d.ts
+++ b/middlewares.d.ts
@@ -2,6 +2,7 @@ import { SSM } from 'aws-sdk'
 import { Options as AjvOptions } from 'ajv'
 import { HttpError } from 'http-errors'
 import middy from './'
+import { int } from 'aws-sdk/clients/datapipeline';
 
 interface ICorsOptions {
   origin: string;
@@ -47,6 +48,7 @@ interface IHTTPPartialResponseOptions {
 
 interface ISSMOptions {
   cache?: boolean;
+  cacheExpiryInMillis?: int;
   paths?: { [key: string]: string; };
   names?: { [key: string]: string; };
   awsSdkOptions?: Partial<SSM.Types.ClientConfiguration>;

--- a/middlewares.d.ts
+++ b/middlewares.d.ts
@@ -2,7 +2,6 @@ import { SSM } from 'aws-sdk'
 import { Options as AjvOptions } from 'ajv'
 import { HttpError } from 'http-errors'
 import middy from './'
-import { int } from 'aws-sdk/clients/datapipeline';
 
 interface ICorsOptions {
   origin: string;
@@ -48,7 +47,7 @@ interface IHTTPPartialResponseOptions {
 
 interface ISSMOptions {
   cache?: boolean;
-  cacheExpiryInMillis?: int;
+  cacheExpiryInMillis?: number;
   paths?: { [key: string]: string; };
   names?: { [key: string]: string; };
   awsSdkOptions?: Partial<SSM.Types.ClientConfiguration>;

--- a/middlewares.d.ts
+++ b/middlewares.d.ts
@@ -1,7 +1,7 @@
 import { SSM } from 'aws-sdk'
 import { Options as AjvOptions } from 'ajv'
 import { HttpError } from 'http-errors'
-import middy from './src/middy'
+import middy from './'
 
 interface ICorsOptions {
   origin: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1765,9 +1765,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
       "dev": true
     },
     "boom": {
@@ -5497,7 +5497,7 @@
       "dev": true,
       "requires": {
         "babylon": "7.0.0-beta.19",
-        "bluebird": "3.5.0",
+        "bluebird": "3.5.1",
         "catharsis": "0.8.9",
         "escape-string-regexp": "1.0.5",
         "js2xmlparser": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "aws-sdk": "2.221.1",
     "babel-jest": "^22.0.0",
     "babel-preset-env": "^1.6.1",
-    "bluebird": "^3.5.1",
     "codecov": "^3.0.1",
     "eslint": "^4.4.1",
     "eslint-config-standard": "^10.2.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "aws-sdk": "2.221.1",
     "babel-jest": "^22.0.0",
     "babel-preset-env": "^1.6.1",
+    "bluebird": "^3.5.1",
     "codecov": "^3.0.1",
     "eslint": "^4.4.1",
     "eslint-config-standard": "^10.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
   "files": [

--- a/src/middlewares/__tests__/ssm.js
+++ b/src/middlewares/__tests__/ssm.js
@@ -3,7 +3,6 @@ jest.mock('aws-sdk')
 const {SSM} = require('aws-sdk')
 const middy = require('../../middy')
 const ssm = require('../ssm')
-const Promise = require('bluebird')
 
 describe('🔒 SSM Middleware', () => {
   const getParametersMock = jest.fn()
@@ -52,7 +51,9 @@ describe('🔒 SSM Middleware', () => {
         })
       }).then(() => {
         if (delay) {
-          return Promise.delay(delay)
+          return new Promise((resolve, reject) => {
+            setTimeout(resolve, delay)
+          })
         }
       })
     })

--- a/src/middlewares/__tests__/ssm.js
+++ b/src/middlewares/__tests__/ssm.js
@@ -91,7 +91,7 @@ describe('🔒 SSM Middleware', () => {
       },
       callbacks: [
         () => {
-          expect(getParametersMock).toBeCalledWith({'Names': ['/dev/service_name/key_name'], 'WithDecryption': true})
+          expect(getParametersMock).toBeCalled()
           getParametersMock.mockReset()
         },
         () => {
@@ -291,7 +291,7 @@ describe('🔒 SSM Middleware', () => {
       callbacks: [
         () => {
           expect(process.env.KEY_NAME).toEqual('key-value')
-          expect(process.env.PREFIX_SERVICE_NAME_KEY_NAME).toEqual('key-value')        
+          expect(process.env.PREFIX_SERVICE_NAME_KEY_NAME).toEqual('key-value')
         }
       ],
       done


### PR DESCRIPTION
- support cache invalidation for the SSM middleware
- refactored the corresponding tests a bit to make it easier to run scenarios that involves multiple invocations