### PR TITLE
Add types for httpSecurityHeaders

### DIFF
--- a/middlewares.d.ts
+++ b/middlewares.d.ts
@@ -79,6 +79,37 @@ interface IWarmupOptions {
   onWarmup?: (event: any) => void;
 }
 
+interface IHTTPSecurityHeadersOptions {
+  dnsPrefetchControl?: {
+    allow?: Boolean
+  },
+  expectCT?: {
+    enforce?: Boolean,
+    maxAge?: Number
+  },
+  frameguard?: {
+    action?: String
+  },
+  hidePoweredBy?: {
+    setTo: String
+  },
+  hsts?: {
+    maxAge?: Number,
+    includeSubDomains?: Boolean,
+    preload?: Boolean
+  },
+  ieNoOpen?: {
+    action?: String
+  },
+  noSniff?: {
+    action?: String
+  },
+  referrerPolicy?: {
+    policy?: String
+  },
+  xssFilter?: Object
+}
+
 declare const cache: middy.Middleware<ICacheOptions>;
 declare const cors: middy.Middleware<ICorsOptions>;
 declare const doNotWaitForEmptyEventLoop: middy.Middleware<IDoNotWaitForEmtpyEventLoopOptions>;
@@ -94,5 +125,6 @@ declare const ssm: middy.Middleware<ISSMOptions>;
 declare const validator: middy.Middleware<IValidatorOptions>;
 declare const urlEncodeBodyParser: middy.Middleware<IURLEncodeBodyParserOptions>;
 declare const warmup: middy.Middleware<IWarmupOptions>;
+declare const httpSecurityHeaders: middy.Middleware<IHTTPSecurityHeadersOptions>;
 
 export as namespace middlewares;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.22.2",
+  "version": "0.23.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.22.2",
+  "version": "0.23.0",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
   "files": [


### PR DESCRIPTION
I noticed the types for **httpSecurityHeaders** is added in 1.0.0-alpha but not master, so just do it to make it work for now.