### PR TITLE
Node8 build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  build_node6:
     docker:
       - image: circleci/node:6.10
 
@@ -37,7 +37,7 @@ jobs:
           paths:
             - middy/*
 
-  build_next:
+  build_node8:
     docker:
       - image: circleci/node:8.10
 
@@ -94,13 +94,13 @@ workflows:
 
   build_test_deploy:
     jobs:
-        - build
-        - build_next
-        # we only deploy if build && build_next both succeed.
+        - build_node6
+        - build_node8
+        # we only deploy if build_node6 && build_node8 both succeed and if on master.
         - deploy:
             requires:
-                - build
-                - build_next
+                - build_node6
+                - build_node8
             filters:
                 branches:
                     only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,12 +11,9 @@ jobs:
 
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package.json" }}
+          - v1-dependencies-v6-{{ checksum "package.json" }}
+          - v1-dependencies-v6-
           - v1-dependencies-
-      
-      - run:
-          name: configure NPM registry
-          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
 
       - run:
           name: install dependencies
@@ -25,19 +22,85 @@ jobs:
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
-        
+          key: v1-dependencies-v6-{{ checksum "package.json" }}
+
       - run:
           name: unit tests
           command: npm test
-          
+
       - run:
           name: coverage reporting
           command: npm run coverage:submit
 
-      - deploy:
-          name: publish
-          command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - middy/*
+
+  build_next:
+    docker:
+      - image: circleci/node:8.10
+
+    working_directory: ~/middy
+
+    # These are almost the same set of steps as above.
+    # Yaml doesn't allow you to concatenate lists: https://github.com/yaml/yaml/issues/35
+    # Not in these steps:
+    #  - uploading code coverage
+    #  - saving workspace for the deploy job
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+          - v1-dependencies-v8-{{ checksum "package.json" }}
+          - v1-dependencies-v8-
+          - v1-dependencies-
+
+      - run:
+          name: install dependencies
+          command: npm install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-v8-{{ checksum "package.json" }}
+
+      - run:
+          name: unit tests
+          command: npm test
+
+  deploy:
+    docker:
+      - image: circleci/node:6.10
+
+    steps:
+        - attach_workspace:
+            at: ~/
+
+        - run:
+            name: configure NPM registry
+            command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+
+        - run:
+            working_directory: ~/middy
+            name: publish
+            command: |
               npm publish && npm run release:tag;
-            fi
+
+
+workflows:
+  version: 2
+
+  build_test_deploy:
+    jobs:
+        - build
+        - build_next
+        # we only deploy if build && build_next both succeed.
+        - deploy:
+            requires:
+                - build
+                - build_next
+            filters:
+                branches:
+                    only: master

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
   "files": [


### PR DESCRIPTION
These changes enable building middy against node v6 (current) and node v8 (next). Additionally it leverages the work flow feature of CircleCI to ensure deploys only happen if the code base passes tests on *both* node versions.

This was discussed in #182 with @vladgolubev and @lmammino 

As with the original file we only trigger the deploy job if we're on master; we just utilize the circleci config to control this instead of using a shell script to check the branch name.

I chose not to run coverage for the `build_next` job as the underlying node version shouldn't make a difference to the output here. Also we only take the workspace from v6 and deploy that since nothing in the build vary's based on node version this should be just fine.