### PR TITLE
move @types/aws-lambda to a peerDependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ To install middy you can use NPM:
 npm install --save @middy/core
 ```
 
+If you are using TypeScript, you will also want to make sure that you have installed the @types/aws-lambda peer-dependency
+
+```bash
+npm install --save-dev @types/aws-lambda
+```
+
 ## Quick example
 
 code is better than 10,000 words, so let's jump into an example.

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.0.0-alpha.45"
+  "version": "1.0.0-alpha.46"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy-monorepo",
-  "version": "1.0.0-alpha.45",
+  "version": "1.0.0-alpha.46",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy-monorepo",
-  "version": "1.0.0-alpha.45",
+  "version": "1.0.0-alpha.46",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "engines": {
     "node": ">=6.10"

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/cache",
-	"version": "1.0.0-alpha.43",
+	"version": "1.0.0-alpha.45",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/cache",
-  "version": "1.0.0-alpha.45",
+  "version": "1.0.0-alpha.46",
   "description": "Cache middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -41,7 +41,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.45",
+    "@middy/core": "^1.0.0-alpha.46",
     "es6-promisify": "^6.0.2"
   }
 }

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,13 +1,14 @@
 {
 	"name": "@middy/core",
-	"version": "1.0.0-alpha.43",
+	"version": "1.0.0-alpha.45",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@types/aws-lambda": {
 			"version": "8.10.23",
 			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.23.tgz",
-			"integrity": "sha512-erfexxfuc1+T7b4OswooKwpIjpdgEOVz6ZrDDWSR+3v7Kjhs4EVowfUkF9KuLKhpcjz+VVHQ/pWIl7zSVbKbFQ=="
+			"integrity": "sha512-erfexxfuc1+T7b4OswooKwpIjpdgEOVz6ZrDDWSR+3v7Kjhs4EVowfUkF9KuLKhpcjz+VVHQ/pWIl7zSVbKbFQ==",
+			"dev": true
 		},
 		"es6-promisify": {
 			"version": "6.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/core",
-  "version": "1.0.0-alpha.45",
+  "version": "1.0.0-alpha.46",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda (core package)",
   "engines": {
     "node": ">=6.10"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,11 +35,14 @@
     "url": "https://github.com/middyjs/middy/issues"
   },
   "homepage": "https://github.com/middyjs/middy#readme",
+  "peerDependencies": {
+    "@types/aws-lambda": "^8.10.3"
+  },
   "dependencies": {
-    "@types/aws-lambda": "^8.10.3",
     "once": "^1.4.0"
   },
   "devDependencies": {
+    "@types/aws-lambda": "^8.10.3",
     "es6-promisify": "^6.0.2"
   }
 }

--- a/packages/do-not-wait-for-empty-event-loop/package-lock.json
+++ b/packages/do-not-wait-for-empty-event-loop/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/do-not-wait-for-empty-event-loop",
-	"version": "1.0.0-alpha.43",
+	"version": "1.0.0-alpha.45",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/do-not-wait-for-empty-event-loop/package.json
+++ b/packages/do-not-wait-for-empty-event-loop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/do-not-wait-for-empty-event-loop",
-  "version": "1.0.0-alpha.45",
+  "version": "1.0.0-alpha.46",
   "description": "Middleware for the middy framework that allows to easily disable the wait for empty event loop in a Lambda function",
   "engines": {
     "node": ">=6.10"
@@ -41,7 +41,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.45",
+    "@middy/core": "^1.0.0-alpha.46",
     "es6-promisify": "^6.0.2"
   }
 }

--- a/packages/error-logger/package-lock.json
+++ b/packages/error-logger/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/error-logger",
-	"version": "1.0.0-alpha.43",
+	"version": "1.0.0-alpha.45",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/error-logger/package.json
+++ b/packages/error-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/error-logger",
-  "version": "1.0.0-alpha.45",
+  "version": "1.0.0-alpha.46",
   "description": "Input and output logger middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -47,7 +47,7 @@
     "@types/node": "^10.0.8"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.45",
+    "@middy/core": "^1.0.0-alpha.46",
     "es6-promisify": "^6.0.2"
   }
 }

--- a/packages/function-shield/package-lock.json
+++ b/packages/function-shield/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/function-shield",
-	"version": "1.0.0-alpha.43",
+	"version": "1.0.0-alpha.45",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/function-shield/package.json
+++ b/packages/function-shield/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/function-shield",
-  "version": "1.0.0-alpha.45",
+  "version": "1.0.0-alpha.46",
   "description": "Hardens AWS Lambda execution environment",
   "engines": {
     "node": ">=6.10"
@@ -45,7 +45,7 @@
     "@puresec/function-shield": "^1.2.2"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.45",
+    "@middy/core": "^1.0.0-alpha.46",
     "es6-promisify": "^6.0.2"
   }
 }

--- a/packages/http-content-negotiation/package-lock.json
+++ b/packages/http-content-negotiation/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/http-content-negotiation",
-	"version": "1.0.0-alpha.43",
+	"version": "1.0.0-alpha.45",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-content-negotiation/package.json
+++ b/packages/http-content-negotiation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-content-negotiation",
-  "version": "1.0.0-alpha.45",
+  "version": "1.0.0-alpha.46",
   "description": "Http content negotiation middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -47,7 +47,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.45",
+    "@middy/core": "^1.0.0-alpha.46",
     "es6-promisify": "^6.0.2"
   }
 }

--- a/packages/http-cors/package-lock.json
+++ b/packages/http-cors/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/http-cors",
-	"version": "1.0.0-alpha.43",
+	"version": "1.0.0-alpha.45",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-cors/package.json
+++ b/packages/http-cors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-cors",
-  "version": "1.0.0-alpha.45",
+  "version": "1.0.0-alpha.46",
   "description": "CORS (Cross-Origin Resource Sharing) middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -42,7 +42,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.45",
+    "@middy/core": "^1.0.0-alpha.46",
     "es6-promisify": "^6.0.2"
   }
 }

--- a/packages/http-error-handler/package-lock.json
+++ b/packages/http-error-handler/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/http-error-handler",
-	"version": "1.0.0-alpha.43",
+	"version": "1.0.0-alpha.45",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-error-handler/package.json
+++ b/packages/http-error-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-error-handler",
-  "version": "1.0.0-alpha.45",
+  "version": "1.0.0-alpha.46",
   "description": "Http error handler middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -47,7 +47,7 @@
     "http-errors": "^1.6.3"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.45",
+    "@middy/core": "^1.0.0-alpha.46",
     "es6-promisify": "^6.0.2"
   }
 }

--- a/packages/http-event-normalizer/package-lock.json
+++ b/packages/http-event-normalizer/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/http-event-normalizer",
-	"version": "1.0.0-alpha.43",
+	"version": "1.0.0-alpha.45",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-event-normalizer/package.json
+++ b/packages/http-event-normalizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-event-normalizer",
-  "version": "1.0.0-alpha.45",
+  "version": "1.0.0-alpha.46",
   "description": "Http event normalizer middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -43,7 +43,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.45",
+    "@middy/core": "^1.0.0-alpha.46",
     "es6-promisify": "^6.0.2"
   }
 }

--- a/packages/http-header-normalizer/package-lock.json
+++ b/packages/http-header-normalizer/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/http-header-normalizer",
-	"version": "1.0.0-alpha.43",
+	"version": "1.0.0-alpha.45",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-header-normalizer/package.json
+++ b/packages/http-header-normalizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-header-normalizer",
-  "version": "1.0.0-alpha.45",
+  "version": "1.0.0-alpha.46",
   "description": "Http header normalizer middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -45,7 +45,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.45",
+    "@middy/core": "^1.0.0-alpha.46",
     "es6-promisify": "^6.0.2"
   }
 }

--- a/packages/http-json-body-parser/package-lock.json
+++ b/packages/http-json-body-parser/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/http-json-body-parser",
-	"version": "1.0.0-alpha.43",
+	"version": "1.0.0-alpha.45",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-json-body-parser/package.json
+++ b/packages/http-json-body-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-json-body-parser",
-  "version": "1.0.0-alpha.45",
+  "version": "1.0.0-alpha.46",
   "description": "Http JSON body parser middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -50,7 +50,7 @@
     "http-errors": "^1.6.3"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.45",
+    "@middy/core": "^1.0.0-alpha.46",
     "es6-promisify": "^6.0.2"
   }
 }

--- a/packages/http-partial-response/package-lock.json
+++ b/packages/http-partial-response/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/http-partial-response",
-	"version": "1.0.0-alpha.43",
+	"version": "1.0.0-alpha.45",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-partial-response/package.json
+++ b/packages/http-partial-response/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-partial-response",
-  "version": "1.0.0-alpha.45",
+  "version": "1.0.0-alpha.46",
   "description": "Http partial response middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -47,7 +47,7 @@
     "json-mask": "^0.3.8"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.45",
+    "@middy/core": "^1.0.0-alpha.46",
     "es6-promisify": "^6.0.2"
   }
 }

--- a/packages/http-response-serializer/package-lock.json
+++ b/packages/http-response-serializer/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/http-response-serializer",
-	"version": "1.0.0-alpha.43",
+	"version": "1.0.0-alpha.45",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-response-serializer/package.json
+++ b/packages/http-response-serializer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-response-serializer",
-  "version": "1.0.0-alpha.45",
+  "version": "1.0.0-alpha.46",
   "description": "Http response serializer middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -48,7 +48,7 @@
     "http-errors": "^1.7.2"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.45",
+    "@middy/core": "^1.0.0-alpha.46",
     "es6-promisify": "^6.0.2"
   }
 }

--- a/packages/http-security-header/package-lock.json
+++ b/packages/http-security-header/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/http-security-header",
-	"version": "1.0.0-alpha.43",
+	"version": "1.0.0-alpha.45",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-security-header/package.json
+++ b/packages/http-security-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-security-header",
-  "version": "1.0.0-alpha.45",
+  "version": "1.0.0-alpha.46",
   "description": "Applies best practice security headers to responses. It's a simplified port of HelmetJS",
   "engines": {
     "node": ">=6.10"
@@ -46,7 +46,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.45",
+    "@middy/core": "^1.0.0-alpha.46",
     "es6-promisify": "^6.0.2"
   }
 }

--- a/packages/http-urlencode-body-parser/package-lock.json
+++ b/packages/http-urlencode-body-parser/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/http-urlencode-body-parser",
-	"version": "1.0.0-alpha.43",
+	"version": "1.0.0-alpha.45",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/http-urlencode-body-parser/package.json
+++ b/packages/http-urlencode-body-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-urlencode-body-parser",
-  "version": "1.0.0-alpha.45",
+  "version": "1.0.0-alpha.46",
   "description": "Urlencode body parser middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -50,7 +50,7 @@
     "querystring": "^0.2.0"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.45",
+    "@middy/core": "^1.0.0-alpha.46",
     "es6-promisify": "^6.0.2"
   }
 }

--- a/packages/input-output-logger/package-lock.json
+++ b/packages/input-output-logger/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/input-output-logger",
-	"version": "1.0.0-alpha.43",
+	"version": "1.0.0-alpha.45",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/input-output-logger/package.json
+++ b/packages/input-output-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/input-output-logger",
-  "version": "1.0.0-alpha.45",
+  "version": "1.0.0-alpha.46",
   "description": "Input and output logger middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -47,7 +47,7 @@
     "@types/node": "^10.0.8"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.45",
+    "@middy/core": "^1.0.0-alpha.46",
     "es6-promisify": "^6.0.2"
   }
 }

--- a/packages/s3-key-normalizer/package-lock.json
+++ b/packages/s3-key-normalizer/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/s3-key-normalizer",
-	"version": "1.0.0-alpha.43",
+	"version": "1.0.0-alpha.45",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/s3-key-normalizer/package.json
+++ b/packages/s3-key-normalizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/s3-key-normalizer",
-  "version": "1.0.0-alpha.45",
+  "version": "1.0.0-alpha.46",
   "description": "S3 key normalizer middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -43,7 +43,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.45",
+    "@middy/core": "^1.0.0-alpha.46",
     "es6-promisify": "^6.0.2"
   }
 }

--- a/packages/secrets-manager/package-lock.json
+++ b/packages/secrets-manager/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/secrets-manager",
-	"version": "1.0.0-alpha.43",
+	"version": "1.0.0-alpha.45",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/secrets-manager/package.json
+++ b/packages/secrets-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/secrets-manager",
-  "version": "1.0.0-alpha.45",
+  "version": "1.0.0-alpha.46",
   "description": "Secrets Manager middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -45,7 +45,7 @@
     "@types/node": "^10.0.8"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.45",
+    "@middy/core": "^1.0.0-alpha.46",
     "es6-promisify": "^6.0.2"
   }
 }

--- a/packages/ssm/package-lock.json
+++ b/packages/ssm/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/ssm",
-	"version": "1.0.0-alpha.43",
+	"version": "1.0.0-alpha.45",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/ssm/package.json
+++ b/packages/ssm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/ssm",
-  "version": "1.0.0-alpha.45",
+  "version": "1.0.0-alpha.46",
   "description": "SSM (EC2 Systems Manager) parameters middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -47,7 +47,7 @@
     "@types/node": "^10.0.8"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.45",
+    "@middy/core": "^1.0.0-alpha.46",
     "es6-promisify": "^6.0.2"
   }
 }

--- a/packages/validator/package-lock.json
+++ b/packages/validator/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/validator",
-	"version": "1.0.0-alpha.43",
+	"version": "1.0.0-alpha.45",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/validator",
-  "version": "1.0.0-alpha.45",
+  "version": "1.0.0-alpha.46",
   "description": "Validator middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -49,7 +49,7 @@
     "http-errors": "^1.6.3"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.45",
+    "@middy/core": "^1.0.0-alpha.46",
     "es6-promisify": "^6.0.2"
   }
 }

--- a/packages/warmup/package-lock.json
+++ b/packages/warmup/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@middy/warmup",
-	"version": "1.0.0-alpha.43",
+	"version": "1.0.0-alpha.45",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/warmup/package.json
+++ b/packages/warmup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/warmup",
-  "version": "1.0.0-alpha.45",
+  "version": "1.0.0-alpha.46",
   "description": "Warmup (cold start mitigation) middleware for the middy framework",
   "engines": {
     "node": ">=6.10"
@@ -43,7 +43,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.45",
+    "@middy/core": "^1.0.0-alpha.46",
     "es6-promisify": "^6.0.2"
   }
 }


### PR DESCRIPTION
I've moved the @types/aws-lambda package to peer dependencies, as some project may have a slightly different version of these types, and when both exist in the same project, it will result in TypeScript errors like:

```
The inferred type of 'myMiddleware' cannot be named without a reference to '@middy/core/node_modules/@types/aws-lambda'. This is likely not portable. A type annotation is necessary.
```

I have also updated the README to reflect this for TypeScript users

closes #409 