### PR TITLE
Fix typo in the appetizer in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Let's assume you are building a JSON API to process a payment:
 # handler.js
 
 const middy = require('middy')
-const { urlEncodeBodyParser, validator, httpErrorHandler } = require('middy/middlewares')
+const { jsonBodyParser, validator, httpErrorHandler } = require('middy/middlewares')
 
 // This is your common handler, in no way different than what you are used to doing every day
 // in AWS Lambda
@@ -103,7 +103,7 @@ const inputSchema = {
 
 // Let's "middyfy" our handler, then we will be able to attach middlewares to it
 const handler = middy(processPayment)
-  .use(urlEncodeBodyParser()) // parses the request body when it's a JSON and converts it to an object
+  .use(jsonBodyParser()) // parses the request body when it's a JSON and converts it to an object
   .use(validator({inputSchema})) // validates the input
   .use(httpErrorHandler()) // handles common http errors and returns proper responses
 

--- a/README.md.hb
+++ b/README.md.hb
@@ -66,7 +66,7 @@ Let's assume you are building a JSON API to process a payment:
 # handler.js
 
 const middy = require('middy')
-const { urlEncodeBodyParser, validator, httpErrorHandler } = require('middy/middlewares')
+const { jsonBodyParser, validator, httpErrorHandler } = require('middy/middlewares')
 
 // This is your common handler, in no way different than what you are used to doing every day
 // in AWS Lambda
@@ -103,7 +103,7 @@ const inputSchema = {
 
 // Let's "middyfy" our handler, then we will be able to attach middlewares to it
 const handler = middy(processPayment)
-  .use(urlEncodeBodyParser()) // parses the request body when it's a JSON and converts it to an object
+  .use(jsonBodyParser()) // parses the request body when it's a JSON and converts it to an object
   .use(validator({inputSchema})) // validates the input
   .use(httpErrorHandler()) // handles common http errors and returns proper responses
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
   "files": [


### PR DESCRIPTION
I think the `urlEncodeBodyParser` isn't supposed to be used here. Use `jsonBodyParser` instead.