### PR TITLE
caseless headers in CORS middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "ajv": "^6.9.1",
     "ajv-i18n": "^3.4.0",
     "ajv-keywords": "^3.4.0",
+    "caseless": "^0.12.0",
     "content-type": "^1.0.4",
     "http-errors": "^1.7.1",
     "json-mask": "^0.3.8",

--- a/src/middlewares/__tests__/cors.js
+++ b/src/middlewares/__tests__/cors.js
@@ -22,6 +22,29 @@ describe('📦 Middleware CORS', () => {
     })
   })
 
+  test('Access-Control-Allow-Origin header should default to origin header in request when options.origin is "*"', () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, {})
+    })
+
+    handler.use(cors())
+
+    const event = {
+      httpMethod: 'GET',
+      headers: {
+        origin: 'http://example.com'
+      }
+    }
+
+    handler(event, {}, (_, response) => {
+      expect(response).toEqual({
+        headers: {
+          'Access-Control-Allow-Origin': 'http://example.com'
+        }
+      })
+    })
+  })
+
   test('It should not override already declared Access-Control-Allow-Origin header', () => {
     const handler = middy((event, context, cb) => {
       cb(null, {
@@ -46,7 +69,7 @@ describe('📦 Middleware CORS', () => {
     })
   })
 
-  test('It should use origin specified in options', () => {
+  test('It should use origin specified in options when there is no Origin header in request', () => {
     const handler = middy((event, context, cb) => {
       cb(null, {})
     })
@@ -70,6 +93,61 @@ describe('📦 Middleware CORS', () => {
     })
   })
 
+  test('It should use origin specified in options when it is not matched to options.origin', () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, {})
+    })
+
+    handler.use(
+      cors({
+        origin: 'https://example.com'
+      })
+    )
+
+    const event = {
+      httpMethod: 'GET',
+      headers: {
+        origin: 'https://origin-example.com'
+      }
+    }
+
+    handler(event, {}, (_, response) => {
+      expect(response).toEqual({
+        headers: {
+          'Access-Control-Allow-Origin': 'https://example.com'
+        }
+      })
+    })
+  })
+
+  test('It should use origin specified in options.origins when it is not matched to options.origins', () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, {})
+    })
+
+    handler.use(
+      cors({
+        origin: 'https://example.com',
+        origins: ['https://second-example.com']
+      })
+    )
+
+    const event = {
+      httpMethod: 'GET',
+      headers: {
+        origin: 'https://origin-example.com'
+      }
+    }
+
+    handler(event, {}, (_, response) => {
+      expect(response).toEqual({
+        headers: {
+          'Access-Control-Allow-Origin': 'https://second-example.com'
+        }
+      })
+    })
+  })
+
   test('It should return whitelisted origin', () => {
     const handler = middy((event, context, cb) => {
       cb(null, {})
@@ -83,7 +161,9 @@ describe('📦 Middleware CORS', () => {
 
     const event = {
       httpMethod: 'GET',
-      headers: { Origin: 'https://another-example.com' }
+      headers: {
+        Origin: 'https://another-example.com'
+      }
     }
 
     handler(event, {}, (_, response) => {
@@ -108,7 +188,9 @@ describe('📦 Middleware CORS', () => {
 
     const event = {
       httpMethod: 'GET',
-      headers: { Origin: 'https://unknown.com' }
+      headers: {
+        Origin: 'https://unknown.com'
+      }
     }
 
     handler(event, {}, (_, response) => {

--- a/src/middlewares/__tests__/cors.js
+++ b/src/middlewares/__tests__/cors.js
@@ -24,20 +24,13 @@ describe('📦 Middleware CORS', () => {
 
   test('It should not override already declared Access-Control-Allow-Origin header', () => {
     const handler = middy((event, context, cb) => {
-      cb(null, {})
+      cb(null, {
+        headers: {
+          'Access-Control-Allow-Origin': 'https://example.com'
+        }
+      })
     })
 
-    // other middleware that puts the cors header
-    handler.use({
-      after: (handler, next) => {
-        handler.response = {
-          headers: {
-            'Access-Control-Allow-Origin': 'https://example.com'
-          }
-        }
-        next()
-      }
-    })
     handler.use(cors())
 
     const event = {
@@ -90,7 +83,7 @@ describe('📦 Middleware CORS', () => {
 
     const event = {
       httpMethod: 'GET',
-      headers: { Origin: 'https://another-example.com' }
+      headers: {Origin: 'https://another-example.com'}
     }
 
     handler(event, {}, (_, response) => {
@@ -115,7 +108,7 @@ describe('📦 Middleware CORS', () => {
 
     const event = {
       httpMethod: 'GET',
-      headers: { Origin: 'https://unknown.com' }
+      headers: {Origin: 'https://unknown.com'}
     }
 
     handler(event, {}, (_, response) => {
@@ -153,20 +146,13 @@ describe('📦 Middleware CORS', () => {
 
   test('It should not override already declared Access-Control-Allow-Headers header', () => {
     const handler = middy((event, context, cb) => {
-      cb(null, {})
+      cb(null, {
+        headers: {
+          'Access-Control-Allow-Headers': 'x-example'
+        }
+      })
     })
 
-    // other middleware that puts the cors header
-    handler.use({
-      after: (handler, next) => {
-        handler.response = {
-          headers: {
-            'Access-Control-Allow-Headers': 'x-example'
-          }
-        }
-        next()
-      }
-    })
     handler.use(cors({
       headers: 'x-example-2'
     }))
@@ -212,20 +198,13 @@ describe('📦 Middleware CORS', () => {
 
   test('It should not override already declared Access-Control-Allow-Credentials header as false', () => {
     const handler = middy((event, context, cb) => {
-      cb(null, {})
+      cb(null, {
+        headers: {
+          'Access-Control-Allow-Credentials': 'false'
+        }
+      })
     })
 
-    // other middleware that puts the cors header
-    handler.use({
-      after: (handler, next) => {
-        handler.response = {
-          headers: {
-            'Access-Control-Allow-Credentials': 'false'
-          }
-        }
-        next()
-      }
-    })
     handler.use(
       cors({
         credentials: true
@@ -248,20 +227,13 @@ describe('📦 Middleware CORS', () => {
 
   test('It should not override already declared Access-Control-Allow-Credentials header as true', () => {
     const handler = middy((event, context, cb) => {
-      cb(null, {})
+      cb(null, {
+        headers: {
+          'Access-Control-Allow-Credentials': 'true'
+        }
+      })
     })
 
-    // other middleware that puts the cors header
-    handler.use({
-      after: (handler, next) => {
-        handler.response = {
-          headers: {
-            'Access-Control-Allow-Credentials': 'true'
-          }
-        }
-        next()
-      }
-    })
     handler.use(
       cors({
         credentials: false
@@ -269,17 +241,38 @@ describe('📦 Middleware CORS', () => {
     )
 
     const event = {
-      httpMethod: 'GET',
-      headers: {
-        Origin: 'http://example.com'
-      }
+      httpMethod: 'GET'
     }
 
     handler(event, {}, (_, response) => {
       expect(response).toEqual({
         headers: {
           'Access-Control-Allow-Credentials': 'true',
-          'Access-Control-Allow-Origin': 'http://example.com'
+          'Access-Control-Allow-Origin': '*'
+        }
+      })
+    })
+  })
+
+  test('It should use change credentials as specified in options (false)', () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, {})
+    })
+
+    handler.use(
+      cors({
+        credentials: false
+      })
+    )
+
+    const event = {
+      httpMethod: 'GET'
+    }
+
+    handler(event, {}, (_, response) => {
+      expect(response).toEqual({
+        headers: {
+          'Access-Control-Allow-Origin': '*'
         }
       })
     })
@@ -297,17 +290,14 @@ describe('📦 Middleware CORS', () => {
     )
 
     const event = {
-      httpMethod: 'GET',
-      headers: {
-        Origin: 'http://example.com'
-      }
+      httpMethod: 'GET'
     }
 
     handler(event, {}, (_, response) => {
       expect(response).toEqual({
         headers: {
           'Access-Control-Allow-Credentials': 'true',
-          'Access-Control-Allow-Origin': 'http://example.com'
+          'Access-Control-Allow-Origin': '*'
         }
       })
     })

--- a/src/middlewares/__tests__/cors.js
+++ b/src/middlewares/__tests__/cors.js
@@ -83,7 +83,7 @@ describe('📦 Middleware CORS', () => {
 
     const event = {
       httpMethod: 'GET',
-      headers: {Origin: 'https://another-example.com'}
+      headers: { Origin: 'https://another-example.com' }
     }
 
     handler(event, {}, (_, response) => {
@@ -108,7 +108,7 @@ describe('📦 Middleware CORS', () => {
 
     const event = {
       httpMethod: 'GET',
-      headers: {Origin: 'https://unknown.com'}
+      headers: { Origin: 'https://unknown.com' }
     }
 
     handler(event, {}, (_, response) => {

--- a/src/middlewares/cors.js
+++ b/src/middlewares/cors.js
@@ -1,3 +1,5 @@
+const caseless = require('caseless')
+
 const defaults = {
   origin: '*',
   origins: [],
@@ -7,43 +9,42 @@ const defaults = {
 
 const getOrigin = (options, handler) => {
   handler.event.headers = handler.event.headers || {}
+  const eventHeaders = caseless(handler.event.headers)
+
   if (options.origins && options.origins.length > 0) {
-    if (handler.event.headers.hasOwnProperty('Origin') && options.origins.includes(handler.event.headers.Origin)) {
-      return handler.event.headers.Origin
+    if (eventHeaders.get('Origin') && options.origins.includes(eventHeaders.get('Origin'))) {
+      return eventHeaders.get('Origin')
     } else {
       return options.origins[0]
     }
   } else {
-    if (handler.event.headers.hasOwnProperty('Origin') && options.credentials && options.origin === '*') {
-      return handler.event.headers.Origin
+    if (eventHeaders.get('Origin') && options.origin === '*') {
+      return eventHeaders.get('Origin')
     }
     return options.origin
   }
 }
 
 const addCorsHeaders = (opts, handler, next) => {
-  const options = Object.assign({}, defaults, opts)
-
   if (handler.event.hasOwnProperty('httpMethod')) {
     handler.response = handler.response || {}
     handler.response.headers = handler.response.headers || {}
 
+    const responseHeaders = caseless(handler.response.headers)
+    const options = Object.assign({}, defaults, opts)
+
     // Check if already setup Access-Control-Allow-Headers
-    if (options.headers !== null && !handler.response.headers.hasOwnProperty('Access-Control-Allow-Headers')) {
-      handler.response.headers['Access-Control-Allow-Headers'] = options.headers
+    if (options.headers !== null && !responseHeaders.has('Access-Control-Allow-Headers')) {
+      responseHeaders.set('Access-Control-Allow-Headers', options.headers)
     }
 
-    // Check if already setup the header Access-Control-Allow-Credentials
-    if (handler.response.headers.hasOwnProperty('Access-Control-Allow-Credentials')) {
-      options.credentials = JSON.parse(handler.response.headers['Access-Control-Allow-Credentials'])
+    if (!responseHeaders.has('Access-Control-Allow-Credentials') && Boolean(options.credentials)) {
+      responseHeaders.set('Access-Control-Allow-Credentials', 'true')
     }
 
-    if (options.credentials) {
-      handler.response.headers['Access-Control-Allow-Credentials'] = String(options.credentials)
-    }
     // Check if already setup the header Access-Control-Allow-Origin
-    if (!handler.response.headers.hasOwnProperty('Access-Control-Allow-Origin')) {
-      handler.response.headers['Access-Control-Allow-Origin'] = getOrigin(options, handler)
+    if (!responseHeaders.has('Access-Control-Allow-Origin')) {
+      responseHeaders.set('Access-Control-Allow-Origin', getOrigin(options, handler))
     }
   }
 


### PR DESCRIPTION
- http headers attributes are *case insensitive* and it can be different by browsers. 
- For example Chrome using *origin* and Firefox is using *Origin*. 
- I think we should not force developer to use another middleware before CORS middleware.

CHANGES:
- Using `caseless` package to `get` or `set` the header attributes.
- update unit tests
- if `headers.Origin` is provided and `options.origin` is equal to `*`, middleware returns `headers.Origin` as `origin` attribute. ( options.credentials is not important to the value of `headers.Origin`, please correct me if I am wrong )

Remaining Tasks:
- Document how default options `origin` and `origins` are working and which one has higher priority
- Document when handler returns any CORS attribute, then middleware won't update that attribute
- Document `Access-Control-Allow-Credentials` options