### PR TITLE
1.0.0-alpha - Fix relative path that breaks TS compile

### DIFF
--- a/packages/secrets-manager/index.d.ts
+++ b/packages/secrets-manager/index.d.ts
@@ -1,5 +1,5 @@
 import { SecretsManager } from 'aws-sdk'
-import middy from '../core'
+import middy from '@middy/core'
 
 interface ISecretsManagerOptions {
   cache?: boolean;


### PR DESCRIPTION
In the Secrets Manager middleware, there is a relative path in the index.d.ts file to middy core. While this probably works in a traditional npm/yarn project, when using yarn workspaces in a mono repo, it cannot be guaranteed that middy core will be installed right along side this plugin.

For example in my project I end up with the following structure:

|- /node_modules
|-- /@middy
|---- /core
|- /services
|-- /service-a
|---- /node_modules
|------ /@middy
|-------- /secrets-manager
|---- package.json
|- package.json