### PR TITLE
Add maxAge and cacheControl options to @middy/http-cors

### DIFF
--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -91,6 +91,8 @@ Sets headers in `after` and `onError` phases.
 - `origins` (array) (optional): An array of allowed origins. The incoming origin is matched against the list and is returned if present.
 - `headers` (string) (optional): value to put in Access-Control-Allow-Headers (default: `null`)
 - `credentials` (bool) (optional): if true, sets the `Access-Control-Allow-Origin` as request header `Origin`, if present (default `false`)
+- `maxAge` (string) (optional): value to put in Access-Control-Max-Age header (default: `null`)
+- `cacheControl` (string) (optional): value to put in Cache-Control header (default: `null`)
 
 NOTES:
 - If another middleware does not handle and swallow errors, then it will bubble all the way up

--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -92,7 +92,7 @@ Sets headers in `after` and `onError` phases.
 - `headers` (string) (optional): value to put in Access-Control-Allow-Headers (default: `null`)
 - `credentials` (bool) (optional): if true, sets the `Access-Control-Allow-Origin` as request header `Origin`, if present (default `false`)
 - `maxAge` (string) (optional): value to put in Access-Control-Max-Age header (default: `null`)
-- `cacheControl` (string) (optional): value to put in Cache-Control header (default: `null`)
+- `cacheControl` (string) (optional): value to put in Cache-Control header on pre-flight (OPTIONS) requests (default: `null`)
 
 NOTES:
 - If another middleware does not handle and swallow errors, then it will bubble all the way up

--- a/src/middlewares/__tests__/cors.js
+++ b/src/middlewares/__tests__/cors.js
@@ -384,7 +384,7 @@ describe('📦 Middleware CORS', () => {
     })
   })
 
-  test('it should overwrite Cache-Control header if already set', () => {
+  test('it should not overwrite Cache-Control header if already set', () => {
     const handler = middy((event, context, cb) => {
       cb(null, { headers: { 'Cache-Control': 'max-age=1200' } })
     })
@@ -426,7 +426,7 @@ describe('📦 Middleware CORS', () => {
     })
   })
 
-  test('it should overwrite Access-Control-Max-Age header if already set', () => {
+  test('it should not overwrite Access-Control-Max-Age header if already set', () => {
     const handler = middy((event, context, cb) => {
       cb(null, { headers: { 'Access-Control-Max-Age': '-1' } })
     })

--- a/src/middlewares/__tests__/cors.js
+++ b/src/middlewares/__tests__/cors.js
@@ -362,4 +362,88 @@ describe('📦 Middleware CORS', () => {
       expect(response).toEqual({})
     })
   })
+
+  test('it should set Cache-Control header if present in config', () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, {})
+    })
+
+    handler.use(cors({ cacheControl: 'max-age=3600, s-maxage=3600, proxy-revalidate' }))
+
+    const event = {
+      httpMethod: 'GET'
+    }
+
+    handler(event, {}, (_, response) => {
+      expect(response).toEqual({
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Cache-Control': 'max-age=3600, s-maxage=3600, proxy-revalidate'
+        }
+      })
+    })
+  })
+
+  test('it should overwrite Cache-Control header if already set', () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, { headers: { 'Cache-Control': 'max-age=1200' } })
+    })
+
+    handler.use(cors({ cacheControl: 'max-age=3600, s-maxage=3600, proxy-revalidate' }))
+
+    const event = {
+      httpMethod: 'GET'
+    }
+
+    handler(event, {}, (_, response) => {
+      expect(response).toEqual({
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Cache-Control': 'max-age=1200'
+        }
+      })
+    })
+  })
+
+  test('it should set Access-Control-Max-Age header if present in config', () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, {})
+    })
+
+    handler.use(cors({ maxAge: '3600' }))
+
+    const event = {
+      httpMethod: 'GET'
+    }
+
+    handler(event, {}, (_, response) => {
+      expect(response).toEqual({
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Max-Age': '3600'
+        }
+      })
+    })
+  })
+
+  test('it should overwrite Access-Control-Max-Age header if already set', () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, { headers: { 'Access-Control-Max-Age': '-1' } })
+    })
+
+    handler.use(cors({ maxAge: '3600' }))
+
+    const event = {
+      httpMethod: 'GET'
+    }
+
+    handler(event, {}, (_, response) => {
+      expect(response).toEqual({
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Max-Age': '-1'
+        }
+      })
+    })
+  })
 })

