### PR TITLE
Fix IMiddy and ICorsOptions type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,9 +9,9 @@ declare var middy: {
 declare namespace middy {
   interface IMiddy extends Handler {
     use: IMiddyUseFunction;
-    before: IMiddyMiddlewareFunction;
-    after: IMiddyMiddlewareFunction;
-    onError: IMiddyMiddlewareFunction;
+    before: (callbackFn: IMiddyMiddlewareFunction) => IMiddy;
+    after: (callbackFn: IMiddyMiddlewareFunction) => IMiddy;
+    onError: (callbackFn: IMiddyMiddlewareFunction) => IMiddy;
   }
 
   type IMiddyUseFunction = (config?: object) => IMiddy;

--- a/middlewares.d.ts
+++ b/middlewares.d.ts
@@ -4,9 +4,9 @@ import { HttpError } from 'http-errors'
 import middy from './'
 
 interface ICorsOptions {
-  origin: string;
-  headers: string;
-  credentials: boolean;
+  origin?: string;
+  headers?: string;
+  credentials?: boolean;
 }
 
 interface ICacheOptions {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -64,6 +64,18 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.6.1.tgz",
       "integrity": "sha512-s+RHKSGc3r0m3YEE2UXomJYrpQaY9cDmNDLU2XvG1/LAZsQ7y8emYkTLfcw/ByDtcsTyRQKwr76Bj4PkN2hfWg=="
+    },
+    "@types/jest": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.0.0.tgz",
+      "integrity": "sha512-hy+8Sdet9JiNEZpJZWRcmT4pBz19H9dKMr/qWD1JJINBpTTts+Vbe8P+nx9vRJUlbVN4GMPAVr1F4Ff3V5U/Kg==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.1.tgz",
+      "integrity": "sha512-IsX9aDHDzJohkm3VCDB8tkzl5RQ34E/PFA29TQk6uDGb7Oc869ZBtmdKVDBzY3+h9GnXB8ssrRXEPVZrlIOPOw==",
+      "dev": true
     },
     "abab": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   "types": "./index.d.ts",
   "scripts": {
     "test:lint": "eslint --ignore-pattern='node_modules/' --ignore-pattern='coverage/' --ignore-pattern='docs/' .",
-    "test:typings": "typings-tester --config tsconfig.json index.d.ts middlewares.d.ts",
+    "test:typings": "typings-tester --config tsconfig.json index.d.ts middlewares.d.ts src/__tests__/*.types.ts src/**/__tests__/*types.ts",
     "test:unit": "jest --verbose --coverage",
     "test:unit:watch": "jest --verbose --coverage --watch",
-    "test": "npm run test:lint && npm run test:unit",
+    "test": "npm run test:lint && npm run test:unit && npm run test:typings",
     "build:readme": "jsdoc2md --global-index-format grouped --template README.md.hb src/* > README.md",
     "build:docs": "jsdoc --readme README.md --package package.json --destination docs src",
     "build": "npm run build:docs && npm run build:readme",
@@ -44,6 +44,8 @@
   },
   "homepage": "https://github.com/middyjs/middy#readme",
   "devDependencies": {
+    "@types/jest": "^23.0.0",
+    "@types/node": "^10.3.1",
     "aws-sdk": "^2.233.1",
     "babel-jest": "^23.0.1",
     "babel-preset-env": "^1.6.1",
@@ -60,7 +62,7 @@
     "jsdoc-to-markdown": "^4.0.1",
     "marked": "^0.3.12",
     "regenerator-runtime": "^0.11.0",
-    "typescript": "^2.8.1",
+    "typescript": "^2.8.3",
     "typings-tester": "^0.3.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
   "files": [

--- a/src/__tests__/middy.types.ts
+++ b/src/__tests__/middy.types.ts
@@ -1,0 +1,47 @@
+import middy from '../../';
+
+describe('🛵  Middy types test suite', () => {
+  test('"before" should take a function', () => {
+    const beforeMiddleware = jest.fn();
+
+    const handler = middy(jest.fn());
+
+    handler.before(beforeMiddleware);
+  })
+
+  test('"after" should take a function', () => {
+    const afterMiddleware = jest.fn();
+
+    const handler = middy(jest.fn());
+
+    handler.after(afterMiddleware);
+  })
+
+  test('"onError" should take a function', () => {
+    const errorMiddleware = jest.fn();
+
+    const handler = middy(jest.fn());
+
+    handler.onError(errorMiddleware);
+  })
+
+  test('middleware calls can be chained', () => {
+    const before = jest.fn()
+    const after = jest.fn()
+    const onError = jest.fn();
+
+    const middleware = () => ({
+      after,
+      before,
+      onError,
+     });
+
+    const handler = middy(jest.fn());
+
+     handler
+      .use(middleware)
+      .after(after)
+      .before(before)
+      .onError(onError);
+  })
+})

--- a/src/middlewares/__tests__/cors.types.ts
+++ b/src/middlewares/__tests__/cors.types.ts
@@ -1,0 +1,35 @@
+import middy from '../../../';
+import { cors } from '../../../middlewares';
+
+describe('📦 Middleware Types', () => {
+  describe('CORS', () => {
+    it('has an optional argument', () => {
+      const handler = middy(jest.fn());
+      handler.use(cors());
+    })
+
+    it ('has an optional origin field', () => {
+      const handler = middy(jest.fn());
+      handler.use(cors({
+        headers: "test-case",
+        credentials: true,
+      }));
+    })
+
+    it('has an optional headers field', () => {
+      const handler = middy(jest.fn());
+      handler.use(cors({
+        origin: 'example.com',
+        credentials: true,
+      }));
+    })
+
+    it('has an optional credentials field', () => {
+      const handler = middy(jest.fn());
+      handler.use(cors({
+        origin: 'example.com',
+        headers: "test-case",
+      }));
+    })
+  })
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,23 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "lib": ["es2015"],
-    "target": "es2015"
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "importHelpers": true,
+    "lib": [
+      "es2018",
+    ],
+    "moduleResolution": "node",
+    "noEmitHelpers": true,
+    "noEmitOnError": true,
+    "noImplicitReturns": true,
+    "target": "es5",
+    "sourceMap": true,
+    "strict": true,
   },
+  "exclude": [
+    "node_modules",
+  ],
   "files": [
     "index.d.ts",
     "middlewares.d.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "noEmitHelpers": true,
     "noEmitOnError": true,
     "noImplicitReturns": true,
-    "target": "es5",
+    "target": "es2015",
     "sourceMap": true,
     "strict": true,
   },


### PR DESCRIPTION
As per #182 this fixes the types issues on IMiddy and ICorsOptions. `before`, `after`, and `onError` on IMiddy were incorrectly configured:

 - they did not take a function
 - they did not return themselves

While `ICorsOptions` itself was optional when `cors()` was being called, the individual properties of it were not.

The project already had the infrastructure to run tests but was missing a few things:

 - `@types/node` were not present, so `typings-tester` would fail
 - it was easy to miss this because `test:typings` was not part of the build workflow; I've now added it to `npm test`.

I have examples of the tests failing:

 - [tests against incorrect IMiddy](https://circleci.com/gh/ossareh/middy/37)
 - [tests against incorrect ICorsOptions](https://circleci.com/gh/ossareh/middy/36)

These have slightly differing package.json setups which allow them to target the specific tests:

 - branch: [before_after_onerror_failure](https://github.com/middyjs/middy/compare/master...ossareh:before_after_onerror_failure)
 - branch [cors_opts_failure](https://github.com/middyjs/middy/compare/master...ossareh:cors_opts_failure)

I chose to use the name: `foo.types.ts` to indicate that the these files are verifying types. Additionally I chose to locate them in `__tests__` because that seemed like the most correct place. Finally, I also chose to use the jest notation (and thus include `@types/jest`) as that allows folks to just copy and paste their tests into `foo.types.ts` and they'll be picked up by `typings-tester`.

I believe we have the minimum here to constitute a basis to ask folks to contribute accurate types to the project now. However I decided not to implement tests for all of the types because that would have made the commit much larger. I'm happy to contribute a few types each weekend though :)