### PR TITLE
Add FAQ item about context.done called twice warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,13 @@ methods to allow you to quickly hook in simple inline middlewares.
 Check the [code for existing middlewares](/src/middlewares) to see more examples
 on how to write a middleware.
 
+## FAQ
+
+### Q: `context.done called twice within handler` warning
+**A**: You're probably trying to use `callback()` inside an async handler, or `next()` inside an async middleware. Async
+handlers and middlewares should return a promise, so calling those functions is not needed.
+See [Promise support](https://github.com/middyjs/middy#promise-support) for examples.
+
 ## Available middlewares
 
 Currently available middlewares:


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Add a FAQ item about the `context.done called twice within handler` warning in the main README file. This warning happens when you try to use callbacks (`callback()` or `next()` functions) inside async handlers or middlewares, and is kinda hard to debug. Hopefully this addition to the docs will be indexed by Google and future devs who stumble in this problem will be able to solve it much quicker than I did.

Does this close any currently open issues?
------------------------------------------
[Issue #480 ](https://github.com/middyjs/middy/issues/480)

Todo list
---------

[ ] Feature/Fix fully implemented
[ ] Added tests
[x] Updated relevant documentation
[ ] Updated relevant examples
