### PR TITLE
Check for upper & lower case origin

### DIFF
--- a/src/middlewares/cors.js
+++ b/src/middlewares/cors.js
@@ -7,7 +7,7 @@ const defaults = {
 
 const getOrigin = (options, handler) => {
   handler.event.headers = handler.event.headers || {}
-  const origin = handler.event.headers.Origin || handler.event.headers.origin;
+  const origin = handler.event.headers.Origin || handler.event.headers.origin
 
   if (options.origins && options.origins.length > 0) {
     if (origin && options.origins.includes(origin)) {

--- a/src/middlewares/cors.js
+++ b/src/middlewares/cors.js
@@ -7,15 +7,17 @@ const defaults = {
 
 const getOrigin = (options, handler) => {
   handler.event.headers = handler.event.headers || {}
+  const origin = handler.event.headers.Origin || handler.event.headers.origin;
+
   if (options.origins && options.origins.length > 0) {
-    if (handler.event.headers.hasOwnProperty('Origin') && options.origins.includes(handler.event.headers.Origin)) {
-      return handler.event.headers.Origin
+    if (origin && options.origins.includes(origin)) {
+      return origin
     } else {
       return options.origins[0]
     }
   } else {
-    if (handler.event.headers.hasOwnProperty('Origin') && options.credentials && options.origin === '*') {
-      return handler.event.headers.Origin
+    if (origin && options.credentials && options.origin === '*') {
+      return origin
     }
     return options.origin
   }


### PR DESCRIPTION
Some browsers can return lower case origin. Serverless also uses lower case origin.