### PR TITLE
[TypeScript] Ability to set your own context

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,14 +4,14 @@ import {
   Handler
 } from 'aws-lambda';
 
-declare type EventType<T> =
-  T extends (event: infer EventArgType, context: Context, callback: Callback<any>) => void ? EventArgType :
-  T extends (event: infer EventArgType, context: Context) => Promise<any> ? EventArgType :
+declare type EventType<T, C> =
+  T extends (event: infer EventArgType, context: C, callback: Callback<any>) => void ? EventArgType :
+  T extends (event: infer EventArgType, context: C) => Promise<any> ? EventArgType :
   never;
 
-declare type HandlerReturnType<T> =
-  T extends (event: any, context: Context) => Promise<infer RetType> ? RetType :
-  T extends (event: any, context: Context, callback: Callback<infer RetType>) => void ? RetType :
+declare type HandlerReturnType<T, C> =
+  T extends (event: any, context: C) => Promise<infer RetType> ? RetType :
+  T extends (event: any, context: C, callback: Callback<infer RetType>) => void ? RetType :
   never;
 
 declare type AsyncHandler<C extends Context> =
@@ -19,8 +19,8 @@ declare type AsyncHandler<C extends Context> =
   ((event: any, context: C) => Promise<any>);
 
 declare const middy: <H extends AsyncHandler<C>, C extends Context = Context>(handler: H) => middy.Middy<
-  EventType<H>,
-  HandlerReturnType<H>,
+  EventType<H, C>,
+  HandlerReturnType<H, C>,
   C
 >;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "main": "./index.js",
   "files": [


### PR DESCRIPTION
Hey @lmammino,
Right now even though some packages rely on context modification you can't change it and use TypeScript in the same time.
I have changed typings so now your custom context is visible in TypeScript, without this change your middleware functions need to have format `HandlerLambda<never, never, CustomContext>`.

Cheers