### PR TITLE
fix: httpErrorHandler minification type checking

### DIFF
--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -270,11 +270,10 @@ module.exports = { handler }
 
 ## [httpErrorHandler](/src/middlewares/httpErrorHandler.js)
 
-Automatically handles uncaught errors that are created with
-[`http-errors`](https://npm.im/http-errors) and creates a proper HTTP response
-for them (using the message and the status code provided by the error object).
+Automatically handles uncaught errors that contain the properties `statusCode` (number) and `message` (string) and creates a proper HTTP response
+for them (using the message and the status code provided by the error object). We recommend generating these HTTP errors with the npm module [`http-errors`](https://npm.im/http-errors).
 
-It should be set as the last error handler.
+This middleware should be set as the last error handler.
 
 ### Options
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
   "files": [

--- a/src/middlewares/__tests__/httpErrorHandler.js
+++ b/src/middlewares/__tests__/httpErrorHandler.js
@@ -20,6 +20,25 @@ describe('📦 Middleware Http Error Handler', () => {
     })
   })
 
+  test('It should create a response for HTTP errors created with a generic error', () => {
+    const handler = middy((event, context, cb) => {
+      const err = new Error('A server error')
+      err.statusCode = 500
+      throw err
+    })
+
+    handler
+      .use(httpErrorHandler({ logger: false }))
+
+    // run the handler
+    handler({}, {}, (_, response) => {
+      expect(response).toEqual({
+        statusCode: 500,
+        body: 'A server error'
+      })
+    })
+  })
+
   test('It should NOT handle non HTTP errors', () => {
     const handler = middy((event, context, cb) => {
       throw new Error('non-http error')

--- a/src/middlewares/httpErrorHandler.js
+++ b/src/middlewares/httpErrorHandler.js
@@ -1,3 +1,5 @@
+const { HttpError } = require('http-errors')
+
 module.exports = (opts) => {
   const defaults = {
     logger: console.error
@@ -7,7 +9,7 @@ module.exports = (opts) => {
 
   return ({
     onError: (handler, next) => {
-      if (handler.error.constructor.super_ && handler.error.constructor.super_.name === 'HttpError') {
+      if (handler.error instanceof HttpError) {
         if (typeof options.logger === 'function') {
           options.logger(handler.error)
         }

--- a/src/middlewares/httpErrorHandler.js
+++ b/src/middlewares/httpErrorHandler.js
@@ -1,5 +1,3 @@
-const { HttpError } = require('http-errors')
-
 module.exports = (opts) => {
   const defaults = {
     logger: console.error
@@ -9,7 +7,7 @@ module.exports = (opts) => {
 
   return ({
     onError: (handler, next) => {
-      if (handler.error instanceof HttpError) {
+      if (handler.error.statusCode) {
         if (typeof options.logger === 'function') {
           options.logger(handler.error)
         }

--- a/src/middlewares/httpErrorHandler.js
+++ b/src/middlewares/httpErrorHandler.js
@@ -7,7 +7,9 @@ module.exports = (opts) => {
 
   return ({
     onError: (handler, next) => {
-      if (handler.error.statusCode) {
+      // if there are a `statusCode` and an `error` field
+      // this is a valid http error object
+      if (handler.error.statusCode && handler.error.message) {
         if (typeof options.logger === 'function') {
           options.logger(handler.error)
         }


### PR DESCRIPTION
If the code is mangled during minification process when using webpack, the check for a type of `HttpError` in the httpErrorHandler middleware will fail. As the private property on `super_.name` will not be `HttpError`, the mangling would change the name.

This is due to [Terser](https://github.com/webpack-contrib/terser-webpack-plugin) setting both `keep_classnames` and `keep_fnames` to false by default.
Either way it shouldn't really use a private property to check the type of error.

This will close https://github.com/middyjs/middy/issues/325