### PR TITLE
Allow cors middleware to specify multiple allowed origins

### DIFF
--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -81,7 +81,7 @@ Sets headers in `after` and `onError` phases.
 
 ### Options
 
- - `origin` (string) (optional): origin to put in the header (default: "`*`")
+ - `origin` (string | array) (optional): origin to put in the header (default: "`*`"). If an array of strings is provided and the incoming origin is matched against the list it is returned. 
  - `headers` (string) (optional): value to put in Access-Control-Allow-Headers (default: `null`)
  - `credentials` (bool) (optional): if true, sets the `Access-Control-Allow-Origin` as request header `Origin`, if present (default `false`)
 

--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -81,7 +81,8 @@ Sets headers in `after` and `onError` phases.
 
 ### Options
 
- - `origin` (string | array) (optional): origin to put in the header (default: "`*`"). If an array of strings is provided and the incoming origin is matched against the list it is returned. 
+ - `origin` (string) (optional): origin to put in the header (default: "`*`"). 
+ - `origins` (array) (optional): An array of allowed origins. The incoming origin is matched against the list and is returned if present. 
  - `headers` (string) (optional): value to put in Access-Control-Allow-Headers (default: `null`)
  - `credentials` (bool) (optional): if true, sets the `Access-Control-Allow-Origin` as request header `Origin`, if present (default `false`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
   "files": [

--- a/src/middlewares/__tests__/cors.js
+++ b/src/middlewares/__tests__/cors.js
@@ -84,7 +84,7 @@ describe('📦 Middleware CORS', () => {
 
     handler.use(
       cors({
-        origin: ['https://example.com', 'https://another-example.com']
+        origins: ['https://example.com', 'https://another-example.com']
       })
     )
 
@@ -109,7 +109,7 @@ describe('📦 Middleware CORS', () => {
 
     handler.use(
       cors({
-        origin: ['https://example.com', 'https://another-example.com']
+        origins: ['https://example.com', 'https://another-example.com']
       })
     )
 

--- a/src/middlewares/__tests__/cors.js
+++ b/src/middlewares/__tests__/cors.js
@@ -77,6 +77,56 @@ describe('📦 Middleware CORS', () => {
     })
   })
 
+  test('It should return whitelisted origin', () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, {})
+    })
+
+    handler.use(
+      cors({
+        origin: ['https://example.com', 'https://another-example.com']
+      })
+    )
+
+    const event = {
+      httpMethod: 'GET',
+      headers: { Origin: 'https://another-example.com' }
+    }
+
+    handler(event, {}, (_, response) => {
+      expect(response).toEqual({
+        headers: {
+          'Access-Control-Allow-Origin': 'https://another-example.com'
+        }
+      })
+    })
+  })
+
+  test('It should return first origin as default if no match', () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, {})
+    })
+
+    handler.use(
+      cors({
+        origin: ['https://example.com', 'https://another-example.com']
+      })
+    )
+
+    const event = {
+      httpMethod: 'GET',
+      headers: { Origin: 'https://unknown.com' }
+    }
+
+    handler(event, {}, (_, response) => {
+      expect(response).toEqual({
+        headers: {
+          'Access-Control-Allow-Origin': 'https://example.com'
+        }
+      })
+    })
+  })
+
   test('It should add headers even onError', () => {
     const handler = middy((event, context, cb) => {
       throw new Error('')

--- a/src/middlewares/cors.js
+++ b/src/middlewares/cors.js
@@ -1,27 +1,24 @@
 const defaults = {
-  origin: '*', // Can also be an array of whitelisted origins
+  origin: '*',
+  origins: [],
   headers: null,
   credentials: false
 }
 
 const getOrigin = (options, handler) => {
   handler.event.headers = handler.event.headers || {}
-
-  if (handler.event.headers.hasOwnProperty('Origin')) {
-    if (options.credentials && options.origin === '*') {
+  if (options.origins && options.origins.length > 0) {
+    if (handler.event.headers.hasOwnProperty('Origin') && options.origins.includes(handler.event.headers.Origin)) {
+      return handler.event.headers.Origin
+    } else {
+      return options.origins[0]
+    }
+  } else {
+    if (handler.event.headers.hasOwnProperty('Origin') && options.credentials && options.origin === '*') {
       return handler.event.headers.Origin
     }
-
-    if (Array.isArray(options.origin)) {
-      if (options.origin.includes(handler.event.headers.Origin)) {
-        return handler.event.headers.Origin
-      } else {
-        return options.origin[0]
-      }
-    }
+    return options.origin
   }
-
-  return options.origin
 }
 
 const addCorsHeaders = (opts, handler, next) => {

--- a/src/middlewares/cors.js
+++ b/src/middlewares/cors.js
@@ -1,5 +1,5 @@
 const defaults = {
-  origin: '*',
+  origin: '*', // Can also be an array of whitelisted origins
   headers: null,
   credentials: false
 }
@@ -7,9 +7,20 @@ const defaults = {
 const getOrigin = (options, handler) => {
   handler.event.headers = handler.event.headers || {}
 
-  if (options.credentials && options.origin === '*' && handler.event.headers.hasOwnProperty('Origin')) {
-    return handler.event.headers.Origin
+  if (handler.event.headers.hasOwnProperty('Origin')) {
+    if (options.credentials && options.origin === '*') {
+      return handler.event.headers.Origin
+    }
+
+    if (Array.isArray(options.origin)) {
+      if (options.origin.includes(handler.event.headers.Origin)) {
+        return handler.event.headers.Origin
+      } else {
+        return options.origin[0]
+      }
+    }
   }
+
   return options.origin
 }
 


### PR DESCRIPTION
Changes the cors middleware options to accept an array of origins. If the request origin matches an origin in the options it is returned. Otherwise the first origin is returned.