### PR TITLE
Add string template option to ssm middleware

### DIFF
--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -632,6 +632,8 @@ For each parameter defined by name, you also provide the name under which its va
 - `onChange` (function) (optional): Callback triggered when call was made to SSM. Useful when you need to regenerate something with different data. Example: `{ onChange: () => { console.log('New data available')} }`
 - `setToContext` (boolean) (optional): This will assign parameters to the `context` object
   of the function handler rather than to `process.env`. Defaults to `false`
+- `stringTemplates`(boolean) (optional): This will allow to use ES6 style variables in the `name` and `path` values with access to all properties of the `handler` object. Do not use back-ticks - use normal strings. Caching is supported  for request with identical variable values.
+  Example: `{names: {DB_URL: '/dev/${event.body.service}/options'}}` or `{paths: {DB_: '/${context.stage}/service/db'}}`
 
 NOTES:
 


### PR DESCRIPTION
**use case:**
* retrieve different options from parameter store based on aws api key
* api key is dynamic set in the context of each request

**implementation**
* only activated when needed with new option `stringTemplates : true`
* uses a syntax well known with ES6 Template literals `${VARIABLENAME}`
* full access to all objects in `handler`
* only requests with identical requests to parameter store are cached

**Examples:** 
`{names: {DB_URL: '/dev/${event.body.service}/options'}}` 
`{paths: {DB_: '/${context.stage}/service/db'}}`

**TODO:**
I need help to implement a test which will check if the cache is ignored when the value of a variable changes. I failed to manipulate the context or the event during two sequential calls:
https://github.com/aheissenberger/middy/blob/25ed9586acfd986224280c1d1a4f57a575212213/src/middlewares/__tests__/ssm.js#L449
