### PR TITLE
Support multiValueHeaders and multiValueQueryStringParameters - fix #251

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
   "files": [

--- a/src/middlewares/__tests__/httpEventNormalizer.js
+++ b/src/middlewares/__tests__/httpEventNormalizer.js
@@ -33,6 +33,21 @@ describe('📦 Middleware normalize HTTP event', () => {
     })
   })
 
+  test('It should default multiValueQueryStringParameters', (endTest) => {
+    const handler = middy((event, context, cb) => cb(null, event))
+
+    handler.use(httpEventNormalizer())
+
+    const event = {
+      httpMethod: 'GET'
+    }
+
+    handler(event, {}, (_, event) => {
+      expect(event).toHaveProperty('multiValueQueryStringParameters', {})
+      endTest()
+    })
+  })
+
   test('It should default pathParameters', (endTest) => {
     const handler = middy((event, context, cb) => cb(null, event))
 
@@ -60,6 +75,22 @@ describe('📦 Middleware normalize HTTP event', () => {
 
     handler(event, {}, (_, event) => {
       expect(event).toHaveProperty('queryStringParameters', { param: '123' })
+      endTest()
+    })
+  })
+
+  test('It should not overwrite multiValueQueryStringParameters', (endTest) => {
+    const handler = middy((event, context, cb) => cb(null, event))
+
+    handler.use(httpEventNormalizer())
+
+    const event = {
+      httpMethod: 'GET',
+      multiValueQueryStringParameters: { param: [ '123', '456', '789' ] }
+    }
+
+    handler(event, {}, (_, event) => {
+      expect(event).toHaveProperty('multiValueQueryStringParameters',  { param: [ '123', '456', '789' ] })
       endTest()
     })
   })

--- a/src/middlewares/__tests__/httpEventNormalizer.js
+++ b/src/middlewares/__tests__/httpEventNormalizer.js
@@ -90,7 +90,7 @@ describe('📦 Middleware normalize HTTP event', () => {
     }
 
     handler(event, {}, (_, event) => {
-      expect(event).toHaveProperty('multiValueQueryStringParameters',  { param: [ '123', '456', '789' ] })
+      expect(event).toHaveProperty('multiValueQueryStringParameters', { param: [ '123', '456', '789' ] })
       endTest()
     })
   })

--- a/src/middlewares/__tests__/httpHeaderNormalizer.js
+++ b/src/middlewares/__tests__/httpHeaderNormalizer.js
@@ -95,4 +95,98 @@ describe('👺 Middleware Http Header Normalizer', () => {
       endTest()
     })
   })
+
+  test('It should normalize all the multivalue headers and create a copy in rawMultiValueHeaders', (endTest) => {
+    const handler = middy((event, context, cb) => cb(null, event))
+
+    handler
+      .use(httpHeaderNormalizer())
+
+    const event = {
+      multiValueHeaders: {
+        'x-api-key': ['123456', '7890'],
+        'tcn': ['abc', 'def'],
+        'te': ['cde'],
+        'DNS': ['d'],
+        'FOO': ['bar']
+      }
+    }
+
+    const expectedHeaders = {
+      'X-Api-Key': ['123456', '7890'],
+      'TCN': ['abc', 'def'],
+      'TE': ['cde'],
+      'Dns': ['d'],
+      'Foo': ['bar']
+    }
+
+    const originalHeaders = Object.assign({}, event.multiValueHeaders)
+
+    // run the handler
+    handler(event, {}, (_, resultingEvent) => {
+      expect(resultingEvent.multiValueHeaders).toEqual(expectedHeaders)
+      expect(resultingEvent.rawMultiValueHeaders).toEqual(originalHeaders)
+      endTest()
+    })
+  })
+
+  test('It can use custom normalization function for multivalue headers', (endTest) => {
+    const normalizeHeaderKey = (key) => key.toUpperCase()
+
+    const handler = middy((event, context, cb) => cb(null, event))
+
+    handler
+      .use(httpHeaderNormalizer({
+        normalizeHeaderKey
+      }))
+
+    const event = {
+      multiValueHeaders: {
+        'x-api-key': ['123456', '7890'],
+        'tcn': ['abc', 'def'],
+        'te': ['cde'],
+        'DNS': ['d'],
+        'FOO': ['bar']
+      }
+    }
+
+    const expectedHeaders = {
+      'X-API-KEY': ['123456', '7890'],
+      'TCN': ['abc', 'def'],
+      'TE': ['cde'],
+      'DNS': ['d'],
+      'FOO': ['bar']
+    }
+
+    const originalHeaders = Object.assign({}, event.multiValueHeaders)
+
+    // run the handler
+    handler(event, {}, (_, resultingEvent) => {
+      expect(resultingEvent.multiValueHeaders).toEqual(expectedHeaders)
+      expect(resultingEvent.rawMultiValueHeaders).toEqual(originalHeaders)
+      endTest()
+    })
+  })
+
+  test('It should not fail if the event does not contain multivalue headers', (endTest) => {
+    const handler = middy((event, context, cb) => cb(null, event))
+
+    handler
+      .use(httpHeaderNormalizer({}))
+
+    const event = {
+      foo: 'bar'
+    }
+
+    const expectedEvent = {
+      foo: 'bar'
+    }
+
+    // run the handler
+    handler(event, {}, (_, resultingEvent) => {
+      expect(resultingEvent).toEqual(expectedEvent)
+      expect(resultingEvent.rawMultiValueHeaders).toBeUndefined()
+      endTest()
+    })
+  })
 })

--- a/src/middlewares/httpEventNormalizer.js
+++ b/src/middlewares/httpEventNormalizer.js
@@ -4,6 +4,7 @@ module.exports = () => ({
 
     if (event.hasOwnProperty('httpMethod')) {
       event.queryStringParameters = event.queryStringParameters || {}
+      event.multiValueQueryStringParameters = event.multiValueQueryStringParameters || {}
       event.pathParameters = event.pathParameters || {}
     }
 

--- a/src/middlewares/httpHeaderNormalizer.js
+++ b/src/middlewares/httpHeaderNormalizer.js
@@ -69,6 +69,19 @@ module.exports = (opts) => {
         handler.event.rawHeaders = rawHeaders
       }
 
+      if (handler.event.multiValueHeaders) {
+        const rawHeaders = {}
+        const headers = {}
+
+        Object.keys(handler.event.multiValueHeaders).forEach((key) => {
+          rawHeaders[key] = handler.event.multiValueHeaders[key]
+          headers[options.normalizeHeaderKey(key)] = handler.event.multiValueHeaders[key]
+        })
+
+        handler.event.multiValueHeaders = headers
+        handler.event.rawMultiValueHeaders = rawHeaders
+      }
+
       next()
     }
   })


### PR DESCRIPTION
Updated httpEventNormalizer and httpHeaderNormalizer to support multiValueHeaders/QueryStringParameters. Also updated appropriate tests

Reference: https://aws.amazon.com/blogs/compute/support-for-multi-value-parameters-in-amazon-api-gateway/