### PR TITLE
Prevent Cors middleware swallowing errors

### DIFF
--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -90,6 +90,11 @@ Sets headers in `after` and `onError` phases.
 - `headers` (string) (optional): value to put in Access-Control-Allow-Headers (default: `null`)
 - `credentials` (bool) (optional): if true, sets the `Access-Control-Allow-Origin` as request header `Origin`, if present (default `false`)
 
+NOTES:
+
+- When used with `httpErrorHandler` middleware, ensure to use the `httpErrorHandler` middleware before `cors` to avoid 
+the loss of CORS headers 
+
 ### Sample usage
 
 ```javascript

--- a/src/middlewares/__tests__/cors.js
+++ b/src/middlewares/__tests__/cors.js
@@ -132,6 +132,10 @@ describe('📦 Middleware CORS', () => {
       throw new Error('')
     })
 
+    handler.use({
+      onError: (handler, next) => next()
+    })
+
     handler.use(
       cors({
         origin: 'https://example.com'
@@ -151,9 +155,28 @@ describe('📦 Middleware CORS', () => {
     })
   })
 
+  test('It should not swallow errors', () => {
+    const handler = middy((event, context, cb) => {
+      throw new Error('some-error')
+    })
+
+    handler.use(
+      cors()
+    )
+
+    handler({}, {}, (error, response) => {
+      expect(response).toBe(undefined)
+      expect(error.message).toEqual('some-error')
+    })
+  })
+
   test('It should not override already declared Access-Control-Allow-Headers header', () => {
     const handler = middy((event, context, cb) => {
       cb(null, {})
+    })
+
+    handler.use({
+      onError: (handler, next) => next()
     })
 
     // other middleware that puts the cors header
@@ -215,6 +238,9 @@ describe('📦 Middleware CORS', () => {
       cb(null, {})
     })
 
+    handler.use({
+      onError: (handler, next) => next()
+    })
     // other middleware that puts the cors header
     handler.use({
       after: (handler, next) => {
@@ -251,6 +277,9 @@ describe('📦 Middleware CORS', () => {
       cb(null, {})
     })
 
+    handler.use({
+      onError: (handler, next) => next()
+    })
     // other middleware that puts the cors header
     handler.use({
       after: (handler, next) => {

--- a/src/middlewares/__tests__/cors.js
+++ b/src/middlewares/__tests__/cors.js
@@ -176,6 +176,7 @@ describe('📦 Middleware CORS', () => {
     const handler = middy((event, context, cb) => {
       cb(null, {})
     })
+
     // other middleware that puts the cors header
     handler.use({
       after: (handler, next) => {
@@ -239,6 +240,7 @@ describe('📦 Middleware CORS', () => {
     const handler = middy((event, context, cb) => {
       cb(null, {})
     })
+
     // other middleware that puts the cors header
     handler.use({
       after: (handler, next) => {
@@ -279,6 +281,7 @@ describe('📦 Middleware CORS', () => {
     const handler = middy((event, context, cb) => {
       cb(null, {})
     })
+
     // other middleware that puts the cors header
     handler.use({
       after: (handler, next) => {

--- a/src/middlewares/__tests__/cors.js
+++ b/src/middlewares/__tests__/cors.js
@@ -132,15 +132,17 @@ describe('📦 Middleware CORS', () => {
       throw new Error('')
     })
 
-    handler.use({
-      onError: (handler, next) => next()
-    })
-
     handler.use(
       cors({
         origin: 'https://example.com'
       })
     )
+
+    handler.use({
+      onError: (handler, next) => {
+        next()
+      }
+    })
 
     const event = {
       httpMethod: 'GET'
@@ -174,11 +176,6 @@ describe('📦 Middleware CORS', () => {
     const handler = middy((event, context, cb) => {
       cb(null, {})
     })
-
-    handler.use({
-      onError: (handler, next) => next()
-    })
-
     // other middleware that puts the cors header
     handler.use({
       after: (handler, next) => {
@@ -193,6 +190,11 @@ describe('📦 Middleware CORS', () => {
     handler.use(cors({
       headers: 'x-example-2'
     }))
+    handler.use({
+      onError: (handler, next) => {
+        next()
+      }
+    })
 
     const event = {
       httpMethod: 'GET'
@@ -237,10 +239,6 @@ describe('📦 Middleware CORS', () => {
     const handler = middy((event, context, cb) => {
       cb(null, {})
     })
-
-    handler.use({
-      onError: (handler, next) => next()
-    })
     // other middleware that puts the cors header
     handler.use({
       after: (handler, next) => {
@@ -257,6 +255,11 @@ describe('📦 Middleware CORS', () => {
         credentials: true
       })
     )
+    handler.use({
+      onError: (handler, next) => {
+        next()
+      }
+    })
 
     const event = {
       httpMethod: 'GET'
@@ -276,10 +279,6 @@ describe('📦 Middleware CORS', () => {
     const handler = middy((event, context, cb) => {
       cb(null, {})
     })
-
-    handler.use({
-      onError: (handler, next) => next()
-    })
     // other middleware that puts the cors header
     handler.use({
       after: (handler, next) => {
@@ -296,6 +295,11 @@ describe('📦 Middleware CORS', () => {
         credentials: false
       })
     )
+    handler.use({
+      onError: (handler, next) => {
+        next()
+      }
+    })
 
     const event = {
       httpMethod: 'GET',

--- a/src/middlewares/cors.js
+++ b/src/middlewares/cors.js
@@ -47,7 +47,7 @@ const addCorsHeaders = (opts, handler, next) => {
     }
   }
 
-  next()
+  next(handler.error)
 }
 
 module.exports = (opts) => ({

--- a/src/middlewares/httpErrorHandler.js
+++ b/src/middlewares/httpErrorHandler.js
@@ -7,21 +7,17 @@ module.exports = (opts) => {
 
   return ({
     onError: (handler, next) => {
-      if (typeof options.logger === 'function') {
-        options.logger(handler.error)
-      }
-
-      handler.response = handler.response || {}
       if (handler.error.constructor.super_ && handler.error.constructor.super_.name === 'HttpError') {
+        if (typeof options.logger === 'function') {
+          options.logger(handler.error)
+        }
+
         handler.response = {
           statusCode: handler.error.statusCode,
           body: handler.error.message
         }
 
         return next()
-      } else {
-        handler.response.statusCode = 502
-        handler.response.body = JSON.stringify({ message: 'Internal server error' })
       }
 
       return next(handler.error)

--- a/src/middlewares/httpErrorHandler.js
+++ b/src/middlewares/httpErrorHandler.js
@@ -7,17 +7,21 @@ module.exports = (opts) => {
 
   return ({
     onError: (handler, next) => {
-      if (handler.error.constructor.super_ && handler.error.constructor.super_.name === 'HttpError') {
-        if (typeof options.logger === 'function') {
-          options.logger(handler.error)
-        }
+      if (typeof options.logger === 'function') {
+        options.logger(handler.error)
+      }
 
+      handler.response = handler.response || {}
+      if (handler.error.constructor.super_ && handler.error.constructor.super_.name === 'HttpError') {
         handler.response = {
           statusCode: handler.error.statusCode,
           body: handler.error.message
         }
 
         return next()
+      } else {
+        handler.response.statusCode = 502
+        handler.response.body = JSON.stringify({ message: 'Internal server error' })
       }
 
       return next(handler.error)


### PR DESCRIPTION
Fixes #264 

Stumbled upon an issue this morning where we found that by using the `cors` middleware with `onError`, errors are not being passed here: 


https://github.com/middyjs/middy/blob/1d04aefd2a5cc8b16e3820bc0ca1d0654c3d3d92/src/middlewares/cors.js#L50

resulting in success callbacks and response of 200 empty body.

When used with other middlewares such as the `httpErrorHandler`, the non-http errors do not have a chance to be converted to an http response and are passed along and when using in addition with `cors`, the error is swallowed and the callback is called without an error resulting in a 200 response with an empty body.

This change allows any errors to be passed to the next middleware by `cors` if any and gives the user a chance to handle the error or if there is no further middleware in the chain, it will bubble up to the `terminate()` and callback correctly with an error here: 

https://github.com/middyjs/middy/blob/1d04aefd2a5cc8b16e3820bc0ca1d0654c3d3d92/src/middy.js#L152

instead of here:

https://github.com/middyjs/middy/blob/1d04aefd2a5cc8b16e3820bc0ca1d0654c3d3d92/src/middy.js#L155

The only problematic issue I see is the loss of cors headers if other middlewares do not handle the error after `cors`. Thoughts? The tests have also been updated to reflect this.