### PR TITLE
TS: Make it possible to extend context type with typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,28 +24,28 @@ declare const middy: <H extends AsyncHandler<C>, C extends Context = Context>(ha
 >;
 
 declare namespace middy {
-  interface Middy<T, R> extends Handler<T, R> {
-    use: <C extends MiddlewareObject<T, R>>(middleware: C) => Middy<T, R>;
-    before: (callbackFn: MiddlewareFunction<T, R>) => Middy<T, R>;
-    after: (callbackFn: MiddlewareFunction<T, R>) => Middy<T, R>;
-    onError: (callbackFn: MiddlewareFunction<T, R>) => Middy<T, R>;
+  interface Middy<T, R, C extends Context = Context> extends Handler<T, R> {
+    use: <M extends MiddlewareObject<T, R, C>>(middleware: M) => Middy<T, R, C>;
+    before: (callbackFn: MiddlewareFunction<T, R, C>) => Middy<T, R, C>;
+    after: (callbackFn: MiddlewareFunction<T, R, C>) => Middy<T, R, C>;
+    onError: (callbackFn: MiddlewareFunction<T, R, C>) => Middy<T, R, C>;
   }
 
   type Middleware<C extends any, T = any, R = any> = (config?: C) => MiddlewareObject<T, R>;
 
-  interface MiddlewareObject<T, R> {
-    before?: MiddlewareFunction<T, R>;
-    after?: MiddlewareFunction<T, R>;
-    onError?: MiddlewareFunction<T, R>;
+  interface MiddlewareObject<T, R, C extends Context = Context> {
+    before?: MiddlewareFunction<T, R, C>;
+    after?: MiddlewareFunction<T, R, C>;
+    onError?: MiddlewareFunction<T, R, C>;
   }
 
-  type MiddlewareFunction<T, R> = (handler: HandlerLambda<T, R>, next: NextFunction) => void | Promise<any>;
+  type MiddlewareFunction<T, R, C extends Context = Context> = (handler: HandlerLambda<T, R, C>, next: NextFunction) => void | Promise<any>;
 
   type NextFunction = (error?: any) => void;
 
-  interface HandlerLambda<T = any, V = {}> {
+  interface HandlerLambda<T = any, V = {}, C extends Context = Context> {
     event: T;
-    context: Context;
+    context: C;
     response: V;
     error: Error;
     callback: Callback<T>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2766,17 +2766,17 @@
       "dev": true
     },
     "dmd": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/dmd/-/dmd-4.0.0.tgz",
-      "integrity": "sha512-J+4CgbQiMuJHiU9dvTVN8iOOZGeR3bef1wBqz6eVvvX17jkpkKVd8TeeutA/FJAeFbLQfXnyQ3o4qY7W+c5cxQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/dmd/-/dmd-4.0.4.tgz",
+      "integrity": "sha512-ZbHUPKUp5Tl8nVVMZw8rc/MQmFVKusvfR10X/lPAXjBUc/LRW7AaXnYrK2LnVIPfTGEw7T6OmsxkvNRX7GnjIQ==",
       "dev": true,
       "requires": {
-        "array-back": "^3.1.0",
+        "array-back": "^4.0.0",
         "cache-point": "^0.4.1",
         "common-sequence": "^1.0.2",
-        "file-set": "^2.0.0",
-        "handlebars": "^4.1.2",
-        "marked": "^0.6.2",
+        "file-set": "^2.0.1",
+        "handlebars": "^4.2.0",
+        "marked": "^0.7.0",
         "object-get": "^2.1.0",
         "reduce-flatten": "^2.0.0",
         "reduce-unique": "^2.0.1",
@@ -2785,10 +2785,10 @@
         "walk-back": "^3.0.1"
       },
       "dependencies": {
-        "marked": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.3.tgz",
-          "integrity": "sha512-Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ==",
+        "array-back": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.0.tgz",
+          "integrity": "sha512-ylVYjv5BzoWXWO7e6fWrzjqzgxmUPWdQrHxgzo/v1EaYXfw6+6ipRdIr7KryAGnVHG08O1Yfpchuv0+YhjPL+Q==",
           "dev": true
         },
         "reduce-flatten": {
@@ -3303,10 +3303,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -4367,9 +4370,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.2.tgz",
+      "integrity": "sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -5208,9 +5211,9 @@
       },
       "dependencies": {
         "handlebars": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-          "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.2.tgz",
+          "integrity": "sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==",
           "dev": true,
           "requires": {
             "neo-async": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
   "files": [


### PR DESCRIPTION
These changes needed to make it possible (and easier) to extend context in runtime with typescript support.

So now we can use it like this: 

```ts
// Defining our extended type of the context
export interface ContextWithExtraArgs extends Context {
    extra?: ExtraType;
}

const before: MiddlewareFunction<SQSEventWithLogger, Response, ContextWithRecords> = ({
    event,
    context,
}) => {
    context.extra = someExtraValue;
};

const withExtraArgs: MiddlewareObject<SQSEventWithLogger, Response, ContextWithRecords> = {
    before,
};

const originalHandler = async (event: SQSEvent, context: ContextWithExtraArgs): Promise<void> => {
    // now we can use extra args here and typescript will happy as well
    console.log(context.extra);
};

const handler = applyMiddleware(originalHandler).use(withExtraArgs);
```

Thanks.
