### PR TITLE
Fix relative imports

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.0.0-alpha.41"
+  "version": "1.0.0-alpha.42"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy-monorepo",
-  "version": "1.0.0-alpha.40",
+  "version": "1.0.0-alpha.42",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy-monorepo",
-  "version": "1.0.0-alpha.35",
+  "version": "1.0.0-alpha.36",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy-monorepo",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "engines": {
     "node": ">=6.10"

--- a/packages/cache/index.d.ts
+++ b/packages/cache/index.d.ts
@@ -1,4 +1,4 @@
-import middy from '../core'
+import middy from '@middy/core'
 
 interface ICacheOptions {
   calculateCacheId?: (event: any) => Promise<string>;

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -39,5 +39,8 @@
   "homepage": "https://github.com/middyjs/middy#readme",
   "peerDependencies": {
     "@middy/core": ">=1.0.0-alpha"
+  },
+  "devDependencies": {
+    "@middy/core": ">=1.0.0-alpha"
   }
 }

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/cache",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "description": "Cache middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -41,6 +41,6 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": ">=1.0.0-alpha"
+    "@middy/core": "^1.0.0-alpha.42"
   }
 }

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/core",
-	"version": "1.0.0-alpha.36",
+	"version": "1.0.0-alpha.41",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/core",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda (core package)",
   "engines": {
     "node": ">=6.10"

--- a/packages/do-not-wait-for-empty-event-loop/index.d.ts
+++ b/packages/do-not-wait-for-empty-event-loop/index.d.ts
@@ -1,4 +1,4 @@
-import middy from '../core'
+import middy from '@middy/core'
 
 interface IDoNotWaitForEmtpyEventLoopOptions {
   runOnBefore?: boolean;

--- a/packages/do-not-wait-for-empty-event-loop/package.json
+++ b/packages/do-not-wait-for-empty-event-loop/package.json
@@ -39,5 +39,8 @@
   "homepage": "https://github.com/middyjs/middy#readme",
   "peerDependencies": {
     "@middy/core": ">=1.0.0-alpha"
+  },
+  "devDependencies": {
+    "@middy/core": ">=1.0.0-alpha"
   }
 }

--- a/packages/do-not-wait-for-empty-event-loop/package.json
+++ b/packages/do-not-wait-for-empty-event-loop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/do-not-wait-for-empty-event-loop",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "description": "Middleware for the middy framework that allows to easily disable the wait for empty event loop in a Lambda function",
   "engines": {
     "node": ">=6.10"
@@ -41,6 +41,6 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": ">=1.0.0-alpha"
+    "@middy/core": "^1.0.0-alpha.42"
   }
 }

--- a/packages/error-logger/index.d.ts
+++ b/packages/error-logger/index.d.ts
@@ -1,4 +1,4 @@
-import middy from '../core';
+import middy from '@middy/core';
 
 interface IErrorLoggerOptions {
   logger?: (message: any) => void;

--- a/packages/error-logger/package-lock.json
+++ b/packages/error-logger/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/error-logger",
-	"version": "1.0.0-alpha.36",
+	"version": "1.0.0-alpha.41",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/error-logger/package.json
+++ b/packages/error-logger/package.json
@@ -45,5 +45,8 @@
   },
   "dependencies": {
     "@types/node": "^10.0.8"
+  },
+  "devDependencies": {
+    "@middy/core": ">=1.0.0-alpha"
   }
 }

--- a/packages/error-logger/package.json
+++ b/packages/error-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/error-logger",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "description": "Input and output logger middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -47,6 +47,6 @@
     "@types/node": "^10.0.8"
   },
   "devDependencies": {
-    "@middy/core": ">=1.0.0-alpha"
+    "@middy/core": "^1.0.0-alpha.42"
   }
 }

--- a/packages/function-shield/index.d.ts
+++ b/packages/function-shield/index.d.ts
@@ -1,4 +1,4 @@
-import middy from '../core'
+import middy from '@middy/core'
 
 declare function functionShield(): middy.IMiddyMiddlewareObject;
 

--- a/packages/function-shield/package-lock.json
+++ b/packages/function-shield/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/function-shield",
-	"version": "1.0.0-alpha.36",
+	"version": "1.0.0-alpha.41",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/function-shield/package.json
+++ b/packages/function-shield/package.json
@@ -43,5 +43,8 @@
   },
   "dependencies": {
     "@puresec/function-shield": "^1.2.2"
+  },
+  "devDependencies": {
+    "@middy/core": ">=1.0.0-alpha"
   }
 }

