### PR TITLE
bugfix - terminate function returns callback or response

### DIFF
--- a/src/middy.js
+++ b/src/middy.js
@@ -148,10 +148,10 @@ const middy = (handler) => {
 
     const terminate = (err) => {
       if (err) {
-        return callback(err)
+        return callback ? callback(err) : err
       }
 
-      return callback(null, instance.response)
+      return callback ? callback(null, instance.response) : instance.response
     }
 
     const errorHandler = err => {


### PR DESCRIPTION
**Summary**
`terminate` function should be able to return the value or the callback to fully support async function flow.

This is my initial approach but very happy to discuss alternatives :+1:

**Issue**
#198 