### PR TITLE
Add default export to ssm middleware

### DIFF
--- a/packages/secrets-manager/index.d.ts
+++ b/packages/secrets-manager/index.d.ts
@@ -10,3 +10,5 @@ interface ISecretsManagerOptions {
 }
 
 declare function secretsManager(opts?: ISecretsManagerOptions): middy.IMiddyMiddlewareObject;
+
+export default secretsManager

--- a/packages/ssm/index.d.ts
+++ b/packages/ssm/index.d.ts
@@ -12,3 +12,5 @@ interface ISSMOptions {
 }
 
 declare function ssm(opts?: ISSMOptions): middy.IMiddyMiddlewareObject;
+
+export default ssm


### PR DESCRIPTION
This seems to be an oversight - the other middlewares have it, and ssm not having it breaks TypeScript imports