--- a/packages/function-shield/package.json
+++ b/packages/function-shield/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/function-shield",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "description": "Hardens AWS Lambda execution environment",
   "engines": {
     "node": ">=6.10"
@@ -45,6 +45,6 @@
     "@puresec/function-shield": "^1.2.2"
   },
   "devDependencies": {
-    "@middy/core": ">=1.0.0-alpha"
+    "@middy/core": "^1.0.0-alpha.42"
   }
 }

--- a/packages/http-content-negotiation/index.d.ts
+++ b/packages/http-content-negotiation/index.d.ts
@@ -1,4 +1,4 @@
-import middy from '../core'
+import middy from '@middy/core'
 
 interface IHTTPContentNegotiationOptions {
   parseCharsets?: boolean;

--- a/packages/http-content-negotiation/package-lock.json
+++ b/packages/http-content-negotiation/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/http-content-negotiation",
-	"version": "1.0.0-alpha.36",
+	"version": "1.0.0-alpha.41",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-content-negotiation/package.json
+++ b/packages/http-content-negotiation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-content-negotiation",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "description": "Http content negotiation middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -47,6 +47,6 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": ">=1.0.0-alpha"
+    "@middy/core": "^1.0.0-alpha.42"
   }
 }

--- a/packages/http-content-negotiation/package.json
+++ b/packages/http-content-negotiation/package.json
@@ -45,5 +45,8 @@
   },
   "peerDependencies": {
     "@middy/core": ">=1.0.0-alpha"
+  },
+  "devDependencies": {
+    "@middy/core": ">=1.0.0-alpha"
   }
 }

--- a/packages/http-cors/index.d.ts
+++ b/packages/http-cors/index.d.ts
@@ -1,4 +1,4 @@
-import middy from '../core'
+import middy from '@middy/core'
 
 interface ICorsOptions {
   origin?: string;

--- a/packages/http-cors/package.json
+++ b/packages/http-cors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-cors",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "description": "CORS (Cross-Origin Resource Sharing) middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -42,6 +42,6 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": ">=1.0.0-alpha"
+    "@middy/core": "^1.0.0-alpha.42"
   }
 }

--- a/packages/http-cors/package.json
+++ b/packages/http-cors/package.json
@@ -40,5 +40,8 @@
   "homepage": "https://github.com/middyjs/middy#readme",
   "peerDependencies": {
     "@middy/core": ">=1.0.0-alpha"
+  },
+  "devDependencies": {
+    "@middy/core": ">=1.0.0-alpha"
   }
 }

--- a/packages/http-error-handler/index.d.ts
+++ b/packages/http-error-handler/index.d.ts
@@ -1,5 +1,5 @@
 import { HttpError } from 'http-errors'
-import middy from '../core'
+import middy from '@middy/core'
 
 interface IHTTPErrorHandlerOptions {
   logger?: (error: HttpError) => void;

--- a/packages/http-error-handler/package-lock.json
+++ b/packages/http-error-handler/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/http-error-handler",
-	"version": "1.0.0-alpha.36",
+	"version": "1.0.0-alpha.41",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-error-handler/package.json
+++ b/packages/http-error-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-error-handler",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "description": "Http error handler middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -47,6 +47,6 @@
     "http-errors": "^1.6.3"
   },
   "devDependencies": {
-    "@middy/core": ">=1.0.0-alpha"
+    "@middy/core": "^1.0.0-alpha.42"
   }
 }

--- a/packages/http-error-handler/package.json
+++ b/packages/http-error-handler/package.json
@@ -45,5 +45,8 @@
   },
   "dependencies": {
     "http-errors": "^1.6.3"
+  },
+  "devDependencies": {
+    "@middy/core": ">=1.0.0-alpha"
   }
 }

--- a/packages/http-event-normalizer/index.d.ts
+++ b/packages/http-event-normalizer/index.d.ts
@@ -1,4 +1,4 @@
-import middy from '../core'
+import middy from '@middy/core'
 
 declare function httpEventNormalizer(): middy.IMiddyMiddlewareObject;
 

--- a/packages/http-event-normalizer/package.json
+++ b/packages/http-event-normalizer/package.json
@@ -41,5 +41,8 @@
   "homepage": "https://github.com/middyjs/middy#readme",
   "peerDependencies": {
     "@middy/core": ">=1.0.0-alpha"
+  },
+  "devDependencies": {
+    "@middy/core": ">=1.0.0-alpha"
   }
 }

--- a/packages/http-event-normalizer/package.json
+++ b/packages/http-event-normalizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-event-normalizer",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "description": "Http event normalizer middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -43,6 +43,6 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": ">=1.0.0-alpha"
+    "@middy/core": "^1.0.0-alpha.42"
   }
 }