--- a/src/middlewares/__tests__/cors.js
+++ b/src/middlewares/__tests__/cors.js
@@ -363,7 +363,7 @@ describe('📦 Middleware CORS', () => {
     })
   })
 
-  test('it should set Cache-Control header if present in config', () => {
+  test('it should set Cache-Control header if present in config and http method OPTIONS', () => {
     const handler = middy((event, context, cb) => {
       cb(null, {})
     })
@@ -371,7 +371,7 @@ describe('📦 Middleware CORS', () => {
     handler.use(cors({ cacheControl: 'max-age=3600, s-maxage=3600, proxy-revalidate' }))
 
     const event = {
-      httpMethod: 'GET'
+      httpMethod: 'OPTIONS'
     }
 
     handler(event, {}, (_, response) => {
@@ -379,6 +379,23 @@ describe('📦 Middleware CORS', () => {
         headers: {
           'Access-Control-Allow-Origin': '*',
           'Cache-Control': 'max-age=3600, s-maxage=3600, proxy-revalidate'
+        }
+      })
+    })
+  })
+
+  test.each(['GET', 'POST', 'PUT', 'PATCH'])('it should not set Cache-Control header on %s', (httpMethod) => {
+    const handler = middy((event, context, cb) => {
+      cb(null, {})
+    })
+
+    handler.use(cors({ cacheControl: 'max-age=3600, s-maxage=3600, proxy-revalidate' }))
+
+    const event = { httpMethod }
+    handler(event, {}, (_, response) => {
+      expect(response).toEqual({
+        headers: {
+          'Access-Control-Allow-Origin': '*'
         }
       })
     })
@@ -392,7 +409,7 @@ describe('📦 Middleware CORS', () => {
     handler.use(cors({ cacheControl: 'max-age=3600, s-maxage=3600, proxy-revalidate' }))
 
     const event = {
-      httpMethod: 'GET'
+      httpMethod: 'OPTIONS'
     }
 
     handler(event, {}, (_, response) => {

--- a/src/middlewares/cors.js
+++ b/src/middlewares/cors.js
@@ -2,7 +2,9 @@ const defaults = {
   origin: '*',
   origins: [],
   headers: null,
-  credentials: false
+  credentials: false,
+  maxAge: null,
+  cacheControl: null
 }
 
 const getOrigin = (options, handler) => {
@@ -44,6 +46,14 @@ const addCorsHeaders = (opts, handler, next) => {
     // Check if already setup the header Access-Control-Allow-Origin
     if (!handler.response.headers.hasOwnProperty('Access-Control-Allow-Origin')) {
       handler.response.headers['Access-Control-Allow-Origin'] = getOrigin(options, handler)
+    }
+
+    if (options.maxAge && !handler.response.headers.hasOwnProperty('Access-Control-Max-Age')) {
+      handler.response.headers['Access-Control-Max-Age'] = String(options.maxAge)
+    }
+
+    if (options.cacheControl && !handler.response.headers.hasOwnProperty('Cache-Control')) {
+      handler.response.headers['Cache-Control'] = String(options.cacheControl)
     }
   }
 

--- a/src/middlewares/cors.js
+++ b/src/middlewares/cors.js
@@ -52,8 +52,10 @@ const addCorsHeaders = (opts, handler, next) => {
       handler.response.headers['Access-Control-Max-Age'] = String(options.maxAge)
     }
 
-    if (options.cacheControl && !handler.response.headers.hasOwnProperty('Cache-Control')) {
-      handler.response.headers['Cache-Control'] = String(options.cacheControl)
+    if (handler.event.httpMethod === 'OPTIONS') {
+      if (options.cacheControl && !handler.response.headers.hasOwnProperty('Cache-Control')) {
+        handler.response.headers['Cache-Control'] = String(options.cacheControl)
+      }
     }
   }
 


### PR DESCRIPTION
# Access-Control-Max-Age
https://fetch.spec.whatwg.org/#http-access-control-max-age

- Indicates the number of seconds (5 by default) the information provided by the `Access-Control-Allow-Methods` and `Access-Control-Allow-Headers` headers can be cached.

# Cache-Control
https://stackoverflow.com/questions/40731465/access-control-max-age-vs-cache-control
Some browsers may ignore `Access-Control-Max-Age` in that case `Cache-Control` helps to reduce the number calls on pre-flight requests (OPTIONS).

