### PR TITLE
Typescript typesafe, guards and generics

### DIFF
--- a/middlewares.d.ts
+++ b/middlewares.d.ts
@@ -79,20 +79,20 @@ interface IWarmupOptions {
   onWarmup?: (event: any) => void;
 }
 
-declare function cache(opts?: ICacheOptions): middy.IMiddyMiddlewareObject;
-declare function cors(opts?: ICorsOptions): middy.IMiddyMiddlewareObject;
-declare function doNotWaitForEmptyEventLoop(opts?: IDoNotWaitForEmtpyEventLoopOptions): middy.IMiddyMiddlewareObject;
-declare function httpContentNegotiation(opts?: IHTTPContentNegotiationOptions): middy.IMiddyMiddlewareObject;
-declare function httpErrorHandler(opts?: IHTTPErrorHandlerOptions): middy.IMiddyMiddlewareObject;
-declare function httpEventNormalizer(): middy.IMiddyMiddlewareObject;
-declare function httpHeaderNormalizer(opts?: IHTTPHeaderNormalizerOptions): middy.IMiddyMiddlewareObject;
-declare function httpPartialResponse(opts?: IHTTPPartialResponseOptions): middy.IMiddyMiddlewareObject;
-declare function jsonBodyParser(): middy.IMiddyMiddlewareObject;
-declare function s3KeyNormalizer(): middy.IMiddyMiddlewareObject;
-declare function secretsManager(opts?: ISecretsManagerOptions): middy.IMiddyMiddlewareObject;
-declare function ssm(opts?: ISSMOptions): middy.IMiddyMiddlewareObject;
-declare function validator(opts?: IValidatorOptions): middy.IMiddyMiddlewareObject;
-declare function urlEncodeBodyParser(opts?: IURLEncodeBodyParserOptions): middy.IMiddyMiddlewareObject;
-declare function warmup(opts?: IWarmupOptions): middy.IMiddyMiddlewareObject;
+declare const cache: middy.Middleware<ICacheOptions>;
+declare const cors: middy.Middleware<ICorsOptions>;
+declare const doNotWaitForEmptyEventLoop: middy.Middleware<IDoNotWaitForEmtpyEventLoopOptions>;
+declare const httpContentNegotiation: middy.Middleware<IHTTPContentNegotiationOptions>;
+declare const httpErrorHandler: middy.Middleware<IHTTPErrorHandlerOptions>;
+declare const httpEventNormalizer: middy.Middleware<never>;
+declare const httpHeaderNormalizer: middy.Middleware<IHTTPHeaderNormalizerOptions>;
+declare const httpPartialResponse: middy.Middleware<IHTTPPartialResponseOptions>;
+declare const jsonBodyParser: middy.Middleware<never>;
+declare const s3KeyNormalizer: middy.Middleware<never>;
+declare const secretsManager: middy.Middleware<ISecretsManagerOptions>;
+declare const ssm: middy.Middleware<ISSMOptions>;
+declare const validator: middy.Middleware<IValidatorOptions>;
+declare const urlEncodeBodyParser: middy.Middleware<IURLEncodeBodyParserOptions>;
+declare const warmup: middy.Middleware<IWarmupOptions>;
 
 export as namespace middlewares;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.20.5",
+  "version": "0.21.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.20.5",
+  "version": "0.21.0",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
   "files": [

--- a/src/__tests__/middy.types.ts
+++ b/src/__tests__/middy.types.ts
@@ -39,7 +39,7 @@ describe('🛵  Middy types test suite', () => {
     const handler = middy(jest.fn());
 
      handler
-      .use(middleware)
+      .use(middleware())
       .after(after)
       .before(before)
       .onError(onError);


### PR DESCRIPTION
As per #275, it's a breaking change for people using Typescript, but it's as safe as it gets. the usage is 

```ts
import { APIGatewayProxyHandler, Context } from 'aws-lambda'

interface CustomContext extends Context {
  haha?: boolean // needs ? because doesn't exist in original context when TS tries to infer the type
}

const get = middy<APIGatewayProxyHandler>( async (event, context: CustomContext) => {
  return {
    statusCode: 200,
    body: ''
  }
}).use(cors()).after((s, next) => { s.context; next() })
```

since it's a breaking change (for the types only), renamed the interfaces to force people rewrite it

custom data on "event" would then be:

```ts
import { Handler, APIGatewayProxyEvent, Context } from 'aws-lambda'

middy<Handler<APIGatewayProxyEvent & { extra: string, field: string }, {}>>( async (event, context: CustomContext) => {
  event.extra
  event.field
  return {
  }
})
```
this way, the event can append data from middlewares that modify the event object, like `httpContentNegotiation` for example, that adds `preferredEncoding`, etc, to the event