--- a/packages/http-header-normalizer/index.d.ts
+++ b/packages/http-header-normalizer/index.d.ts
@@ -1,4 +1,4 @@
-import middy from '../core'
+import middy from '@middy/core'
 
 interface IHTTPHeaderNormalizerOptions {
   normalizeHeaderKey?: (key: string) => string;

--- a/packages/http-header-normalizer/package.json
+++ b/packages/http-header-normalizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-header-normalizer",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "description": "Http header normalizer middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -45,6 +45,6 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": ">=1.0.0-alpha"
+    "@middy/core": "^1.0.0-alpha.42"
   }
 }

--- a/packages/http-header-normalizer/package.json
+++ b/packages/http-header-normalizer/package.json
@@ -43,5 +43,8 @@
   "homepage": "https://github.com/middyjs/middy#readme",
   "peerDependencies": {
     "@middy/core": ">=1.0.0-alpha"
+  },
+  "devDependencies": {
+    "@middy/core": ">=1.0.0-alpha"
   }
 }

--- a/packages/http-json-body-parser/index.d.ts
+++ b/packages/http-json-body-parser/index.d.ts
@@ -1,4 +1,4 @@
-import middy from '../core'
+import middy from '@middy/core'
 
 interface IJsonBodyParserOptions {
   reviver?: (key: string, value: any) => any

--- a/packages/http-json-body-parser/package-lock.json
+++ b/packages/http-json-body-parser/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/http-json-body-parser",
-	"version": "1.0.0-alpha.36",
+	"version": "1.0.0-alpha.41",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-json-body-parser/package.json
+++ b/packages/http-json-body-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-json-body-parser",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "description": "Http JSON body parser middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -50,6 +50,6 @@
     "http-errors": "^1.6.3"
   },
   "devDependencies": {
-    "@middy/core": ">=1.0.0-alpha"
+    "@middy/core": "^1.0.0-alpha.42"
   }
 }

--- a/packages/http-json-body-parser/package.json
+++ b/packages/http-json-body-parser/package.json
@@ -48,5 +48,8 @@
     "@types/http-errors": "^1.6.1",
     "content-type": "^1.0.4",
     "http-errors": "^1.6.3"
+  },
+  "devDependencies": {
+    "@middy/core": ">=1.0.0-alpha"
   }
 }

--- a/packages/http-partial-response/index.d.ts
+++ b/packages/http-partial-response/index.d.ts
@@ -1,4 +1,4 @@
-import middy from '../core'
+import middy from '@middy/core'
 
 interface IHTTPPartialResponseOptions {
   filteringKeyName?: string;

--- a/packages/http-partial-response/package-lock.json
+++ b/packages/http-partial-response/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/http-partial-response",
-	"version": "1.0.0-alpha.36",
+	"version": "1.0.0-alpha.41",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-partial-response/package.json
+++ b/packages/http-partial-response/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-partial-response",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "description": "Http partial response middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -47,6 +47,6 @@
     "json-mask": "^0.3.8"
   },
   "devDependencies": {
-    "@middy/core": ">=1.0.0-alpha"
+    "@middy/core": "^1.0.0-alpha.42"
   }
 }

--- a/packages/http-partial-response/package.json
+++ b/packages/http-partial-response/package.json
@@ -45,5 +45,8 @@
   },
   "dependencies": {
     "json-mask": "^0.3.8"
+  },
+  "devDependencies": {
+    "@middy/core": ">=1.0.0-alpha"
   }
 }

--- a/packages/http-response-serializer/index.d.ts
+++ b/packages/http-response-serializer/index.d.ts
@@ -1,4 +1,4 @@
-import middy from '../core'
+import middy from '@middy/core'
 
 interface SerializerHandler {
   regex: any;

--- a/packages/http-response-serializer/package-lock.json
+++ b/packages/http-response-serializer/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/http-response-serializer",
-	"version": "1.0.0-alpha.36",
+	"version": "1.0.0-alpha.41",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-response-serializer/package.json
+++ b/packages/http-response-serializer/package.json
@@ -46,5 +46,8 @@
   "dependencies": {
     "accept": "^3.1.3",
     "http-errors": "^1.7.2"
+  },
+  "devDependencies": {
+    "@middy/core": ">=1.0.0-alpha"
   }
 }

--- a/packages/http-response-serializer/package.json
+++ b/packages/http-response-serializer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-response-serializer",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "description": "Http response serializer middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -48,6 +48,6 @@
     "http-errors": "^1.7.2"
   },
   "devDependencies": {
-    "@middy/core": ">=1.0.0-alpha"
+    "@middy/core": "^1.0.0-alpha.42"
   }
 }

