### PR TITLE
Add in RDS Auth Token option to dbManager

### DIFF
--- a/packages/db-manager/README.md
+++ b/packages/db-manager/README.md
@@ -61,7 +61,7 @@ npm install --save @middy/db-manager
 - `secretsPath` (optional): if for any reason you want to pass credentials using context, pass path to secrets laying in context object  - good example is combining this middleware with [ssm](#ssm)
 - `removeSecrets` (optional): By default is true. Works only in combination with `secretsPath`. Removes sensitive data from context once client is initialized.
 - `forceNewConnection` (optional): Creates new connection on every run and destroys it after. Database client needs to have `destroy` function in order to properly clean up connections.
-- `awsSdkOptions` (optional): Will use to create an IAM RDS Auth Token for the database connection using `[RDS.Signer](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/RDS/Signer.html)`. See AWs docs for required params, `region` is automatically pulled from the `hostname` unless overridden.
+- `rdsSigner` (optional): Will use to create an IAM RDS Auth Token for the database connection using `[RDS.Signer](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/RDS/Signer.html)`. See AWs docs for required params, `region` is automatically pulled from the `hostname` unless overridden.
 
 ## Sample usage
 

--- a/packages/db-manager/README.md
+++ b/packages/db-manager/README.md
@@ -61,6 +61,7 @@ npm install --save @middy/db-manager
 - `secretsPath` (optional): if for any reason you want to pass credentials using context, pass path to secrets laying in context object  - good example is combining this middleware with [ssm](#ssm)
 - `removeSecrets` (optional): By default is true. Works only in combination with `secretsPath`. Removes sensitive data from context once client is initialized.
 - `forceNewConnection` (optional): Creates new connection on every run and destroys it after. Database client needs to have `destroy` function in order to properly clean up connections.
+- `awsSdkOptions` (optional): Will use to create an IAM RDS Auth Token for the database connection using `[RDS.Signer](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/RDS/Signer.html)`. See AWs docs for required params, `region` is automatically pulled from the `hostname` unless overridden.
 
 ## Sample usage
 
@@ -181,6 +182,8 @@ handler.use(dbManager({
   }
 }));
 ```
+
+**Note:** If you see an error 
 
 See AWS Docs [Rotating Your SSL/TLS Certificate](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL-certificate-rotation.html) to ensure you're using the right certificate.
 

--- a/packages/db-manager/__tests__/index.js
+++ b/packages/db-manager/__tests__/index.js
@@ -2,6 +2,7 @@
 jest.mock('knex')
 
 const knex = require('knex')
+const RDS = require('aws-sdk/clients/rds')
 
 const middy = require('../../core')
 const dbManager = require('../')
@@ -9,7 +10,16 @@ const dbManager = require('../')
 describe('💾  Database manager', () => {
   let destroyFn
   let clientMock
+
+  let getAuthTokenMock
+  let SignerMock
+
   beforeEach(() => {
+    getAuthTokenMock = jest.fn()
+    SignerMock = jest.fn(() => ({
+      getAuthToken: getAuthTokenMock
+    }))
+    RDS.prototype.Signer = SignerMock
     destroyFn = jest.fn()
     clientMock = jest.fn(() => ({
       destroy: destroyFn
@@ -44,6 +54,7 @@ describe('💾  Database manager', () => {
     })
   })
 
+  // TODO async before causing quite error w/r toHaveBeenCalledTimes
   test('it should destroy instance if forceNewConnection flag provided', (done) => {
     knex.mockReturnValue(clientMock())
     const handler = middy((event, context, cb) => {
@@ -233,8 +244,7 @@ describe('💾  Database manager', () => {
       user: '1234',
       password: '56678'
     }
-    const config = {
-    }
+    const config = { connection }
     const handler = middy((event, context, cb) => {
       expect(context.db.toString()).toEqual(clientMock.toString()) // compare invocations, not functions
       expect(newClient).toHaveBeenCalledTimes(1)
@@ -276,9 +286,11 @@ describe('💾  Database manager', () => {
     })
   })
 
-  test('it should create an authToken to be used as the password', (done) => {
+  // TODO async before causing quite error w/r toHaveBeenCalledTimes, running test by itself passes.
+  test('it should create an authToken to be used as the password', async () => {
     const newClient = jest.fn().mockReturnValue(clientMock)
     const secretsPath = 'secret_location'
+    const secretsValue = 'secret_token'
     const config = {
       connection: {
         host: '127.0.0.1',
@@ -286,9 +298,13 @@ describe('💾  Database manager', () => {
         port: '5432'
       }
     }
+    getAuthTokenMock.mockReturnValue({
+      promise: () => Promise.resolve(secretsValue)
+    })
     const handler = middy((event, context, cb) => {
       expect(context.db.toString()).toEqual(clientMock.toString()) // compare invocations, not functions
       expect(newClient).toHaveBeenCalledTimes(1)
+      config.connection[secretsPath] = secretsValue
       expect(newClient).toHaveBeenCalledWith(config)
       return cb(null, event.body) // propagates the body as a response
     })
@@ -309,10 +325,9 @@ describe('💾  Database manager', () => {
     const event = {
       body: JSON.stringify({ foo: 'bar' })
     }
-    handler(event, {}, (err, body) => {
+    await handler(event, {}, (err, body) => {
       expect(err).toEqual(null)
       expect(body).toEqual('{"foo":"bar"}')
-      done()
     })
   })
 })

--- a/packages/db-manager/index.d.ts
+++ b/packages/db-manager/index.d.ts
@@ -2,6 +2,7 @@ import Knex from 'knex';
 
 export interface DbManagerOptions {
   client?: any,
+  rdsSigner?: any,
   config: Knex.Config | Knex.AliasDict,
   forceNewConnection?: boolean,
   secretsPath?: string,

--- a/packages/db-manager/index.js
+++ b/packages/db-manager/index.js
@@ -7,16 +7,22 @@ module.exports = (opts) => {
   const defaults = {
     client: knex,
     config: null,
-    awsSdkOptions: null,
+    rdsSigner: null,
     forceNewConnection: false,
-    secretsPath: null, // provide path where credentials lay in context
+    secretsPath: null, // provide path where credentials lay in context, default to try to get RDS authToken
     removeSecrets: true
   }
 
   const options = Object.assign({}, defaults, opts)
 
+  const cleanup = (handler, next) => {
+    if (options.forceNewConnection && (dbInstance && typeof dbInstance.destroy === 'function')) {
+      dbInstance.destroy((err) => next(err || handler.error))
+    }
+    next(handler.error)
+  }
+
   const signer = (config) => {
-    if (!config.region && config.hostname) config.region = config.hostname.split('.')[2]
     if (typeof config.port === 'string') config.port = Number.parseInt(config.port)
     const signer = new RDS.Signer(config)
     return new Promise((resolve, reject) => {
@@ -29,15 +35,8 @@ module.exports = (opts) => {
     })
   }
 
-  const cleanup = (handler, next) => {
-    if (options.forceNewConnection && (dbInstance && typeof dbInstance.destroy === 'function')) {
-      dbInstance.destroy((err) => next(err || handler.error))
-    }
-    next(handler.error)
-  }
-
   return {
-    before: async (handler, next) => {
+    before: (handler, next) => {
       const {
         client,
         config,
@@ -50,24 +49,32 @@ module.exports = (opts) => {
         throw new Error('Config is required in dbManager')
       }
 
+      let secretPromise = Promise.resolve()
       if (!dbInstance || forceNewConnection) {
         const secrets = {}
-        if (options.awsSdkOptions !== null && secretsPath) {
-          secrets[secretsPath] = await signer(options.awsSdkOptions)
+
+        if (options.rdsSigner && secretsPath) {
+          // secrets[secretsPath] = await signer(options.rdsSigner)
+          secretPromise = signer(options.rdsSigner)
         } else if (secretsPath) {
-          secrets[secretsPath] = handler.context[secretsPath]
+          // secrets[secretsPath] = handler.context[secretsPath]
+          secretPromise = Promise.resolve(handler.context[secretsPath])
         }
-        config.connection = Object.assign({}, config.connection || {}, secrets)
+        secretPromise.then((secret) => {
+          secrets[secretsPath] = secret
+          config.connection = Object.assign({}, config.connection || {}, secrets)
 
-        dbInstance = client(config)
+          dbInstance = client(config)
+        })
       }
 
-      Object.assign(handler.context, { db: dbInstance })
-      if (secretsPath && removeSecrets) {
-        delete handler.context[secretsPath]
-      }
-
-      next()
+      secretPromise.then(() => {
+        Object.assign(handler.context, { db: dbInstance })
+        if (secretsPath && removeSecrets) {
+          delete handler.context[secretsPath]
+        }
+        next()
+      })
     },
 
     after: cleanup,

--- a/packages/db-manager/index.js
+++ b/packages/db-manager/index.js
@@ -36,7 +36,7 @@ module.exports = (opts) => {
   }
 
   return {
-    before: async (handler, next) => {
+    before: async (handler) => {
       const {
         client,
         config,

--- a/packages/db-manager/index.js
+++ b/packages/db-manager/index.js
@@ -1,4 +1,5 @@
 const knex = require('knex')
+const RDS = require('aws-sdk/clients/rds')
 
 let dbInstance
 
@@ -6,6 +7,7 @@ module.exports = (opts) => {
   const defaults = {
     client: knex,
     config: null,
+    rdsSigner: null,
     forceNewConnection: false,
     secretsPath: null, // provide path where credentials lay in context
     removeSecrets: true
@@ -20,8 +22,21 @@ module.exports = (opts) => {
     next(handler.error)
   }
 
+  const signer = (config) => {
+    if (typeof config.port === 'string') config.port = Number.parseInt(config.port)
+    const signer = new RDS.Signer(config)
+    return new Promise((resolve, reject) => {
+      signer.getAuthToken({}, (err, token) => {
+        if (err) {
+          reject(err)
+        }
+        resolve(token)
+      })
+    })
+  }
+
   return {
-    before: (handler, next) => {
+    before: async (handler, next) => {
       const {
         client,
         config,
@@ -34,9 +49,14 @@ module.exports = (opts) => {
         throw new Error('Config is required in dbManager')
       }
       if (!dbInstance || forceNewConnection) {
-        if (secretsPath) {
-          config.connection = Object.assign({}, config.connection || {}, handler.context[secretsPath])
+        const secrets = {}
+        if (options.rdsSigner !== null && secretsPath) {
+          secrets[secretsPath] = await signer(options.rdsSigner)
+        } else if (secretsPath) {
+          secrets[secretsPath] = handler.context[secretsPath]
         }
+        config.connection = Object.assign({}, config.connection || {}, secrets)
+
         dbInstance = client(config)
       }
 
@@ -44,7 +64,7 @@ module.exports = (opts) => {
       if (secretsPath && removeSecrets) {
         delete handler.context[secretsPath]
       }
-      return next()
+      next()
     },
 
     after: cleanup,


### PR DESCRIPTION
Closes #428

I did build it as a separate middleware, but the amount of excess code needed and managing the expiry didn't seem right.

Looking for some feedback/help:
- [x] `rdsSigner` option name, need to change?
- [x] A way to mock out `RDS.Signer`, currently failing due to missing creds
- [x] Should we add a connection retry in? Not at this time
- [x] One test having issue with `async`

cc @sdomagala