### PR TITLE
Bug fix: Allow multiple environment variables to be set to the same SSM parameter via name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
   "files": [

--- a/src/middlewares/__tests__/ssm.js
+++ b/src/middlewares/__tests__/ssm.js
@@ -393,7 +393,7 @@ describe('🔒 SSM Middleware', () => {
     })
   })
 
-  test('It should allow multiple environment variables to point at the same SSM path', (done) => {
+  test('It should allow multiple option names to point at the same SSM path', (done) => {
     testScenario({
       ssmMockResponses: [
         {
@@ -408,8 +408,6 @@ describe('🔒 SSM Middleware', () => {
       },
       callbacks: [
         () => {
-          console.log('first one: ', process.env.KEY_NAME_1)
-          console.log('second one: ', process.env.KEY_NAME_2)
           expect(process.env.KEY_NAME_1).toEqual('key-value')
           expect(process.env.KEY_NAME_2).toEqual('key-value')
         }

--- a/src/middlewares/__tests__/ssm.js
+++ b/src/middlewares/__tests__/ssm.js
@@ -397,21 +397,21 @@ describe('🔒 SSM Middleware', () => {
     testScenario({
       ssmMockResponses: [
         {
-          Parameters: [{ Name: '/dev/service_name/key_name1', Value: 'key-value1' }]
+          Parameters: [{ Name: '/dev/service_name/key_name', Value: 'key-value' }]
         }
       ],
       middlewareOptions: {
         names: {
-          KEY_NAME_1: '/dev/service_name/key_name1',
-          KEY_NAME_2: '/dev/service_name/key_name2'
+          KEY_NAME_1: '/dev/service_name/key_name',
+          KEY_NAME_2: '/dev/service_name/key_name'
         }
       },
       callbacks: [
         () => {
           console.log('first one: ', process.env.KEY_NAME_1)
           console.log('second one: ', process.env.KEY_NAME_2)
-          expect(process.env.KEY_NAME_1).toEqual('key-value1')
-          expect(process.env.KEY_NAME_2).toEqual('key-value2')
+          expect(process.env.KEY_NAME_1).toEqual('key-value')
+          expect(process.env.KEY_NAME_2).toEqual('key-value')
         }
       ],
       done

--- a/src/middlewares/__tests__/ssm.js
+++ b/src/middlewares/__tests__/ssm.js
@@ -392,4 +392,29 @@ describe('🔒 SSM Middleware', () => {
       done
     })
   })
+
+  test('It should allow multiple environment variables to point at the same SSM path', (done) => {
+    testScenario({
+      ssmMockResponses: [
+        {
+          Parameters: [{ Name: '/dev/service_name/key_name1', Value: 'key-value1' }]
+        }
+      ],
+      middlewareOptions: {
+        names: {
+          KEY_NAME_1: '/dev/service_name/key_name1',
+          KEY_NAME_2: '/dev/service_name/key_name2'
+        }
+      },
+      callbacks: [
+        () => {
+          console.log('first one: ', process.env.KEY_NAME_1)
+          console.log('second one: ', process.env.KEY_NAME_2)
+          expect(process.env.KEY_NAME_1).toEqual('key-value1')
+          expect(process.env.KEY_NAME_2).toEqual('key-value2')
+        }
+      ],
+      done
+    })
+  })
 })

--- a/src/middlewares/ssm.js
+++ b/src/middlewares/ssm.js
@@ -56,7 +56,6 @@ module.exports = opts => {
         },
         []
       )
-
       const ssmParamNames = getSSMParamValues(options.names)
       if (ssmParamNames.length) {
         const ssmPromise = ssmInstance
@@ -149,7 +148,7 @@ const getTargetObjectToAssign = (handler, options) =>
   options.setToContext ? handler.context : process.env
 
 const getSSMParamValues = userParamsMap =>
-  Object.keys(userParamsMap).map(key => userParamsMap[key])
+  [...new Set(Object.keys(userParamsMap).map(key => userParamsMap[key]))]
 
 /**
  * Lazily load aws-sdk and initialize SSM constructor

--- a/src/middlewares/ssm.js
+++ b/src/middlewares/ssm.js
@@ -191,12 +191,11 @@ const handleInvalidParams = ({ Parameters, InvalidParameters }) => {
  * @return {Object} Merged object for assignment to target object
  */
 const getParamsToAssignByName = (userParamsMap, ssmParams) => {
-  const ssmToUserParamsMap = invertObject(userParamsMap)
-
-  return ssmParams.reduce((aggregator, ssmParam) => {
-    aggregator[ssmToUserParamsMap[ssmParam.Name]] = ssmParam.Value
-    return aggregator
+  return Object.entries(userParamsMap).reduce((acc, [key, value]) => {
+    acc[key] = ssmParams.find(param => param.Name === value).Value
+    return acc
   }, {})
+
 }
 
 /**
@@ -219,8 +218,3 @@ const getParamsToAssignByPath = (
     return aggregator
   }, {})
 
-const invertObject = obj =>
-  Object.keys(obj).reduce((aggregator, key) => {
-    aggregator[obj[key]] = key
-    return aggregator
-  }, {})

--- a/src/middlewares/ssm.js
+++ b/src/middlewares/ssm.js
@@ -191,11 +191,10 @@ const handleInvalidParams = ({ Parameters, InvalidParameters }) => {
  * @return {Object} Merged object for assignment to target object
  */
 const getParamsToAssignByName = (userParamsMap, ssmParams) => {
-  return Object.entries(userParamsMap).reduce((acc, [key, value]) => {
-    acc[key] = ssmParams.find(param => param.Name === value).Value
+  return Object.keys(userParamsMap).reduce((acc, key) => {
+    acc[key] = ssmParams.find(param => param.Name === userParamsMap[key]).Value
     return acc
   }, {})
-
 }
 
 /**
@@ -217,4 +216,3 @@ const getParamsToAssignByPath = (
       ssmParam.Value
     return aggregator
   }, {})
-


### PR DESCRIPTION
The SSM middleware currently has a bug where, when using names to access SSM parameters, the last of multiple names pointing at the same SSM parameter will overwrite the others.

E.g. with the following middleware options, only `KEY_NAME_2` will be set.
```javaScript
names: {
          KEY_NAME_1: '/dev/service_name/key_name',
          KEY_NAME_2: '/dev/service_name/key_name'
}
```

This PR fixes this bug and deduplicates the SSM parameters which are being accessed by name so that in the above scenario, `/dev/service_name/key_name` is fetched exactly once and then set onto both `KEY_NAME_1` and `KEY_NAME_2`.