--- a/packages/http-security-header/index.d.ts
+++ b/packages/http-security-header/index.d.ts
@@ -1,4 +1,4 @@
-import middy from '../core'
+import middy from '@middy/core'
 
 interface IHTTPSecurityHeadersOptions {
   dnsPrefetchControl?: {

--- a/packages/http-security-header/package.json
+++ b/packages/http-security-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-security-header",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "description": "Applies best practice security headers to responses. It's a simplified port of HelmetJS",
   "engines": {
     "node": ">=6.10"
@@ -46,6 +46,6 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": ">=1.0.0-alpha"
+    "@middy/core": "^1.0.0-alpha.42"
   }
 }

--- a/packages/http-security-header/package.json
+++ b/packages/http-security-header/package.json
@@ -44,5 +44,8 @@
   "homepage": "https://github.com/middyjs/middy#readme",
   "peerDependencies": {
     "@middy/core": ">=1.0.0-alpha"
+  },
+  "devDependencies": {
+    "@middy/core": ">=1.0.0-alpha"
   }
 }

--- a/packages/http-urlencode-body-parser/index.d.ts
+++ b/packages/http-urlencode-body-parser/index.d.ts
@@ -1,4 +1,4 @@
-import middy from '../core'
+import middy from '@middy/core'
 
 interface IURLEncodeBodyParserOptions {
   extended?: false;

--- a/packages/http-urlencode-body-parser/package-lock.json
+++ b/packages/http-urlencode-body-parser/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/http-urlencode-body-parser",
-	"version": "1.0.0-alpha.36",
+	"version": "1.0.0-alpha.41",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-urlencode-body-parser/package.json
+++ b/packages/http-urlencode-body-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-urlencode-body-parser",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "description": "Urlencode body parser middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -50,6 +50,6 @@
     "querystring": "^0.2.0"
   },
   "devDependencies": {
-    "@middy/core": ">=1.0.0-alpha"
+    "@middy/core": "^1.0.0-alpha.42"
   }
 }

--- a/packages/http-urlencode-body-parser/package.json
+++ b/packages/http-urlencode-body-parser/package.json
@@ -48,5 +48,8 @@
     "content-type": "^1.0.4",
     "qs": "^6.5.2",
     "querystring": "^0.2.0"
+  },
+  "devDependencies": {
+    "@middy/core": ">=1.0.0-alpha"
   }
 }

--- a/packages/input-output-logger/index.d.ts
+++ b/packages/input-output-logger/index.d.ts
@@ -1,4 +1,4 @@
-import middy from '../core';
+import middy from '@middy/core';
 
 interface IInputOutputLoggerOptions {
   logger?: (message: any) => void;

--- a/packages/input-output-logger/package-lock.json
+++ b/packages/input-output-logger/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/input-output-logger",
-	"version": "1.0.0-alpha.36",
+	"version": "1.0.0-alpha.41",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/input-output-logger/package.json
+++ b/packages/input-output-logger/package.json
@@ -45,5 +45,8 @@
   },
   "dependencies": {
     "@types/node": "^10.0.8"
+  },
+  "devDependencies": {
+    "@middy/core": ">=1.0.0-alpha"
   }
 }

--- a/packages/input-output-logger/package.json
+++ b/packages/input-output-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/input-output-logger",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "description": "Input and output logger middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -47,6 +47,6 @@
     "@types/node": "^10.0.8"
   },
   "devDependencies": {
-    "@middy/core": ">=1.0.0-alpha"
+    "@middy/core": "^1.0.0-alpha.42"
   }
 }

--- a/packages/s3-key-normalizer/index.d.ts
+++ b/packages/s3-key-normalizer/index.d.ts
@@ -1,4 +1,4 @@
-import middy from '../core'
+import middy from '@middy/core'
 
 declare function s3KeyNormalizer(): middy.IMiddyMiddlewareObject;
 

--- a/packages/s3-key-normalizer/package.json
+++ b/packages/s3-key-normalizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/s3-key-normalizer",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "description": "S3 key normalizer middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -43,6 +43,6 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": ">=1.0.0-alpha"
+    "@middy/core": "^1.0.0-alpha.42"
   }
 }

--- a/packages/s3-key-normalizer/package.json
+++ b/packages/s3-key-normalizer/package.json
@@ -41,5 +41,8 @@
   "homepage": "https://github.com/middyjs/middy#readme",
   "peerDependencies": {
     "@middy/core": ">=1.0.0-alpha"
+  },
+  "devDependencies": {
+    "@middy/core": ">=1.0.0-alpha"
   }
 }

