### PR TITLE
Make ICorsOptions fields optional

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.0.0-alpha.28"
+  "version": "1.0.0-alpha.29"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy-monorepo",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy-monorepo",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.29",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "engines": {
     "node": ">=6.10"

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/cache",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.29",
   "description": "Cache middleware for the middy framework",
   "engines": {
     "node": ">=6.10"

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/core",
-	"version": "1.0.0-alpha.27",
+	"version": "1.0.0-alpha.28",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/core",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.29",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda (core package)",
   "engines": {
     "node": ">=6.10"

--- a/packages/do-not-wait-for-empty-event-loop/package.json
+++ b/packages/do-not-wait-for-empty-event-loop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/do-not-wait-for-empty-event-loop",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.29",
   "description": "Middleware for the middy framework that allows to easily disable the wait for empty event loop in a Lambda function",
   "engines": {
     "node": ">=6.10"

--- a/packages/error-logger/package-lock.json
+++ b/packages/error-logger/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/error-logger",
-	"version": "1.0.0-alpha.27",
+	"version": "1.0.0-alpha.28",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/error-logger/package.json
+++ b/packages/error-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/error-logger",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.29",
   "description": "Input and output logger middleware for the middy framework",
   "engines": {
     "node": ">=6.10"

--- a/packages/function-shield/package-lock.json
+++ b/packages/function-shield/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/function-shield",
-	"version": "1.0.0-alpha.27",
+	"version": "1.0.0-alpha.28",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/function-shield/package.json
+++ b/packages/function-shield/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/function-shield",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.29",
   "description": "Hardens AWS Lambda execution environment",
   "engines": {
     "node": ">=6.10"

--- a/packages/http-content-negotiation/package-lock.json
+++ b/packages/http-content-negotiation/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/http-content-negotiation",
-	"version": "1.0.0-alpha.27",
+	"version": "1.0.0-alpha.28",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-content-negotiation/package.json
+++ b/packages/http-content-negotiation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-content-negotiation",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.29",
   "description": "Http content negotiation middleware for the middy framework",
   "engines": {
     "node": ">=6.10"

--- a/packages/http-cors/index.d.ts
+++ b/packages/http-cors/index.d.ts
@@ -1,10 +1,10 @@
 import middy from '../core'
 
 interface ICorsOptions {
-  origin: string;
+  origin?: string;
   origins?: string[];
-  headers: string;
-  credentials: boolean;
+  headers?: string;
+  credentials?: boolean;
 }
 
 declare function cors(opts?: ICorsOptions): middy.IMiddyMiddlewareObject;

--- a/packages/http-cors/package.json
+++ b/packages/http-cors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-cors",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.29",
   "description": "CORS (Cross-Origin Resource Sharing) middleware for the middy framework",
   "engines": {
     "node": ">=6.10"

--- a/packages/http-error-handler/package-lock.json
+++ b/packages/http-error-handler/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/http-error-handler",
-	"version": "1.0.0-alpha.27",
+	"version": "1.0.0-alpha.28",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-error-handler/package.json
+++ b/packages/http-error-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-error-handler",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.29",
   "description": "Http error handler middleware for the middy framework",
   "engines": {
     "node": ">=6.10"

--- a/packages/http-event-normalizer/package.json
+++ b/packages/http-event-normalizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-event-normalizer",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.29",
   "description": "Http event normalizer middleware for the middy framework",
   "engines": {
     "node": ">=6.10"

--- a/packages/http-header-normalizer/package.json
+++ b/packages/http-header-normalizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-header-normalizer",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.29",
   "description": "Http header normalizer middleware for the middy framework",
   "engines": {
     "node": ">=6.10"

--- a/packages/http-json-body-parser/package-lock.json
+++ b/packages/http-json-body-parser/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/http-json-body-parser",
-	"version": "1.0.0-alpha.27",
+	"version": "1.0.0-alpha.28",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-json-body-parser/package.json
+++ b/packages/http-json-body-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-json-body-parser",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.29",
   "description": "Http JSON body parser middleware for the middy framework",
   "engines": {
     "node": ">=6.10"

--- a/packages/http-partial-response/package-lock.json
+++ b/packages/http-partial-response/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/http-partial-response",
-	"version": "1.0.0-alpha.27",
+	"version": "1.0.0-alpha.28",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-partial-response/package.json
+++ b/packages/http-partial-response/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-partial-response",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.29",
   "description": "Http partial response middleware for the middy framework",
   "engines": {
     "node": ">=6.10"

--- a/packages/http-response-serializer/package-lock.json
+++ b/packages/http-response-serializer/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/http-response-serializer",
-	"version": "1.0.0-alpha.27",
+	"version": "1.0.0-alpha.28",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-response-serializer/package.json
+++ b/packages/http-response-serializer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-response-serializer",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.29",
   "description": "Http response serializer middleware for the middy framework",
   "engines": {
     "node": ">=6.10"

--- a/packages/http-security-header/package.json
+++ b/packages/http-security-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-security-header",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.29",
   "description": "Applies best practice security headers to responses. It's a simplified port of HelmetJS",
   "engines": {
     "node": ">=6.10"

--- a/packages/http-urlencode-body-parser/package-lock.json
+++ b/packages/http-urlencode-body-parser/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/http-urlencode-body-parser",
-	"version": "1.0.0-alpha.27",
+	"version": "1.0.0-alpha.28",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-urlencode-body-parser/package.json
+++ b/packages/http-urlencode-body-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-urlencode-body-parser",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.29",
   "description": "Urlencode body parser middleware for the middy framework",
   "engines": {
     "node": ">=6.10"

--- a/packages/input-output-logger/package-lock.json
+++ b/packages/input-output-logger/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/input-output-logger",
-	"version": "1.0.0-alpha.27",
+	"version": "1.0.0-alpha.28",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/input-output-logger/package.json
+++ b/packages/input-output-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/input-output-logger",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.29",
   "description": "Input and output logger middleware for the middy framework",
   "engines": {
     "node": ">=6.10"

--- a/packages/s3-key-normalizer/package.json
+++ b/packages/s3-key-normalizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/s3-key-normalizer",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.29",
   "description": "S3 key normalizer middleware for the middy framework",
   "engines": {
     "node": ">=6.10"

--- a/packages/secrets-manager/package-lock.json
+++ b/packages/secrets-manager/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/secrets-manager",
-	"version": "1.0.0-alpha.27",
+	"version": "1.0.0-alpha.28",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/secrets-manager/package.json
+++ b/packages/secrets-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/secrets-manager",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.29",
   "description": "Secrets Manager middleware for the middy framework",
   "engines": {
     "node": ">=6.10"

--- a/packages/ssm/package-lock.json
+++ b/packages/ssm/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/ssm",
-	"version": "1.0.0-alpha.27",
+	"version": "1.0.0-alpha.28",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/ssm/package.json
+++ b/packages/ssm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/ssm",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.29",
   "description": "SSM (EC2 Systems Manager) parameters middleware for the middy framework",
   "engines": {
     "node": ">=6.10"

--- a/packages/validator/package-lock.json
+++ b/packages/validator/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/validator",
-	"version": "1.0.0-alpha.27",
+	"version": "1.0.0-alpha.28",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/validator",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.29",
   "description": "Validator middleware for the middy framework",
   "engines": {
     "node": ">=6.10"

--- a/packages/warmup/package.json
+++ b/packages/warmup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/warmup",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.29",
   "description": "Warmup (cold start mitigation) middleware for the middy framework",
   "engines": {
     "node": ">=6.10"


### PR DESCRIPTION
None of these fields are required when using the `http-cors` module but the type doesn't reflect that and forces users consuming the API via TypeScript to either cast their type to any or fill in the default values manually.

Looking at other middleware options it appears as if they all follow the same pattern of marking most fields as optional.