### PR TITLE
Fix: Http-response-serializer returns {} when body is falsey

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.0.0-beta.5"
+  "version": "1.0.0-beta.6"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "middy-monorepo",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy-monorepo",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "engines": {
     "node": ">=10"

--- a/packages/cache/package-lock.json
+++ b/packages/cache/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/cache",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-U5jcCCWxXeKcnGxV99n4H6OZak0YLXLCqAn/8y/9ZtnaN56E6W3sd8wyxfO5A2WXrLjS/1hqIxyEfUvx8dbqxA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-aQESYn6jJQ73pjwk1hponQ9K1taxNSI6rxMuN8Im/nc7CwFwWu+c9iSRHwbWACu4rsleTn37lWUAH/vvZ7oEHg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/cache",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "Cache middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -41,7 +41,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-beta.5",
+    "@middy/core": "^1.0.0-beta.6",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/core",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/core",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda (core package)",
   "engines": {
     "node": ">=10"

--- a/packages/db-manager/package-lock.json
+++ b/packages/db-manager/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/db-manager",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,9 +14,9 @@
       }
     },
     "@middy/core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-U5jcCCWxXeKcnGxV99n4H6OZak0YLXLCqAn/8y/9ZtnaN56E6W3sd8wyxfO5A2WXrLjS/1hqIxyEfUvx8dbqxA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-aQESYn6jJQ73pjwk1hponQ9K1taxNSI6rxMuN8Im/nc7CwFwWu+c9iSRHwbWACu4rsleTn37lWUAH/vvZ7oEHg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/db-manager/package.json
+++ b/packages/db-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/db-manager",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "Simple database manager for the middy framework",
   "engines": {
     "node": ">=10"
@@ -40,7 +40,7 @@
     "knex": "^0.17.3"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-beta.5"
+    "@middy/core": "^1.0.0-beta.6"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"
 }

