### PR TITLE
Added update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 </p>
 </div>
 
-**⚠️ UPGRADE NOTICE: if you are updating from Middy 0.x, check out the [update instructions](/UPDATE.md)!**
+**⚠️ UPGRADE NOTICE: if you are updating from Middy 0.x, check out the [update instructions](UPDATE.md)!**
 
 ## What is Middy
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@
 </p>
 </div>
 
+**UPGRADE NOTICE: if you are updating from Middy 0.x, check out the [update instructions](/UPDATE.md)!**
+
 ## What is Middy
 
 Middy is a very simple middleware engine that allows you to simplify your AWS Lambda code when using Node.js.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 </p>
 </div>
 
-**UPGRADE NOTICE: if you are updating from Middy 0.x, check out the [update instructions](/UPDATE.md)!**
+**⚠️ UPGRADE NOTICE: if you are updating from Middy 0.x, check out the [update instructions](/UPDATE.md)!**
 
 ## What is Middy
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,35 @@
+# 0.x -> 1.0
+
+## Independent packages structure
+
+Version 1.0 of Middy features decoupled independent packages published on npm under the `@middy` namespace. The core middleware engine has been modev to [`@middy/core`](https://www.npmjs.com/package/@middy/core) and all the other middlewares are moved into their own paclages as well. This allows to only install the features that are needed and to keep your Lambda dependencies small. See the list below to check which packages you need based on the middlewares you use:
+
+  - Core middleware functionality -> [`@middy/core`](https://www.npmjs.com/package/@middy/core)
+  - `cache` -> [`@middy/cache`](https://www.npmjs.com/package/@middy/cache)
+  - `cors` -> [`@middy/http-cors`](https://www.npmjs.com/package/@middy/http-cors)
+  - `doNotWaitForEmptyEventLoop` -> [`@middy/do-not-wait-for-empty-event-loop`](https://www.npmjs.com/package/@middy/do-not-wait-for-empty-event-loop)
+  - `httpContentNegotiation` ->  [`@middy/http-content-negotiation`](https://www.npmjs.com/package/@middy/http-content-negotiation)
+  - `httpErrorHandler` ->  [`@middy/http-error-handler`](https://www.npmjs.com/package/@middy/http-error-handler)
+  - `httpEventNormalizer` ->  [`@middy/http-event-normalizer`](https://www.npmjs.com/package/@middy/http-event-normalizer)
+  - `httpHeaderNormalizer` ->  [`@middy/http-header-normalizer`](https://www.npmjs.com/package/@middy/http-header-normalizer)
+  - `httpMultipartBodyParser` ->  [`@middy/http-json-body-parser`](https://www.npmjs.com/package/@middy/http-json-body-parser)
+  - `httpPartialResponse` ->  [`@middy/http-partial-response`](https://www.npmjs.com/package/@middy/http-partial-response)
+  - `jsonBodyParser` ->  [`@middy/http-json-body-parser`](https://www.npmjs.com/package/@middy/http-json-body-parser)
+  - `s3KeyNormalizer` ->  [`@middy/s3-key-normalizer`](https://www.npmjs.com/package/@middy/s3-key-normalizer)
+  - `secretsManager` ->  [`@middy/secrets-manager`](https://www.npmjs.com/package/@middy/secrets-manager)
+  - `ssm` ->  [`@middy/ssm`](https://www.npmjs.com/package/@middy/ssm)
+  - `validator` ->  [`@middy/validator`](https://www.npmjs.com/package/@middy/validator)
+  - `urlEncodeBodyParser` ->  [`@middy/http-urlencode-body-parser`](https://www.npmjs.com/package/@middy/http-urlencode-body-parser)
+  - `warmup` ->  [`@middy/warmup`](https://www.npmjs.com/package/@middy/warmup)
+
+
+## Header normalization in `http-header-normalizer`
+
+In Middy 0.x the `httpHeaderNormalizer` middleware normalizes HTTP header names into their own canonical format, for instance `Sec-WebSocket-Key` (notice the casing). In Middy 1.0 this behavior has been changed to provide header names in lowercase format (e.g. `sec-webSocket-key`). This new behavior is more consistent with what Node.js core `http` package does and what other famous http frameworks like Express or Fastify do, so this is considered a more intuitive approach.
+When updating to Middy 1.0, make sure you double check all your references to HTTP headers and switch to the lowercase version to read them.
+All the middy core modules have been already updated to support the new format, so you should worry only about your userland code.
+
+
+## Node.js 10 and 12 now supported / Node.js 6 and 8 now dropped
+
+Version 1.0 of Middy does not support Node.js versions 6.x and 8.x. These versions are now out of support, so you are highly encourage to move to Node.js 12 or 10, which are the new supported versions in Middy 1.0.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,7 +2,7 @@
 
 ## Independent packages structure
 
-Version 1.0 of Middy features decoupled independent packages published on npm under the `@middy` namespace. The core middleware engine has been moved to [`@middy/core`](https://www.npmjs.com/package/@middy/core) and all the other middlewares are moved into their own packages as well. This allows to only install the features that are needed and to keep your Lambda dependencies small. See the list below to check which packages you need based on the middlewares you use:
+Version 1.x of Middy features decoupled independent packages published on npm under the `@middy` namespace. The core middleware engine has been moved to [`@middy/core`](https://www.npmjs.com/package/@middy/core) and all the other middlewares are moved into their own packages as well. This allows to only install the features that are needed and to keep your Lambda dependencies small. See the list below to check which packages you need based on the middlewares you use:
 
   - Core middleware functionality -> [`@middy/core`](https://www.npmjs.com/package/@middy/core)
   - `cache` -> [`@middy/cache`](https://www.npmjs.com/package/@middy/cache)
@@ -25,11 +25,11 @@ Version 1.0 of Middy features decoupled independent packages published on npm un
 
 ## Header normalization in `http-header-normalizer`
 
-In Middy 0.x the `httpHeaderNormalizer` middleware normalizes HTTP header names into their own canonical format, for instance `Sec-WebSocket-Key` (notice the casing). In Middy 1.0 this behavior has been changed to provide header names in lowercase format (e.g. `sec-webSocket-key`). This new behavior is more consistent with what Node.js core `http` package does and what other famous http frameworks like Express or Fastify do, so this is considered a more intuitive approach.
-When updating to Middy 1.0, make sure you double check all your references to HTTP headers and switch to the lowercase version to read them.
+In Middy 0.x the `httpHeaderNormalizer` middleware normalizes HTTP header names into their own canonical format, for instance `Sec-WebSocket-Key` (notice the casing). In Middy 1.x this behavior has been changed to provide header names in lowercase format (e.g. `sec-webSocket-key`). This new behavior is more consistent with what Node.js core `http` package does and what other famous http frameworks like Express or Fastify do, so this is considered a more intuitive approach.
+When updating to Middy 1.x, make sure you double check all your references to HTTP headers and switch to the lowercase version to read them.
 All the middy core modules have been already updated to support the new format, so you should worry only about your userland code.
 
 
 ## Node.js 10 and 12 now supported / Node.js 6 and 8 now dropped
 
-Version 1.0 of Middy no longer supports Node.js versions 6.x and 8.x as these versions have been dropped by the AWS Lambda runtime itself and not supported anymore by the Node.js community. You are highly encouraged to move to Node.js 12 or 10, which are the new supported versions in Middy 1.0.
+Version 1.x of Middy no longer supports Node.js versions 6.x and 8.x as these versions have been dropped by the AWS Lambda runtime itself and not supported anymore by the Node.js community. You are highly encouraged to move to Node.js 12 or 10, which are the new supported versions in Middy 1.x.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,8 +1,8 @@
-# 0.x -> 1.0
+# 0.x -> 1.x
 
 ## Independent packages structure
 
-Version 1.0 of Middy features decoupled independent packages published on npm under the `@middy` namespace. The core middleware engine has been modev to [`@middy/core`](https://www.npmjs.com/package/@middy/core) and all the other middlewares are moved into their own paclages as well. This allows to only install the features that are needed and to keep your Lambda dependencies small. See the list below to check which packages you need based on the middlewares you use:
+Version 1.0 of Middy features decoupled independent packages published on npm under the `@middy` namespace. The core middleware engine has been moved to [`@middy/core`](https://www.npmjs.com/package/@middy/core) and all the other middlewares are moved into their own packages as well. This allows to only install the features that are needed and to keep your Lambda dependencies small. See the list below to check which packages you need based on the middlewares you use:
 
   - Core middleware functionality -> [`@middy/core`](https://www.npmjs.com/package/@middy/core)
   - `cache` -> [`@middy/cache`](https://www.npmjs.com/package/@middy/cache)
@@ -32,4 +32,4 @@ All the middy core modules have been already updated to support the new format, 
 
 ## Node.js 10 and 12 now supported / Node.js 6 and 8 now dropped
 
-Version 1.0 of Middy does not support Node.js versions 6.x and 8.x. These versions are now out of support, so you are highly encourage to move to Node.js 12 or 10, which are the new supported versions in Middy 1.0.
+Version 1.0 of Middy no longer supports Node.js versions 6.x and 8.x as these versions have been dropped by the AWS Lambda runtime itself and not supported anymore by the Node.js community. You are highly encouraged to move to Node.js 12 or 10, which are the new supported versions in Middy 1.0.

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.0.0-alpha.64"
+  "version": "1.0.0-alpha.65"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy-monorepo",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy-monorepo",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "engines": {
     "node": ">=10"

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/cache",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-alpha.63",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.63.tgz",
-      "integrity": "sha512-i19Jo2gek/ygc2n3XggmaRhluexgVnHnAay7g7ga4f/ADv1KcYK7U7woMONhswYAz+Bagd9L8eYhtKyEHLDgnw==",
+      "version": "1.0.0-alpha.64",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.64.tgz",
+      "integrity": "sha512-I/WcE+R16NKx11gxJ6ISK1dWU0fG9vhRM1x5TDwWk/GjjHzq1ENgljnHZFBhzKezTufouESTMyR62OPPjUD0Xw==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/cache",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "Cache middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -41,7 +41,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.64",
+    "@middy/core": "^1.0.0-alpha.65",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/core",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/core",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda (core package)",
   "engines": {
     "node": ">=10"

--- a/packages/db-manager/package-lock.json
+++ b/packages/db-manager/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/db-manager",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,9 +14,9 @@
       }
     },
     "@middy/core": {
-      "version": "1.0.0-alpha.63",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.63.tgz",
-      "integrity": "sha512-i19Jo2gek/ygc2n3XggmaRhluexgVnHnAay7g7ga4f/ADv1KcYK7U7woMONhswYAz+Bagd9L8eYhtKyEHLDgnw==",
+      "version": "1.0.0-alpha.64",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.64.tgz",
+      "integrity": "sha512-I/WcE+R16NKx11gxJ6ISK1dWU0fG9vhRM1x5TDwWk/GjjHzq1ENgljnHZFBhzKezTufouESTMyR62OPPjUD0Xw==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/db-manager/package.json
+++ b/packages/db-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/db-manager",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "Simple database manager for the middy framework",
   "engines": {
     "node": ">=10"
@@ -40,7 +40,7 @@
     "knex": "^0.17.3"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.64"
+    "@middy/core": "^1.0.0-alpha.65"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"
 }

--- a/packages/do-not-wait-for-empty-event-loop/package-lock.json
+++ b/packages/do-not-wait-for-empty-event-loop/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/do-not-wait-for-empty-event-loop",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-alpha.63",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.63.tgz",
-      "integrity": "sha512-i19Jo2gek/ygc2n3XggmaRhluexgVnHnAay7g7ga4f/ADv1KcYK7U7woMONhswYAz+Bagd9L8eYhtKyEHLDgnw==",
+      "version": "1.0.0-alpha.64",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.64.tgz",
+      "integrity": "sha512-I/WcE+R16NKx11gxJ6ISK1dWU0fG9vhRM1x5TDwWk/GjjHzq1ENgljnHZFBhzKezTufouESTMyR62OPPjUD0Xw==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/do-not-wait-for-empty-event-loop/package.json
+++ b/packages/do-not-wait-for-empty-event-loop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/do-not-wait-for-empty-event-loop",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "Middleware for the middy framework that allows to easily disable the wait for empty event loop in a Lambda function",
   "engines": {
     "node": ">=10"
@@ -41,7 +41,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.64",
+    "@middy/core": "^1.0.0-alpha.65",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/error-logger/package-lock.json
+++ b/packages/error-logger/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/error-logger",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-alpha.63",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.63.tgz",
-      "integrity": "sha512-i19Jo2gek/ygc2n3XggmaRhluexgVnHnAay7g7ga4f/ADv1KcYK7U7woMONhswYAz+Bagd9L8eYhtKyEHLDgnw==",
+      "version": "1.0.0-alpha.64",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.64.tgz",
+      "integrity": "sha512-I/WcE+R16NKx11gxJ6ISK1dWU0fG9vhRM1x5TDwWk/GjjHzq1ENgljnHZFBhzKezTufouESTMyR62OPPjUD0Xw==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/error-logger/package.json
+++ b/packages/error-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/error-logger",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "Input and output logger middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -47,7 +47,7 @@
     "@types/node": "^10.0.8"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.64",
+    "@middy/core": "^1.0.0-alpha.65",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/function-shield/package-lock.json
+++ b/packages/function-shield/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/function-shield",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-alpha.63",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.63.tgz",
-      "integrity": "sha512-i19Jo2gek/ygc2n3XggmaRhluexgVnHnAay7g7ga4f/ADv1KcYK7U7woMONhswYAz+Bagd9L8eYhtKyEHLDgnw==",
+      "version": "1.0.0-alpha.64",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.64.tgz",
+      "integrity": "sha512-I/WcE+R16NKx11gxJ6ISK1dWU0fG9vhRM1x5TDwWk/GjjHzq1ENgljnHZFBhzKezTufouESTMyR62OPPjUD0Xw==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/function-shield/package.json
+++ b/packages/function-shield/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/function-shield",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "Hardens AWS Lambda execution environment",
   "engines": {
     "node": ">=10"
@@ -45,7 +45,7 @@
     "@puresec/function-shield": "^1.2.2"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.64",
+    "@middy/core": "^1.0.0-alpha.65",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/http-content-negotiation/package-lock.json
+++ b/packages/http-content-negotiation/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/http-content-negotiation",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-alpha.63",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.63.tgz",
-      "integrity": "sha512-i19Jo2gek/ygc2n3XggmaRhluexgVnHnAay7g7ga4f/ADv1KcYK7U7woMONhswYAz+Bagd9L8eYhtKyEHLDgnw==",
+      "version": "1.0.0-alpha.64",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.64.tgz",
+      "integrity": "sha512-I/WcE+R16NKx11gxJ6ISK1dWU0fG9vhRM1x5TDwWk/GjjHzq1ENgljnHZFBhzKezTufouESTMyR62OPPjUD0Xw==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/http-content-negotiation/package.json
+++ b/packages/http-content-negotiation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-content-negotiation",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "Http content negotiation middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -47,7 +47,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.64",
+    "@middy/core": "^1.0.0-alpha.65",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/http-cors/README.md
+++ b/packages/http-cors/README.md
@@ -10,8 +10,8 @@
 
 <div align="center">
 <p>
-  <a href="http://badge.fury.io/js/%40middy%2Fcors">
-    <img src="https://badge.fury.io/js/%40middy%2Fcors.svg" alt="npm version" style="max-width:100%;">
+  <a href="http://badge.fury.io/js/%40middy%2Fhttp-cors">
+    <img src="https://badge.fury.io/js/%40middy%2Fhttp-cors.svg" alt="npm version" style="max-width:100%;">
   </a>
   <a href="https://snyk.io/test/github/middyjs/middy">
     <img src="https://snyk.io/test/github/middyjs/middy/badge.svg" alt="Known Vulnerabilities" data-canonical-src="https://snyk.io/test/github/middyjs/middy" style="max-width:100%;">

--- a/packages/http-cors/package-lock.json
+++ b/packages/http-cors/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/http-cors",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-alpha.63",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.63.tgz",
-      "integrity": "sha512-i19Jo2gek/ygc2n3XggmaRhluexgVnHnAay7g7ga4f/ADv1KcYK7U7woMONhswYAz+Bagd9L8eYhtKyEHLDgnw==",
+      "version": "1.0.0-alpha.64",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.64.tgz",
+      "integrity": "sha512-I/WcE+R16NKx11gxJ6ISK1dWU0fG9vhRM1x5TDwWk/GjjHzq1ENgljnHZFBhzKezTufouESTMyR62OPPjUD0Xw==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/http-cors/package.json
+++ b/packages/http-cors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-cors",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "CORS (Cross-Origin Resource Sharing) middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -42,7 +42,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.64",
+    "@middy/core": "^1.0.0-alpha.65",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/http-error-handler/package-lock.json
+++ b/packages/http-error-handler/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/http-error-handler",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-alpha.63",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.63.tgz",
-      "integrity": "sha512-i19Jo2gek/ygc2n3XggmaRhluexgVnHnAay7g7ga4f/ADv1KcYK7U7woMONhswYAz+Bagd9L8eYhtKyEHLDgnw==",
+      "version": "1.0.0-alpha.64",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.64.tgz",
+      "integrity": "sha512-I/WcE+R16NKx11gxJ6ISK1dWU0fG9vhRM1x5TDwWk/GjjHzq1ENgljnHZFBhzKezTufouESTMyR62OPPjUD0Xw==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/http-error-handler/package.json
+++ b/packages/http-error-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-error-handler",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "Http error handler middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -47,7 +47,7 @@
     "http-errors": "^1.6.3"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.64",
+    "@middy/core": "^1.0.0-alpha.65",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/http-event-normalizer/package-lock.json
+++ b/packages/http-event-normalizer/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/http-event-normalizer",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-alpha.63",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.63.tgz",
-      "integrity": "sha512-i19Jo2gek/ygc2n3XggmaRhluexgVnHnAay7g7ga4f/ADv1KcYK7U7woMONhswYAz+Bagd9L8eYhtKyEHLDgnw==",
+      "version": "1.0.0-alpha.64",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.64.tgz",
+      "integrity": "sha512-I/WcE+R16NKx11gxJ6ISK1dWU0fG9vhRM1x5TDwWk/GjjHzq1ENgljnHZFBhzKezTufouESTMyR62OPPjUD0Xw==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/http-event-normalizer/package.json
+++ b/packages/http-event-normalizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-event-normalizer",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "Http event normalizer middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -43,7 +43,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.64",
+    "@middy/core": "^1.0.0-alpha.65",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/http-header-normalizer/package-lock.json
+++ b/packages/http-header-normalizer/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/http-header-normalizer",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-alpha.63",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.63.tgz",
-      "integrity": "sha512-i19Jo2gek/ygc2n3XggmaRhluexgVnHnAay7g7ga4f/ADv1KcYK7U7woMONhswYAz+Bagd9L8eYhtKyEHLDgnw==",
+      "version": "1.0.0-alpha.64",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.64.tgz",
+      "integrity": "sha512-I/WcE+R16NKx11gxJ6ISK1dWU0fG9vhRM1x5TDwWk/GjjHzq1ENgljnHZFBhzKezTufouESTMyR62OPPjUD0Xw==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/http-header-normalizer/package.json
+++ b/packages/http-header-normalizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-header-normalizer",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "Http header normalizer middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -45,7 +45,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.64",
+    "@middy/core": "^1.0.0-alpha.65",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/http-json-body-parser/package-lock.json
+++ b/packages/http-json-body-parser/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/http-json-body-parser",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-alpha.63",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.63.tgz",
-      "integrity": "sha512-i19Jo2gek/ygc2n3XggmaRhluexgVnHnAay7g7ga4f/ADv1KcYK7U7woMONhswYAz+Bagd9L8eYhtKyEHLDgnw==",
+      "version": "1.0.0-alpha.64",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.64.tgz",
+      "integrity": "sha512-I/WcE+R16NKx11gxJ6ISK1dWU0fG9vhRM1x5TDwWk/GjjHzq1ENgljnHZFBhzKezTufouESTMyR62OPPjUD0Xw==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/http-json-body-parser/package.json
+++ b/packages/http-json-body-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-json-body-parser",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "Http JSON body parser middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -50,7 +50,7 @@
     "http-errors": "^1.6.3"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.64",
+    "@middy/core": "^1.0.0-alpha.65",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/http-multipart-body-parser/package-lock.json
+++ b/packages/http-multipart-body-parser/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/http-multipart-body-parser",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-alpha.63",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.63.tgz",
-      "integrity": "sha512-i19Jo2gek/ygc2n3XggmaRhluexgVnHnAay7g7ga4f/ADv1KcYK7U7woMONhswYAz+Bagd9L8eYhtKyEHLDgnw==",
+      "version": "1.0.0-alpha.64",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.64.tgz",
+      "integrity": "sha512-I/WcE+R16NKx11gxJ6ISK1dWU0fG9vhRM1x5TDwWk/GjjHzq1ENgljnHZFBhzKezTufouESTMyR62OPPjUD0Xw==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/http-multipart-body-parser/package.json
+++ b/packages/http-multipart-body-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-multipart-body-parser",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "Http event normalizer middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -48,7 +48,7 @@
     "http-errors": "^1.7.3"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.64",
+    "@middy/core": "^1.0.0-alpha.65",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/http-partial-response/package-lock.json
+++ b/packages/http-partial-response/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/http-partial-response",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-alpha.63",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.63.tgz",
-      "integrity": "sha512-i19Jo2gek/ygc2n3XggmaRhluexgVnHnAay7g7ga4f/ADv1KcYK7U7woMONhswYAz+Bagd9L8eYhtKyEHLDgnw==",
+      "version": "1.0.0-alpha.64",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.64.tgz",
+      "integrity": "sha512-I/WcE+R16NKx11gxJ6ISK1dWU0fG9vhRM1x5TDwWk/GjjHzq1ENgljnHZFBhzKezTufouESTMyR62OPPjUD0Xw==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/http-partial-response/package.json
+++ b/packages/http-partial-response/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-partial-response",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "Http partial response middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -47,7 +47,7 @@
     "json-mask": "^0.3.8"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.64",
+    "@middy/core": "^1.0.0-alpha.65",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/http-response-serializer/package-lock.json
+++ b/packages/http-response-serializer/package-lock.json
@@ -1,13 +1,13 @@
 {
 	"name": "@middy/http-response-serializer",
-	"version": "1.0.0-alpha.64",
+	"version": "1.0.0-alpha.65",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@middy/core": {
-			"version": "1.0.0-alpha.63",
-			"resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.63.tgz",
-			"integrity": "sha512-i19Jo2gek/ygc2n3XggmaRhluexgVnHnAay7g7ga4f/ADv1KcYK7U7woMONhswYAz+Bagd9L8eYhtKyEHLDgnw==",
+			"version": "1.0.0-alpha.64",
+			"resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.64.tgz",
+			"integrity": "sha512-I/WcE+R16NKx11gxJ6ISK1dWU0fG9vhRM1x5TDwWk/GjjHzq1ENgljnHZFBhzKezTufouESTMyR62OPPjUD0Xw==",
 			"dev": true,
 			"requires": {
 				"once": "^1.4.0"

--- a/packages/http-response-serializer/package.json
+++ b/packages/http-response-serializer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-response-serializer",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "The Http Serializer middleware lets you define serialization mechanisms based on the current content negotiation.",
   "engines": {
     "node": ">=10"
@@ -50,7 +50,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.64",
+    "@middy/core": "^1.0.0-alpha.65",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/http-security-headers/package-lock.json
+++ b/packages/http-security-headers/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/http-security-headers",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-alpha.63",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.63.tgz",
-      "integrity": "sha512-i19Jo2gek/ygc2n3XggmaRhluexgVnHnAay7g7ga4f/ADv1KcYK7U7woMONhswYAz+Bagd9L8eYhtKyEHLDgnw==",
+      "version": "1.0.0-alpha.64",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.64.tgz",
+      "integrity": "sha512-I/WcE+R16NKx11gxJ6ISK1dWU0fG9vhRM1x5TDwWk/GjjHzq1ENgljnHZFBhzKezTufouESTMyR62OPPjUD0Xw==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/http-security-headers/package.json
+++ b/packages/http-security-headers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-security-headers",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "Applies best practice security headers to responses. It's a simplified port of HelmetJS",
   "engines": {
     "node": ">=10"
@@ -46,7 +46,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.64",
+    "@middy/core": "^1.0.0-alpha.65",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/http-urlencode-body-parser/package-lock.json
+++ b/packages/http-urlencode-body-parser/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/http-urlencode-body-parser",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-alpha.63",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.63.tgz",
-      "integrity": "sha512-i19Jo2gek/ygc2n3XggmaRhluexgVnHnAay7g7ga4f/ADv1KcYK7U7woMONhswYAz+Bagd9L8eYhtKyEHLDgnw==",
+      "version": "1.0.0-alpha.64",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.64.tgz",
+      "integrity": "sha512-I/WcE+R16NKx11gxJ6ISK1dWU0fG9vhRM1x5TDwWk/GjjHzq1ENgljnHZFBhzKezTufouESTMyR62OPPjUD0Xw==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/http-urlencode-body-parser/package.json
+++ b/packages/http-urlencode-body-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-urlencode-body-parser",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "Urlencode body parser middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -50,7 +50,7 @@
     "querystring": "^0.2.0"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.64",
+    "@middy/core": "^1.0.0-alpha.65",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/http-urlencode-path-parser/package-lock.json
+++ b/packages/http-urlencode-path-parser/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/http-urlencode-path-parser",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-alpha.63",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.63.tgz",
-      "integrity": "sha512-i19Jo2gek/ygc2n3XggmaRhluexgVnHnAay7g7ga4f/ADv1KcYK7U7woMONhswYAz+Bagd9L8eYhtKyEHLDgnw==",
+      "version": "1.0.0-alpha.64",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.64.tgz",
+      "integrity": "sha512-I/WcE+R16NKx11gxJ6ISK1dWU0fG9vhRM1x5TDwWk/GjjHzq1ENgljnHZFBhzKezTufouESTMyR62OPPjUD0Xw==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/http-urlencode-path-parser/package.json
+++ b/packages/http-urlencode-path-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-urlencode-path-parser",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "Urlencode path parser middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -47,7 +47,7 @@
     "@types/http-errors": "^1.6.1"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.64"
+    "@middy/core": "^1.0.0-alpha.65"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"
 }

--- a/packages/input-output-logger/package-lock.json
+++ b/packages/input-output-logger/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/input-output-logger",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-alpha.63",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.63.tgz",
-      "integrity": "sha512-i19Jo2gek/ygc2n3XggmaRhluexgVnHnAay7g7ga4f/ADv1KcYK7U7woMONhswYAz+Bagd9L8eYhtKyEHLDgnw==",
+      "version": "1.0.0-alpha.64",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.64.tgz",
+      "integrity": "sha512-I/WcE+R16NKx11gxJ6ISK1dWU0fG9vhRM1x5TDwWk/GjjHzq1ENgljnHZFBhzKezTufouESTMyR62OPPjUD0Xw==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/input-output-logger/package.json
+++ b/packages/input-output-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/input-output-logger",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "Input and output logger middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -47,7 +47,7 @@
     "@types/node": "^10.0.8"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.64",
+    "@middy/core": "^1.0.0-alpha.65",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/s3-key-normalizer/package-lock.json
+++ b/packages/s3-key-normalizer/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/s3-key-normalizer",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-alpha.63",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.63.tgz",
-      "integrity": "sha512-i19Jo2gek/ygc2n3XggmaRhluexgVnHnAay7g7ga4f/ADv1KcYK7U7woMONhswYAz+Bagd9L8eYhtKyEHLDgnw==",
+      "version": "1.0.0-alpha.64",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.64.tgz",
+      "integrity": "sha512-I/WcE+R16NKx11gxJ6ISK1dWU0fG9vhRM1x5TDwWk/GjjHzq1ENgljnHZFBhzKezTufouESTMyR62OPPjUD0Xw==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/s3-key-normalizer/package.json
+++ b/packages/s3-key-normalizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/s3-key-normalizer",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "S3 key normalizer middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -43,7 +43,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.64",
+    "@middy/core": "^1.0.0-alpha.65",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/secrets-manager/package-lock.json
+++ b/packages/secrets-manager/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/secrets-manager",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-alpha.63",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.63.tgz",
-      "integrity": "sha512-i19Jo2gek/ygc2n3XggmaRhluexgVnHnAay7g7ga4f/ADv1KcYK7U7woMONhswYAz+Bagd9L8eYhtKyEHLDgnw==",
+      "version": "1.0.0-alpha.64",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.64.tgz",
+      "integrity": "sha512-I/WcE+R16NKx11gxJ6ISK1dWU0fG9vhRM1x5TDwWk/GjjHzq1ENgljnHZFBhzKezTufouESTMyR62OPPjUD0Xw==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/secrets-manager/package.json
+++ b/packages/secrets-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/secrets-manager",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "Secrets Manager middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -45,7 +45,7 @@
     "@types/node": "^10.0.8"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.64",
+    "@middy/core": "^1.0.0-alpha.65",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/ssm/package-lock.json
+++ b/packages/ssm/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/ssm",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-alpha.63",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.63.tgz",
-      "integrity": "sha512-i19Jo2gek/ygc2n3XggmaRhluexgVnHnAay7g7ga4f/ADv1KcYK7U7woMONhswYAz+Bagd9L8eYhtKyEHLDgnw==",
+      "version": "1.0.0-alpha.64",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.64.tgz",
+      "integrity": "sha512-I/WcE+R16NKx11gxJ6ISK1dWU0fG9vhRM1x5TDwWk/GjjHzq1ENgljnHZFBhzKezTufouESTMyR62OPPjUD0Xw==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/ssm/package.json
+++ b/packages/ssm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/ssm",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "SSM (EC2 Systems Manager) parameters middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -47,7 +47,7 @@
     "@types/node": "^10.0.8"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.64",
+    "@middy/core": "^1.0.0-alpha.65",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/validator/package-lock.json
+++ b/packages/validator/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/validator",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-alpha.63",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.63.tgz",
-      "integrity": "sha512-i19Jo2gek/ygc2n3XggmaRhluexgVnHnAay7g7ga4f/ADv1KcYK7U7woMONhswYAz+Bagd9L8eYhtKyEHLDgnw==",
+      "version": "1.0.0-alpha.64",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.64.tgz",
+      "integrity": "sha512-I/WcE+R16NKx11gxJ6ISK1dWU0fG9vhRM1x5TDwWk/GjjHzq1ENgljnHZFBhzKezTufouESTMyR62OPPjUD0Xw==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/validator",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "Validator middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -49,7 +49,7 @@
     "http-errors": "^1.6.3"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.64",
+    "@middy/core": "^1.0.0-alpha.65",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/warmup/package-lock.json
+++ b/packages/warmup/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/warmup",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-alpha.63",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.63.tgz",
-      "integrity": "sha512-i19Jo2gek/ygc2n3XggmaRhluexgVnHnAay7g7ga4f/ADv1KcYK7U7woMONhswYAz+Bagd9L8eYhtKyEHLDgnw==",
+      "version": "1.0.0-alpha.64",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-alpha.64.tgz",
+      "integrity": "sha512-I/WcE+R16NKx11gxJ6ISK1dWU0fG9vhRM1x5TDwWk/GjjHzq1ENgljnHZFBhzKezTufouESTMyR62OPPjUD0Xw==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/warmup/package.json
+++ b/packages/warmup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/warmup",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "Warmup (cold start mitigation) middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -43,7 +43,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-alpha.64",
+    "@middy/core": "^1.0.0-alpha.65",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"


### PR DESCRIPTION
Adds update instructions for devs coming from 0.x.


Once this is merged, I'll move the `alpha` version to `beta` and update the `0.x` branch with a warning to start switching to `1.0`.

I am thinking to aim first week of march as a official release date for `1.0`. At that point current `master` will be moved to its own `0.x` branch and `1.0.0-beta` will become the new `master`.