### PR TITLE
Changed error handling logic to stop after error has been handled

### DIFF
--- a/src/__tests__/middy.js
+++ b/src/__tests__/middy.js
@@ -276,7 +276,7 @@ describe('🛵  Middy test suite', () => {
     })
   })
 
-  test('If theres an error and one error middleware handles the error, the next error middlewares is executed', (endTest) => {
+  test('If theres is an error and one error middleware handles the error, the next error middlewares should not be executed', (endTest) => {
     const expectedResponse = { message: 'error handled' }
 
     const onErrorMiddleware1 = jest.fn((handler, next) => {
@@ -297,7 +297,7 @@ describe('🛵  Middy test suite', () => {
     handler({}, {}, (err, response) => {
       expect(err).toBeNull()
       expect(onErrorMiddleware1).toBeCalled()
-      expect(onErrorMiddleware2).toBeCalled()
+      expect(onErrorMiddleware2).not.toHaveBeenCalled()
       expect(response).toBe(expectedResponse)
 
       endTest()

--- a/src/middy.js
+++ b/src/middy.js
@@ -103,7 +103,13 @@ const runErrorMiddlewares = (middlewares, instance, done) => {
       const nextMiddleware = stack.shift()
 
       if (nextMiddleware && !instance.__handledError) {
-        const retVal = nextMiddleware(instance, runNext)
+        const retVal = nextMiddleware(instance, (retCallBackError) => {
+          if (!retCallBackError) {
+            done()
+          } else {
+            runNext(retCallBackError)
+          }
+        })
 
         if (retVal) {
           if (!isPromise(retVal)) {

--- a/src/middy.js
+++ b/src/middy.js
@@ -102,7 +102,7 @@ const runErrorMiddlewares = (middlewares, instance, done) => {
 
       const nextMiddleware = stack.shift()
 
-      if (nextMiddleware) {
+      if (nextMiddleware && !instance.__handledError) {
         const retVal = nextMiddleware(instance, runNext)
 
         if (retVal) {


### PR DESCRIPTION
Changed run error middlewares so that it conforms to the behaviour stated in the documentation

```javascript
middleware1 = {
  onError: (handler) => {
    handler.response = { error: handler.error };
    return Promise.resolve();
    // Resolves to a falsy value
  }
}
middleware2 = {
  onError: (handler) => {
    return Promise.resolve(handler.error)
  }
}
handler.use(middleware1).use(middleware2);
```

`middleware2` should not be called.

# Relevant issues:

- #485 