### PR TITLE
Update warmup.js to work alongside with doNotWaitForEmptyEventLoop

### DIFF
--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -841,6 +841,7 @@ If you use [`serverless-plugin-warmup`](https://www.npmjs.com/package/serverless
 - `isWarmingUp`: a function that accepts the `event` object as a parameter
   and returns `true` if the current event is a warmup event and `false` if it's a regular execution. The default function will check if the `event` object has a `source` property set to `serverless-plugin-warmup`.
 - `onWarmup`: a function that gets executed before the handler exits in case of warmup. By default the function just prints: `Exiting early via warmup Middleware`.
+- `waitForEmptyEventLoop`: a boolean value (`null` by default), that if set will change the current value for `context.callbackWaitsForEmptyEventLoop`. In some circumstances it might be useful to force this value to be `false` to make sure that the lambda quits as early as possible in case of warmup (for instance if you have created a database connection in a previous middleware, this might be hanging and keeping you lambda active until timeout).
 
 ### Sample usage
 

--- a/middlewares.d.ts
+++ b/middlewares.d.ts
@@ -81,6 +81,7 @@ interface IURLEncodeBodyParserOptions {
 interface IWarmupOptions {
   isWarmingUp?: (event: any) => boolean;
   onWarmup?: (event: any) => void;
+  waitForEmptyEventLoop?: boolean;
 }
 
 interface IHTTPSecurityHeadersOptions {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.27.2",
+  "version": "0.28.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.27.2",
+  "version": "0.28.0",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
   "files": [

--- a/src/middlewares/__tests__/warmup.js
+++ b/src/middlewares/__tests__/warmup.js
@@ -75,4 +75,69 @@ describe('🥃 Warmup', () => {
       endTest()
     })
   })
+
+  test(`Should execute handler with callbackWaitsForEmptyEventLoop if waitForEmptyEventLoop true`, (endTest) => {
+    console.log = jest.fn()
+
+    const handler = middy((event, context, cb) => {
+      cb()
+    })
+    handler.use(lambdaIsWarmingUp({
+      waitForEmptyEventLoop: true
+    }))
+
+    const event = {
+      source: 'serverless-plugin-warmup'
+    }
+    const context = {}
+    handler(event, context, (_, response) => {
+      expect(context.callbackWaitsForEmptyEventLoop).toBe(true)
+      expect(response).toBe('warmup')
+      endTest()
+    })
+  })
+
+  test(`Should execute handler with callbackWaitsForEmptyEventLoop if waitForEmptyEventLoop false`, (endTest) => {
+    console.log = jest.fn()
+
+    const handler = middy((event, context, cb) => {
+      cb()
+    })
+    handler.use(lambdaIsWarmingUp({
+      waitForEmptyEventLoop: false
+    }))
+
+    const event = {
+      source: 'serverless-plugin-warmup'
+    }
+    const context = {
+      callbackWaitsForEmptyEventLoop: true
+    }
+    handler(event, context, (_, response) => {
+      expect(context.callbackWaitsForEmptyEventLoop).toBe(false)
+      expect(response).toBe('warmup')
+      endTest()
+    })
+  })
+
+  test(`Should execute handler with callbackWaitsForEmptyEventLoop unchanged if waitForEmptyEventLoop is not set`, (endTest) => {
+    console.log = jest.fn()
+
+    const handler = middy((event, context, cb) => {
+      cb()
+    })
+    handler.use(lambdaIsWarmingUp({}))
+
+    const event = {
+      source: 'serverless-plugin-warmup'
+    }
+    const context = {
+      callbackWaitsForEmptyEventLoop: true
+    }
+    handler(event, context, (_, response) => {
+      expect(context.callbackWaitsForEmptyEventLoop).toBe(true)
+      expect(response).toBe('warmup')
+      endTest()
+    })
+  })
 })

--- a/src/middlewares/warmup.js
+++ b/src/middlewares/warmup.js
@@ -10,6 +10,7 @@ module.exports = (config) => {
     before: (handler, next) => {
       if (options.isWarmingUp(handler.event)) {
         options.onWarmup(handler.event)
+        handler.context.callbackWaitsForEmptyEventLoop = false;
         return handler.callback(null, 'warmup')
       }
 

--- a/src/middlewares/warmup.js
+++ b/src/middlewares/warmup.js
@@ -1,7 +1,8 @@
 module.exports = (config) => {
   const defaults = {
     isWarmingUp: (event) => event.source === 'serverless-plugin-warmup',
-    onWarmup: (event) => console.log('Exiting early via warmup Middleware')
+    onWarmup: (event) => console.log('Exiting early via warmup Middleware'),
+    waitForEmptyEventLoop: null
   }
 
   const options = Object.assign({}, defaults, config)
@@ -10,7 +11,9 @@ module.exports = (config) => {
     before: (handler, next) => {
       if (options.isWarmingUp(handler.event)) {
         options.onWarmup(handler.event)
-        handler.context.callbackWaitsForEmptyEventLoop = false;
+        if (waitForEmptyEventLoop !== null) {
+          handler.context.callbackWaitsForEmptyEventLoop = Boolean(options.waitForEmptyEventLoop);
+        }
         return handler.callback(null, 'warmup')
       }
 

--- a/src/middlewares/warmup.js
+++ b/src/middlewares/warmup.js
@@ -11,8 +11,8 @@ module.exports = (config) => {
     before: (handler, next) => {
       if (options.isWarmingUp(handler.event)) {
         options.onWarmup(handler.event)
-        if (waitForEmptyEventLoop !== null) {
-          handler.context.callbackWaitsForEmptyEventLoop = Boolean(options.waitForEmptyEventLoop);
+        if (options.waitForEmptyEventLoop !== null) {
+          handler.context.callbackWaitsForEmptyEventLoop = Boolean(options.waitForEmptyEventLoop)
         }
         return handler.callback(null, 'warmup')
       }


### PR DESCRIPTION
This is required when using both `warmup` & `doNotWaitForEmptyEventLoop`.