### PR TITLE
Expose types in core TypeScript typings

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -1,46 +1,42 @@
 import { Callback, Context, Handler, ProxyResult } from 'aws-lambda'
 
-type AsyncHandler = (
+export type AsyncHandler = (
   event: any,
   context: Context
 ) => Promise<ProxyResult | object>
 
-declare var middy: {
-(handler: Handler | AsyncHandler): middy.IMiddy
+declare const middy: (handler: Handler | AsyncHandler) => IMiddy
+
+export interface IMiddy extends Handler {
+  use: IMiddyUseFunction
+  before: IMiddyMiddlewareFunction
+  after: IMiddyMiddlewareFunction
+  onError: IMiddyMiddlewareFunction
 }
 
-declare namespace middy {
-  interface IMiddy extends Handler {
-    use: IMiddyUseFunction
-    before: IMiddyMiddlewareFunction
-    after: IMiddyMiddlewareFunction
-    onError: IMiddyMiddlewareFunction
-  }
+export type IMiddyUseFunction = (
+  middlewares?: IMiddyMiddlewareObject | IMiddyMiddlewareObject[]
+) => IMiddy
 
-  type IMiddyUseFunction = (
-    middlewares?: IMiddyMiddlewareObject | IMiddyMiddlewareObject[]
-  ) => IMiddy
+export interface IMiddyMiddlewareObject {
+  before?: IMiddyMiddlewareFunction
+  after?: IMiddyMiddlewareFunction
+  onError?: IMiddyMiddlewareFunction
+}
 
-  interface IMiddyMiddlewareObject {
-    before?: IMiddyMiddlewareFunction
-    after?: IMiddyMiddlewareFunction
-    onError?: IMiddyMiddlewareFunction
-  }
+export type IMiddyMiddlewareFunction = (
+  handler: IHandlerLambda,
+  next: IMiddyNextFunction
+) => void | Promise<any>
 
-  type IMiddyMiddlewareFunction = (
-    handler: IHandlerLambda,
-    next: IMiddyNextFunction
-  ) => void | Promise<any>
+export type IMiddyNextFunction = (error?: any) => void
 
-  type IMiddyNextFunction = (error?: any) => void
-
-  interface IHandlerLambda<T = any, V = object> {
-    event: T
-    context: Context
-    response: V
-    error: Error
-    callback: Callback
-  }
+export interface IHandlerLambda<T = any, V = object> {
+  event: T
+  context: Context
+  response: V
+  error: Error
+  callback: Callback
 }
 
 export default middy


### PR DESCRIPTION
In v1.0.0-alpha it's hard to make your own middleware with TypeScript because none of the middleware types are exported.

I've made some changes to the `core` typings to expose the types to allow making middleware with TypeScript.

For example, you can now do this:

```typescript
import { IHandlerLambda, IMiddyMiddlewareObject } from "@middy/core";
import { APIGatewayEvent } from "aws-lambda";

const myMiddleware = (): IMiddyMiddlewareObject => ({
  before: (handler: IHandlerLambda<APIGatewayEvent>) => {
    console.log(handler.event.path);

    return Promise.resolve();
  },
});

export default myMiddleware;
```

This should open the way for #373 to be worked on now too.