### PR TITLE
Check for case-insensitive content-type property

### DIFF
--- a/src/middlewares/jsonBodyParser.js
+++ b/src/middlewares/jsonBodyParser.js
@@ -3,13 +3,16 @@ const contentType = require('content-type')
 
 module.exports = () => ({
   before: (handler, next) => {
-    if (handler.event.headers && handler.event.headers['Content-Type']) {
-      const { type } = contentType.parse(handler.event.headers['Content-Type'])
-      if (type === 'application/json') {
-        try {
-          handler.event.body = JSON.parse(handler.event.body)
-        } catch (err) {
-          throw new createError.UnprocessableEntity('Content type defined as JSON but an invalid JSON was provided')
+    if (handler.event.headers) {
+      const contentTypeHeader = handler.event.headers['Content-Type'] || handler.event.headers['content-type']
+      if (contentTypeHeader) {
+        const { type } = contentType.parse(contentTypeHeader)
+        if (type === 'application/json') {
+          try {
+            handler.event.body = JSON.parse(handler.event.body)
+          } catch (err) {
+            throw new createError.UnprocessableEntity('Content type defined as JSON but an invalid JSON was provided')
+          }
         }
       }
     }


### PR DESCRIPTION
The headers field name are case-insensitive as mentioned in [Section 4.2, "Message Headers"](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2)

> Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.