### PR TITLE
Updates S3 event version to allow event versions of 2.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
   "files": [

--- a/src/middlewares/__tests__/s3KeyNormalizer.js
+++ b/src/middlewares/__tests__/s3KeyNormalizer.js
@@ -6,7 +6,7 @@ describe('📦  Middleware s3KeyNormalizer', () => {
     const event = {
       'Records': [
         {
-          'eventVersion': '2.0',
+          'eventVersion': '2.1',
           'eventTime': '1970-01-01T00:00:00.000Z',
           'requestParameters': {
             'sourceIPAddress': '127.0.0.1'
@@ -59,7 +59,58 @@ describe('📦  Middleware s3KeyNormalizer', () => {
     const event = {
       'Records': [
         {
-          'eventVersion': '2.0',
+          'eventVersion': '2.1',
+          'eventTime': '1970-01-01T00:00:00.000Z',
+          'requestParameters': {
+            'sourceIPAddress': '127.0.0.1'
+          },
+          's3': {
+            'configurationId': 'testConfigRule',
+            'object': {
+              'sequencer': '0A1B2C3D4E5F678901',
+              'key': 'This+is+a+picture.jpg'
+            },
+            'bucket': {
+              'arn': 'arn:aws:s3:::mybucket',
+              'name': 'sourcebucket',
+              'ownerIdentity': {
+                'principalId': 'EXAMPLE'
+              }
+            },
+            's3SchemaVersion': '1.0'
+          },
+          'responseElements': {
+            'x-amz-id-2': 'EXAMPLE123/5678abcdefghijklambdaisawesome/mnopqrstuvwxyzABCDEFGH',
+            'x-amz-request-id': 'EXAMPLE123456789'
+          },
+          'awsRegion': 'us-east-1',
+          'eventName': 'ObjectRemoved:Delete',
+          'userIdentity': {
+            'principalId': 'EXAMPLE'
+          },
+          'eventSource': 'aws:s3'
+        }
+      ]
+    }
+
+    const handler = middy((event, context, callback) => {
+      callback(null, event) // returns the event as response
+    })
+
+    handler
+      .use(s3KeyNormalizer())
+
+    // invokes the handler
+    handler(event, {}, (_, response) => {
+      expect(response.Records[0].s3.object.key).toEqual('This is a picture.jpg')
+    })
+  })
+
+  test('It should normalize the event if the event version is 2.x', () => {
+    const event = {
+      'Records': [
+        {
+          'eventVersion': '2.3',
           'eventTime': '1970-01-01T00:00:00.000Z',
           'requestParameters': {
             'sourceIPAddress': '127.0.0.1'

--- a/src/middlewares/s3KeyNormalizer.js
+++ b/src/middlewares/s3KeyNormalizer.js
@@ -4,7 +4,8 @@ module.exports = () => ({
   before: (handler, next) => {
     if (handler.event.Records && Array.isArray(handler.event.Records)) {
       handler.event.Records = handler.event.Records.map((record) => {
-        if (record.s3 && record.s3.object && record.eventVersion === '2.0') {
+        const eventVersion = parseFloat(record.eventVersion)
+        if (record.s3 && record.s3.object && eventVersion >= 2 && eventVersion < 3) {
           record.s3.object.key = normalizeKey(record.s3.object.key)
         }
         return record


### PR DESCRIPTION
## Description

The s3KeyNormalizer middleware was not running because the version check was failing. AWS have updated S3 events and are now using a new version of 2.1. This PR updates the version number to run the normalizer when the version is 2.1. [AWS docs for S3 events](https://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html)