--- a/packages/do-not-wait-for-empty-event-loop/package-lock.json
+++ b/packages/do-not-wait-for-empty-event-loop/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/do-not-wait-for-empty-event-loop",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-U5jcCCWxXeKcnGxV99n4H6OZak0YLXLCqAn/8y/9ZtnaN56E6W3sd8wyxfO5A2WXrLjS/1hqIxyEfUvx8dbqxA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-aQESYn6jJQ73pjwk1hponQ9K1taxNSI6rxMuN8Im/nc7CwFwWu+c9iSRHwbWACu4rsleTn37lWUAH/vvZ7oEHg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/do-not-wait-for-empty-event-loop/package.json
+++ b/packages/do-not-wait-for-empty-event-loop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/do-not-wait-for-empty-event-loop",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "Middleware for the middy framework that allows to easily disable the wait for empty event loop in a Lambda function",
   "engines": {
     "node": ">=10"
@@ -41,7 +41,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-beta.5",
+    "@middy/core": "^1.0.0-beta.6",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/error-logger/package-lock.json
+++ b/packages/error-logger/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/error-logger",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-U5jcCCWxXeKcnGxV99n4H6OZak0YLXLCqAn/8y/9ZtnaN56E6W3sd8wyxfO5A2WXrLjS/1hqIxyEfUvx8dbqxA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-aQESYn6jJQ73pjwk1hponQ9K1taxNSI6rxMuN8Im/nc7CwFwWu+c9iSRHwbWACu4rsleTn37lWUAH/vvZ7oEHg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/error-logger/package.json
+++ b/packages/error-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/error-logger",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "Input and output logger middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -47,7 +47,7 @@
     "@types/node": "^10.0.8"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-beta.5",
+    "@middy/core": "^1.0.0-beta.6",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/function-shield/package-lock.json
+++ b/packages/function-shield/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/function-shield",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-U5jcCCWxXeKcnGxV99n4H6OZak0YLXLCqAn/8y/9ZtnaN56E6W3sd8wyxfO5A2WXrLjS/1hqIxyEfUvx8dbqxA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-aQESYn6jJQ73pjwk1hponQ9K1taxNSI6rxMuN8Im/nc7CwFwWu+c9iSRHwbWACu4rsleTn37lWUAH/vvZ7oEHg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/function-shield/package.json
+++ b/packages/function-shield/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/function-shield",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "Hardens AWS Lambda execution environment",
   "engines": {
     "node": ">=10"
@@ -45,7 +45,7 @@
     "@puresec/function-shield": "^2.0.16"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-beta.5",
+    "@middy/core": "^1.0.0-beta.6",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/http-content-negotiation/package-lock.json
+++ b/packages/http-content-negotiation/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/http-content-negotiation",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-U5jcCCWxXeKcnGxV99n4H6OZak0YLXLCqAn/8y/9ZtnaN56E6W3sd8wyxfO5A2WXrLjS/1hqIxyEfUvx8dbqxA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-aQESYn6jJQ73pjwk1hponQ9K1taxNSI6rxMuN8Im/nc7CwFwWu+c9iSRHwbWACu4rsleTn37lWUAH/vvZ7oEHg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/http-content-negotiation/package.json
+++ b/packages/http-content-negotiation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-content-negotiation",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "Http content negotiation middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -47,7 +47,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-beta.5",
+    "@middy/core": "^1.0.0-beta.6",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/http-cors/package-lock.json
+++ b/packages/http-cors/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/http-cors",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-U5jcCCWxXeKcnGxV99n4H6OZak0YLXLCqAn/8y/9ZtnaN56E6W3sd8wyxfO5A2WXrLjS/1hqIxyEfUvx8dbqxA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-aQESYn6jJQ73pjwk1hponQ9K1taxNSI6rxMuN8Im/nc7CwFwWu+c9iSRHwbWACu4rsleTn37lWUAH/vvZ7oEHg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/http-cors/package.json
+++ b/packages/http-cors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-cors",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "CORS (Cross-Origin Resource Sharing) middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -42,7 +42,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-beta.5",
+    "@middy/core": "^1.0.0-beta.6",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/http-error-handler/package-lock.json
+++ b/packages/http-error-handler/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/http-error-handler",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-U5jcCCWxXeKcnGxV99n4H6OZak0YLXLCqAn/8y/9ZtnaN56E6W3sd8wyxfO5A2WXrLjS/1hqIxyEfUvx8dbqxA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-aQESYn6jJQ73pjwk1hponQ9K1taxNSI6rxMuN8Im/nc7CwFwWu+c9iSRHwbWACu4rsleTn37lWUAH/vvZ7oEHg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/http-error-handler/package.json
+++ b/packages/http-error-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-error-handler",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "Http error handler middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -47,7 +47,7 @@
     "http-errors": "^1.6.3"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-beta.5",
+    "@middy/core": "^1.0.0-beta.6",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/http-event-normalizer/package-lock.json
+++ b/packages/http-event-normalizer/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/http-event-normalizer",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-U5jcCCWxXeKcnGxV99n4H6OZak0YLXLCqAn/8y/9ZtnaN56E6W3sd8wyxfO5A2WXrLjS/1hqIxyEfUvx8dbqxA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-aQESYn6jJQ73pjwk1hponQ9K1taxNSI6rxMuN8Im/nc7CwFwWu+c9iSRHwbWACu4rsleTn37lWUAH/vvZ7oEHg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/http-event-normalizer/package.json
+++ b/packages/http-event-normalizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-event-normalizer",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "Http event normalizer middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -43,7 +43,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-beta.5",
+    "@middy/core": "^1.0.0-beta.6",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/http-header-normalizer/package-lock.json
+++ b/packages/http-header-normalizer/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/http-header-normalizer",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-U5jcCCWxXeKcnGxV99n4H6OZak0YLXLCqAn/8y/9ZtnaN56E6W3sd8wyxfO5A2WXrLjS/1hqIxyEfUvx8dbqxA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-aQESYn6jJQ73pjwk1hponQ9K1taxNSI6rxMuN8Im/nc7CwFwWu+c9iSRHwbWACu4rsleTn37lWUAH/vvZ7oEHg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/http-header-normalizer/package.json
+++ b/packages/http-header-normalizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-header-normalizer",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "Http header normalizer middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -45,7 +45,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-beta.5",
+    "@middy/core": "^1.0.0-beta.6",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/http-json-body-parser/package-lock.json
+++ b/packages/http-json-body-parser/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/http-json-body-parser",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-U5jcCCWxXeKcnGxV99n4H6OZak0YLXLCqAn/8y/9ZtnaN56E6W3sd8wyxfO5A2WXrLjS/1hqIxyEfUvx8dbqxA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-aQESYn6jJQ73pjwk1hponQ9K1taxNSI6rxMuN8Im/nc7CwFwWu+c9iSRHwbWACu4rsleTn37lWUAH/vvZ7oEHg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/http-json-body-parser/package.json
+++ b/packages/http-json-body-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-json-body-parser",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "Http JSON body parser middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -50,7 +50,7 @@
     "http-errors": "^1.6.3"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-beta.5",
+    "@middy/core": "^1.0.0-beta.6",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/http-multipart-body-parser/package-lock.json
+++ b/packages/http-multipart-body-parser/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/http-multipart-body-parser",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-U5jcCCWxXeKcnGxV99n4H6OZak0YLXLCqAn/8y/9ZtnaN56E6W3sd8wyxfO5A2WXrLjS/1hqIxyEfUvx8dbqxA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-aQESYn6jJQ73pjwk1hponQ9K1taxNSI6rxMuN8Im/nc7CwFwWu+c9iSRHwbWACu4rsleTn37lWUAH/vvZ7oEHg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/http-multipart-body-parser/package.json
+++ b/packages/http-multipart-body-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-multipart-body-parser",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "Http event normalizer middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -48,7 +48,7 @@
     "http-errors": "^1.7.3"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-beta.5",
+    "@middy/core": "^1.0.0-beta.6",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/http-partial-response/package-lock.json
+++ b/packages/http-partial-response/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/http-partial-response",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-U5jcCCWxXeKcnGxV99n4H6OZak0YLXLCqAn/8y/9ZtnaN56E6W3sd8wyxfO5A2WXrLjS/1hqIxyEfUvx8dbqxA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-aQESYn6jJQ73pjwk1hponQ9K1taxNSI6rxMuN8Im/nc7CwFwWu+c9iSRHwbWACu4rsleTn37lWUAH/vvZ7oEHg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/http-partial-response/package.json
+++ b/packages/http-partial-response/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-partial-response",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "Http partial response middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -47,7 +47,7 @@
     "json-mask": "^0.3.8"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-beta.5",
+    "@middy/core": "^1.0.0-beta.6",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/http-response-serializer/CHANGELOG.md
+++ b/packages/http-response-serializer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# http-response-serializer Changelog
+
+## 1.0.0-beta.6
+
+- [#477](https://github.com/middyjs/middy/pull/477) Potential breaking change: from this version on null-ish values such as `0` and `false` will be threated correctly as responses and not converted to empty objects. (by [@roni-frantchi](https://github.com/roni-frantchi))

--- a/packages/http-response-serializer/__tests__/index.js
+++ b/packages/http-response-serializer/__tests__/index.js
@@ -252,4 +252,26 @@ describe('📦  Middleware Http Response Serializer', () => {
       body: '{}'
     })
   })
+
+  test('It should return false when response body is falsey', async () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, { statusCode: 200, body: false })
+    })
+
+    const event = {
+      headers: {
+        Accept: 'text/plain'
+      }
+    }
+    handler.use(httpResponseSerializer(standardConfiguration))
+    const response = await invoke(handler, event)
+
+    expect(response).toEqual({
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'text/plain'
+      },
+      body: false
+    })
+  })
 })

