### PR TITLE
bugfix - ssm middleware - setToContext doesn't work when cache option is enabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
   "files": [

--- a/src/middlewares/__tests__/ssm.js
+++ b/src/middlewares/__tests__/ssm.js
@@ -20,7 +20,7 @@ describe('🔒 SSM Middleware', () => {
 
   function testScenario ({ssmMockResponse, ssmMockResponses, middlewareOptions, callbacks, done, delay = 0}) {
     (ssmMockResponses || [ssmMockResponse]).forEach(ssmMockResponse => {
-      getParametersMock.mockReturnValueOnce({
+      getParametersMock.mockReturnValue({
         promise: () => Promise.resolve(ssmMockResponse)
       })
 
@@ -86,16 +86,18 @@ describe('🔒 SSM Middleware', () => {
       },
       middlewareOptions: {
         names: {
-          KEY_NAME: '/dev/service_name/key-value'
+          KEY_NAME: '/dev/service_name/key_name'
         },
         cache: true
       },
       callbacks: [
         () => {
+          expect(process.env.KEY_NAME).toEqual('key-value')
           expect(getParametersMock).toBeCalled()
-          getParametersMock.mockReset()
+          getParametersMock.mockClear()
         },
         () => {
+          expect(process.env.KEY_NAME).toEqual('key-value')
           expect(getParametersMock).not.toBeCalled()
         }
       ],
@@ -120,11 +122,13 @@ describe('🔒 SSM Middleware', () => {
         setToContext: true
       },
       callbacks: [
-        () => {
+        (_, {context}) => {
+          expect(context.secureValue).toEqual('something-secure')
           expect(getParametersMock).toBeCalledWith({'Names': ['/dev/service_name/secure_param'], 'WithDecryption': true})
-          getParametersMock.mockReset()
+          getParametersMock.mockClear()
         },
-        () => {
+        (_, {context}) => {
+          expect(context.secureValue).toEqual('something-secure')
           expect(getParametersMock).not.toBeCalled()
         }
       ],
@@ -146,7 +150,8 @@ describe('🔒 SSM Middleware', () => {
         paramsLoaded: false
       },
       callbacks: [
-        () => {
+        (_, {context}) => {
+          expect(context.secureValue).toEqual('something-secure')
           expect(getParametersMock).toBeCalledWith({'Names': ['/dev/service_name/secure_param'], 'WithDecryption': true})
         }
       ],
@@ -169,11 +174,13 @@ describe('🔒 SSM Middleware', () => {
         paramsLoaded: false
       },
       callbacks: [
-        () => {
+        (_, {context}) => {
+          expect(context.secureValue).toEqual('something-secure')
           expect(getParametersMock).toBeCalledWith({'Names': ['/dev/service_name/secure_param'], 'WithDecryption': true})
-          getParametersMock.mockReset()
+          getParametersMock.mockClear()
         },
-        () => {
+        (_, {context}) => {
+          expect(context.secureValue).toEqual('something-secure')
           expect(getParametersMock).toBeCalledWith({'Names': ['/dev/service_name/secure_param'], 'WithDecryption': true})
         }
       ],
@@ -197,11 +204,13 @@ describe('🔒 SSM Middleware', () => {
         paramsLoaded: false
       },
       callbacks: [
-        () => {
+        (_, {context}) => {
+          expect(context.secureValue).toEqual('something-secure')
           expect(getParametersMock).toBeCalledWith({'Names': ['/dev/service_name/secure_param'], 'WithDecryption': true})
-          getParametersMock.mockReset()
+          getParametersMock.mockClear()
         },
-        () => {
+        (_, {context}) => {
+          expect(context.secureValue).toEqual('something-secure')
           expect(getParametersMock).not.toBeCalled()
         }
       ],

--- a/src/middlewares/ssm.js
+++ b/src/middlewares/ssm.js
@@ -49,7 +49,7 @@ module.exports = opts => {
 
       const ssmParamNames = getSSMParamValues(options.names)
       if (ssmParamNames.length) {
-        const ssmPromise = 
+        const ssmPromise =
           ssmInstance
             .getParameters({ Names: ssmParamNames, WithDecryption: true })
             .promise()

--- a/src/middlewares/ssm.js
+++ b/src/middlewares/ssm.js
@@ -13,6 +13,7 @@ module.exports = opts => {
     cache: false,
     cacheExpiryInMillis: undefined,
     paramsLoaded: false,
+    paramsCache: undefined,
     paramsLoadedAt: new Date(0)
   }
 
@@ -20,7 +21,16 @@ module.exports = opts => {
 
   return {
     before: (handler, next) => {
-      if (!shouldFetchFromParamStore(options)) return next()
+      if (!shouldFetchFromParamStore(options)) {
+        if (options.paramsCache) {
+          const targetParamsObject = getTargetObjectToAssign(handler, options)
+          options.paramsCache.forEach(object => {
+            Object.assign(targetParamsObject, object)
+          })
+        }
+
+        return next()
+      }
 
       ssmInstance = ssmInstance || getSSMInstance(options.awsSdkOptions)
 
@@ -39,13 +49,13 @@ module.exports = opts => {
 
       const ssmParamNames = getSSMParamValues(options.names)
       if (ssmParamNames.length) {
-        ssmPromises.push(
+        const ssmPromise = 
           ssmInstance
             .getParameters({ Names: ssmParamNames, WithDecryption: true })
             .promise()
             .then(handleInvalidParams)
             .then(ssmResponse => getParamsToAssignByName(options.names, ssmResponse))
-        )
+        ssmPromises.push(ssmPromise)
       }
 
       return Promise.all(ssmPromises).then(objectsToMap => {
@@ -54,6 +64,7 @@ module.exports = opts => {
           Object.assign(targetParamsObject, object)
         })
         options.paramsLoaded = true
+        options.paramsCache = objectsToMap
         options.paramsLoadedAt = new Date()
       })
     }


### PR DESCRIPTION
**Summary**
In the `ssm` middleware, when the `cache` option is enabled we skip the call to SSM but it also skips the step to set the params onto the context.

This wasn't caught in the tests as the tests didn't verify that the properties are set on the invocation context.

**Changes**

- fixed some ssm plugin tests which weren't validating that values are set in the context
- changed places where mockReset is used where it  should be mockClear (since we just want to reset the invocation count)
- cache the SSM response, and apply the cached params even when skip calling SSM