--- a/packages/secrets-manager/index.d.ts
+++ b/packages/secrets-manager/index.d.ts
@@ -1,5 +1,5 @@
 import { SecretsManager } from 'aws-sdk'
-import middy from '../core'
+import middy from '@middy/core'
 
 interface ISecretsManagerOptions {
   cache?: boolean;

--- a/packages/secrets-manager/package-lock.json
+++ b/packages/secrets-manager/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/secrets-manager",
-	"version": "1.0.0-alpha.36",
+	"version": "1.0.0-alpha.41",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/secrets-manager/package.json
+++ b/packages/secrets-manager/package.json
@@ -43,5 +43,8 @@
   },
   "dependencies": {
     "@types/node": "^10.0.8"
+  },
+  "devDependencies": {
+    "@middy/core": ">=1.0.0-alpha"
   }
 }

--- a/packages/secrets-manager/package.json
+++ b/packages/secrets-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/secrets-manager",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "description": "Secrets Manager middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -45,6 +45,6 @@
     "@types/node": "^10.0.8"
   },
   "devDependencies": {
-    "@middy/core": ">=1.0.0-alpha"
+    "@middy/core": "^1.0.0-alpha.42"
   }
 }

--- a/packages/ssm/index.d.ts
+++ b/packages/ssm/index.d.ts
@@ -1,5 +1,5 @@
 import { SSM } from 'aws-sdk'
-import middy from '../core'
+import middy from '@middy/core'
 
 interface ISSMOptions {
   cache?: boolean;

--- a/packages/ssm/package-lock.json
+++ b/packages/ssm/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/ssm",
-	"version": "1.0.0-alpha.36",
+	"version": "1.0.0-alpha.41",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/ssm/package.json
+++ b/packages/ssm/package.json
@@ -45,5 +45,8 @@
   },
   "dependencies": {
     "@types/node": "^10.0.8"
+  },
+  "devDependencies": {
+    "@middy/core": ">=1.0.0-alpha"
   }
 }

--- a/packages/ssm/package.json
+++ b/packages/ssm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/ssm",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "description": "SSM (EC2 Systems Manager) parameters middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -47,6 +47,6 @@
     "@types/node": "^10.0.8"
   },
   "devDependencies": {
-    "@middy/core": ">=1.0.0-alpha"
+    "@middy/core": "^1.0.0-alpha.42"
   }
 }

--- a/packages/validator/index.d.ts
+++ b/packages/validator/index.d.ts
@@ -1,4 +1,4 @@
-import middy from '../core'
+import middy from '@middy/core'
 
 import { Options as AjvOptions } from 'ajv'
 

--- a/packages/validator/package-lock.json
+++ b/packages/validator/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/validator",
-	"version": "1.0.0-alpha.36",
+	"version": "1.0.0-alpha.41",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -47,5 +47,8 @@
     "ajv-i18n": "^3.3.0",
     "ajv-keywords": "^3.2.0",
     "http-errors": "^1.6.3"
+  },
+  "devDependencies": {
+    "@middy/core": ">=1.0.0-alpha"
   }
 }

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/validator",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "description": "Validator middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -49,6 +49,6 @@
     "http-errors": "^1.6.3"
   },
   "devDependencies": {
-    "@middy/core": ">=1.0.0-alpha"
+    "@middy/core": "^1.0.0-alpha.42"
   }
 }

--- a/packages/warmup/index.d.ts
+++ b/packages/warmup/index.d.ts
@@ -1,4 +1,4 @@
-import middy from '../core'
+import middy from '@middy/core'
 
 interface IWarmupOptions {
   isWarmingUp?: (event: any) => boolean;

--- a/packages/warmup/package.json
+++ b/packages/warmup/package.json
@@ -41,5 +41,8 @@
   "homepage": "https://github.com/middyjs/middy#readme",
   "peerDependencies": {
     "@middy/core": ">=1.0.0-alpha"
+  },
+  "devDependencies": {
+    "@middy/core": ">=1.0.0-alpha"
   }
 }

--- a/packages/warmup/package.json
+++ b/packages/warmup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/warmup",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "description": "Warmup (cold start mitigation) middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -43,6 +43,6 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": ">=1.0.0-alpha"
+    "@middy/core": "^1.0.0-alpha.42"
   }
 }


### PR DESCRIPTION
Build on #315 by fixing all relative imports of `@middy/core` in 1.0.0-alpha.

- [x] Add `@middy/core` to `devDependencies` of packages
- [x] Change all relative imports

Closes #315. 