--- a/packages/http-response-serializer/__tests__/index.js
+++ b/packages/http-response-serializer/__tests__/index.js
@@ -273,24 +273,4 @@ describe('📦  Middleware Http Response Serializer', () => {
       body: false
     })
   })
-  test('It should return false when response body is falsey', async () => {
-    const handler = middy((event, context, cb) => {
-      cb(null, false)
-    })
-
-    const event = {
-      headers: {
-        Accept: 'text/plain'
-      }
-    }
-    handler.use(httpResponseSerializer(standardConfiguration))
-    const response = await invoke(handler, event)
-
-    expect(response).toEqual({
-      headers: {
-        'Content-Type': 'text/plain'
-      },
-      body: false
-    })
-  })
 })

--- a/packages/http-response-serializer/__tests__/index.js
+++ b/packages/http-response-serializer/__tests__/index.js
@@ -255,7 +255,7 @@ describe('📦  Middleware Http Response Serializer', () => {
 
   test('It should return false when response body is falsey', async () => {
     const handler = middy((event, context, cb) => {
-      cb(null, { statusCode: 200, body: false })
+      cb(null, false)
     })
 
     const event = {
@@ -267,7 +267,26 @@ describe('📦  Middleware Http Response Serializer', () => {
     const response = await invoke(handler, event)
 
     expect(response).toEqual({
-      statusCode: 200,
+      headers: {
+        'Content-Type': 'text/plain'
+      },
+      body: false
+    })
+  })
+  test('It should return false when response body is falsey', async () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, false)
+    })
+
+    const event = {
+      headers: {
+        Accept: 'text/plain'
+      }
+    }
+    handler.use(httpResponseSerializer(standardConfiguration))
+    const response = await invoke(handler, event)
+
+    expect(response).toEqual({
       headers: {
         'Content-Type': 'text/plain'
       },

--- a/packages/http-response-serializer/index.js
+++ b/packages/http-response-serializer/index.js
@@ -42,7 +42,7 @@ const middleware = (opts, handler, next) => {
 
     if (!test) { return false }
 
-    // if the response is null or undefined, normalizes it back to an object    
+    // if the response is null or undefined, normalizes it back to an object
     handler.response = (handler.response !== null && typeof handler.response !== 'undefined') ? handler.response : {}
 
     // set header

--- a/packages/http-response-serializer/index.js
+++ b/packages/http-response-serializer/index.js
@@ -42,7 +42,7 @@ const middleware = (opts, handler, next) => {
 
     if (!test) { return false }
 
-    // if the response is not an object, assign it to body. { body: undefined } is not serelized
+    // if the response is not an object, assign it to body. { body: undefined } is not serialized
     handler.response = typeof handler.response === 'object' ? handler.response : { body: handler.response }
 
     // set header

--- a/packages/http-response-serializer/index.js
+++ b/packages/http-response-serializer/index.js
@@ -43,7 +43,7 @@ const middleware = (opts, handler, next) => {
     if (!test) { return false }
 
     // if the response is null or undefined, normalizes it back to an object
-    handler.response = handler.response || {}
+    handler.response = handler.response != null ? handler.response : {}
 
     // set header
     handler.response.headers = Object.assign({}, handler.response.headers, { 'Content-Type': type })

--- a/packages/http-response-serializer/index.js
+++ b/packages/http-response-serializer/index.js
@@ -42,8 +42,8 @@ const middleware = (opts, handler, next) => {
 
     if (!test) { return false }
 
-    // if the response is null or undefined, normalizes it back to an object
-    handler.response = (handler.response !== null && typeof handler.response !== 'undefined') ? handler.response : {}
+    // if the response is not an object, assign it to body. { body: undefined } is not serelized
+    handler.response = typeof handler.response === 'object' ? handler.response : { body: handler.response }
 
     // set header
     handler.response.headers = Object.assign({}, handler.response.headers, { 'Content-Type': type })

--- a/packages/http-response-serializer/index.js
+++ b/packages/http-response-serializer/index.js
@@ -42,8 +42,8 @@ const middleware = (opts, handler, next) => {
 
     if (!test) { return false }
 
-    // if the response is null or undefined, normalizes it back to an object
-    handler.response = handler.response != null ? handler.response : {}
+    // if the response is null or undefined, normalizes it back to an object    
+    handler.response = (handler.response !== null && typeof handler.response !== 'undefined')  ? handler.response : {}
 
     // set header
     handler.response.headers = Object.assign({}, handler.response.headers, { 'Content-Type': type })

--- a/packages/http-response-serializer/index.js
+++ b/packages/http-response-serializer/index.js
@@ -43,7 +43,7 @@ const middleware = (opts, handler, next) => {
     if (!test) { return false }
 
     // if the response is null or undefined, normalizes it back to an object    
-    handler.response = (handler.response !== null && typeof handler.response !== 'undefined')  ? handler.response : {}
+    handler.response = (handler.response !== null && typeof handler.response !== 'undefined') ? handler.response : {}
 
     // set header
     handler.response.headers = Object.assign({}, handler.response.headers, { 'Content-Type': type })

--- a/packages/http-response-serializer/package-lock.json
+++ b/packages/http-response-serializer/package-lock.json
@@ -1,13 +1,13 @@
 {
 	"name": "@middy/http-response-serializer",
-	"version": "1.0.0-beta.5",
+	"version": "1.0.0-beta.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@middy/core": {
-			"version": "1.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.4.tgz",
-			"integrity": "sha512-U5jcCCWxXeKcnGxV99n4H6OZak0YLXLCqAn/8y/9ZtnaN56E6W3sd8wyxfO5A2WXrLjS/1hqIxyEfUvx8dbqxA==",
+			"version": "1.0.0-beta.5",
+			"resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.5.tgz",
+			"integrity": "sha512-aQESYn6jJQ73pjwk1hponQ9K1taxNSI6rxMuN8Im/nc7CwFwWu+c9iSRHwbWACu4rsleTn37lWUAH/vvZ7oEHg==",
 			"dev": true,
 			"requires": {
 				"once": "^1.4.0"

--- a/packages/http-response-serializer/package.json
+++ b/packages/http-response-serializer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-response-serializer",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "The Http Serializer middleware lets you define serialization mechanisms based on the current content negotiation.",
   "engines": {
     "node": ">=10"
@@ -50,7 +50,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-beta.5",
+    "@middy/core": "^1.0.0-beta.6",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/http-security-headers/package-lock.json
+++ b/packages/http-security-headers/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/http-security-headers",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-U5jcCCWxXeKcnGxV99n4H6OZak0YLXLCqAn/8y/9ZtnaN56E6W3sd8wyxfO5A2WXrLjS/1hqIxyEfUvx8dbqxA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-aQESYn6jJQ73pjwk1hponQ9K1taxNSI6rxMuN8Im/nc7CwFwWu+c9iSRHwbWACu4rsleTn37lWUAH/vvZ7oEHg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/http-security-headers/package.json
+++ b/packages/http-security-headers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-security-headers",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "Applies best practice security headers to responses. It's a simplified port of HelmetJS",
   "engines": {
     "node": ">=10"
@@ -46,7 +46,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-beta.5",
+    "@middy/core": "^1.0.0-beta.6",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/http-urlencode-body-parser/package-lock.json
+++ b/packages/http-urlencode-body-parser/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/http-urlencode-body-parser",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-U5jcCCWxXeKcnGxV99n4H6OZak0YLXLCqAn/8y/9ZtnaN56E6W3sd8wyxfO5A2WXrLjS/1hqIxyEfUvx8dbqxA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-aQESYn6jJQ73pjwk1hponQ9K1taxNSI6rxMuN8Im/nc7CwFwWu+c9iSRHwbWACu4rsleTn37lWUAH/vvZ7oEHg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/http-urlencode-body-parser/package.json
+++ b/packages/http-urlencode-body-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-urlencode-body-parser",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "Urlencode body parser middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -50,7 +50,7 @@
     "querystring": "^0.2.0"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-beta.5",
+    "@middy/core": "^1.0.0-beta.6",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/http-urlencode-path-parser/package-lock.json
+++ b/packages/http-urlencode-path-parser/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/http-urlencode-path-parser",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-U5jcCCWxXeKcnGxV99n4H6OZak0YLXLCqAn/8y/9ZtnaN56E6W3sd8wyxfO5A2WXrLjS/1hqIxyEfUvx8dbqxA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-aQESYn6jJQ73pjwk1hponQ9K1taxNSI6rxMuN8Im/nc7CwFwWu+c9iSRHwbWACu4rsleTn37lWUAH/vvZ7oEHg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/http-urlencode-path-parser/package.json
+++ b/packages/http-urlencode-path-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/http-urlencode-path-parser",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "Urlencode path parser middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -47,7 +47,7 @@
     "@types/http-errors": "^1.6.1"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-beta.5"
+    "@middy/core": "^1.0.0-beta.6"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"
 }

--- a/packages/input-output-logger/package-lock.json
+++ b/packages/input-output-logger/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/input-output-logger",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-U5jcCCWxXeKcnGxV99n4H6OZak0YLXLCqAn/8y/9ZtnaN56E6W3sd8wyxfO5A2WXrLjS/1hqIxyEfUvx8dbqxA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-aQESYn6jJQ73pjwk1hponQ9K1taxNSI6rxMuN8Im/nc7CwFwWu+c9iSRHwbWACu4rsleTn37lWUAH/vvZ7oEHg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/input-output-logger/package.json
+++ b/packages/input-output-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/input-output-logger",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "Input and output logger middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -47,7 +47,7 @@
     "@types/node": "^10.0.8"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-beta.5",
+    "@middy/core": "^1.0.0-beta.6",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/s3-key-normalizer/package-lock.json
+++ b/packages/s3-key-normalizer/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/s3-key-normalizer",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-U5jcCCWxXeKcnGxV99n4H6OZak0YLXLCqAn/8y/9ZtnaN56E6W3sd8wyxfO5A2WXrLjS/1hqIxyEfUvx8dbqxA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-aQESYn6jJQ73pjwk1hponQ9K1taxNSI6rxMuN8Im/nc7CwFwWu+c9iSRHwbWACu4rsleTn37lWUAH/vvZ7oEHg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/s3-key-normalizer/package.json
+++ b/packages/s3-key-normalizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/s3-key-normalizer",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "S3 key normalizer middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -43,7 +43,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-beta.5",
+    "@middy/core": "^1.0.0-beta.6",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/secrets-manager/package-lock.json
+++ b/packages/secrets-manager/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/secrets-manager",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-U5jcCCWxXeKcnGxV99n4H6OZak0YLXLCqAn/8y/9ZtnaN56E6W3sd8wyxfO5A2WXrLjS/1hqIxyEfUvx8dbqxA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-aQESYn6jJQ73pjwk1hponQ9K1taxNSI6rxMuN8Im/nc7CwFwWu+c9iSRHwbWACu4rsleTn37lWUAH/vvZ7oEHg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/secrets-manager/package.json
+++ b/packages/secrets-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/secrets-manager",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "Secrets Manager middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -45,7 +45,7 @@
     "@types/node": "^10.0.8"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-beta.5",
+    "@middy/core": "^1.0.0-beta.6",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/sqs-partial-batch-failure/package-lock.json
+++ b/packages/sqs-partial-batch-failure/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/sqs-partial-batch-failure",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-U5jcCCWxXeKcnGxV99n4H6OZak0YLXLCqAn/8y/9ZtnaN56E6W3sd8wyxfO5A2WXrLjS/1hqIxyEfUvx8dbqxA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-aQESYn6jJQ73pjwk1hponQ9K1taxNSI6rxMuN8Im/nc7CwFwWu+c9iSRHwbWACu4rsleTn37lWUAH/vvZ7oEHg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/sqs-partial-batch-failure/package.json
+++ b/packages/sqs-partial-batch-failure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/sqs-partial-batch-failure",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "SQS partial batch failure middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -44,7 +44,7 @@
     "aws-sdk": ">=2.221.1"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-beta.5",
+    "@middy/core": "^1.0.0-beta.6",
     "@serverless/event-mocks": "^1.1.1",
     "promise.allsettled": "^1.0.2"
   },

--- a/packages/ssm/package-lock.json
+++ b/packages/ssm/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/ssm",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-U5jcCCWxXeKcnGxV99n4H6OZak0YLXLCqAn/8y/9ZtnaN56E6W3sd8wyxfO5A2WXrLjS/1hqIxyEfUvx8dbqxA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-aQESYn6jJQ73pjwk1hponQ9K1taxNSI6rxMuN8Im/nc7CwFwWu+c9iSRHwbWACu4rsleTn37lWUAH/vvZ7oEHg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/ssm/package.json
+++ b/packages/ssm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/ssm",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "SSM (EC2 Systems Manager) parameters middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -47,7 +47,7 @@
     "@types/node": "^10.0.8"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-beta.5",
+    "@middy/core": "^1.0.0-beta.6",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/validator/package-lock.json
+++ b/packages/validator/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/validator",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-U5jcCCWxXeKcnGxV99n4H6OZak0YLXLCqAn/8y/9ZtnaN56E6W3sd8wyxfO5A2WXrLjS/1hqIxyEfUvx8dbqxA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-aQESYn6jJQ73pjwk1hponQ9K1taxNSI6rxMuN8Im/nc7CwFwWu+c9iSRHwbWACu4rsleTn37lWUAH/vvZ7oEHg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/validator",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "Validator middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -49,7 +49,7 @@
     "http-errors": "^1.6.3"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-beta.5",
+    "@middy/core": "^1.0.0-beta.6",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"

--- a/packages/warmup/package-lock.json
+++ b/packages/warmup/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@middy/warmup",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-U5jcCCWxXeKcnGxV99n4H6OZak0YLXLCqAn/8y/9ZtnaN56E6W3sd8wyxfO5A2WXrLjS/1hqIxyEfUvx8dbqxA==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-aQESYn6jJQ73pjwk1hponQ9K1taxNSI6rxMuN8Im/nc7CwFwWu+c9iSRHwbWACu4rsleTn37lWUAH/vvZ7oEHg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"

--- a/packages/warmup/package.json
+++ b/packages/warmup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/warmup",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "Warmup (cold start mitigation) middleware for the middy framework",
   "engines": {
     "node": ">=10"
@@ -43,7 +43,7 @@
     "@middy/core": ">=1.0.0-alpha"
   },
   "devDependencies": {
-    "@middy/core": "^1.0.0-beta.5",
+    "@middy/core": "^1.0.0-beta.6",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"


### PR DESCRIPTION
When response is falsey (boolean `false` or the number `0`), `http-response-serializer` thinks it is `null` or `undefined`, thus creating an empty object `{}`.  

Root cause is the check doesn't actually test for `null` or `undefined` properly.  