### PR TITLE
Ability to exclude paths in input-output-logger

### DIFF
--- a/packages/input-output-logger/README.md
+++ b/packages/input-output-logger/README.md
@@ -45,7 +45,7 @@ npm install --save @middy/input-output-logger
 ## Options
 
 `logger` property accept a function (default `console.log`)
-`exclude` property accept an array of paths to exclude from the log (default `[]`)
+`omitPaths` property accept an array of paths to omitPaths from the log (default `[]`)
 
 
 ## Sample usage

--- a/packages/input-output-logger/README.md
+++ b/packages/input-output-logger/README.md
@@ -45,6 +45,7 @@ npm install --save @middy/input-output-logger
 ## Options
 
 `logger` property accept a function (default `console.log`)
+`exclude` property accept an array of paths to exclude from the log (default `[]`)
 
 
 ## Sample usage

--- a/packages/input-output-logger/README.md
+++ b/packages/input-output-logger/README.md
@@ -45,7 +45,7 @@ npm install --save @middy/input-output-logger
 ## Options
 
 `logger` property accept a function (default `console.log`)
-`omitPaths` property accept an array of paths to omitPaths from the log (default `[]`)
+`omitPaths` property accepts an array of paths that will be used to remove particular fields from the logged objects. This could serve as a simple way to redact sensitive data from logs (default []).
 
 
 ## Sample usage

--- a/packages/input-output-logger/__tests__/index.js
+++ b/packages/input-output-logger/__tests__/index.js
@@ -18,7 +18,7 @@ describe('📦 Middleware Input Output Logger', () => {
     expect(logger).toHaveBeenCalledWith({ event: { foo: 'bar', fuu: 'baz' } })
     expect(logger).toHaveBeenCalledWith({ response: { message: 'hello world' } })
   })
-  test('It should exclude paths', async () => {
+  test('It should omit paths', async () => {
     const logger = jest.fn()
 
     const handler = middy((event, context, cb) => {
@@ -26,7 +26,7 @@ describe('📦 Middleware Input Output Logger', () => {
     })
 
     handler
-      .use(inputOutputLogger({ logger, exclude: ['event.foo', 'response.bar'] }))
+      .use(inputOutputLogger({ logger, omitPaths: ['event.foo', 'response.bar'] }))
 
     await invoke(handler, { foo: 'bar', fuu: 'baz' })
 

--- a/packages/input-output-logger/__tests__/index.js
+++ b/packages/input-output-logger/__tests__/index.js
@@ -18,4 +18,19 @@ describe('📦 Middleware Input Output Logger', () => {
     expect(logger).toHaveBeenCalledWith({ event: { foo: 'bar', fuu: 'baz' } })
     expect(logger).toHaveBeenCalledWith({ response: { message: 'hello world' } })
   })
+  test('It should exclude paths', async () => {
+    const logger = jest.fn()
+
+    const handler = middy((event, context, cb) => {
+      cb(null, { message: 'hello world', bar: 'bi' })
+    })
+
+    handler
+      .use(inputOutputLogger({ logger, exclude: ['event.foo', 'response.bar'] }))
+
+    await invoke(handler, { foo: 'bar', fuu: 'baz' })
+
+    expect(logger).toHaveBeenCalledWith({ event: { fuu: 'baz' } })
+    expect(logger).toHaveBeenCalledWith({ response: { message: 'hello world' } })
+  })
 })

--- a/packages/input-output-logger/index.d.ts
+++ b/packages/input-output-logger/index.d.ts
@@ -2,7 +2,7 @@ import middy from '@middy/core';
 
 interface IInputOutputLoggerOptions {
   logger?: (message: any) => void;
-  exclude?: string[];
+  omitPaths?: string[];
 }
 
 declare const inputOutputLogger : middy.Middleware<IInputOutputLoggerOptions, any, any>

--- a/packages/input-output-logger/index.d.ts
+++ b/packages/input-output-logger/index.d.ts
@@ -2,6 +2,7 @@ import middy from '@middy/core';
 
 interface IInputOutputLoggerOptions {
   logger?: (message: any) => void;
+  exclude?: string[];
 }
 
 declare const inputOutputLogger : middy.Middleware<IInputOutputLoggerOptions, any, any>

--- a/packages/input-output-logger/index.js
+++ b/packages/input-output-logger/index.js
@@ -6,11 +6,11 @@ module.exports = (opts) => {
     exclude: []
   }
 
-  const { logger, exclude } = Object.assign({}, defaults, opts)
+  const { logger, omitPaths } = Object.assign({}, defaults, opts)
 
-  const omitAndLog = data => {
-    const message = omit(data, exclude)
-    logger(message)
+  const omitAndLog = message => {
+    const redactedMessage = omit(message, omitPaths)
+    logger(redactedMessage)
   }
 
   return ({

--- a/packages/input-output-logger/index.js
+++ b/packages/input-output-logger/index.js
@@ -1,4 +1,4 @@
-import omit from 'lodash/omit'
+const omit = require('lodash/omit')
 
 module.exports = (opts) => {
   const defaults = {

--- a/packages/input-output-logger/index.js
+++ b/packages/input-output-logger/index.js
@@ -3,7 +3,7 @@ const omit = require('lodash/omit')
 module.exports = (opts) => {
   const defaults = {
     logger: data => console.log(JSON.stringify(data, null, 2)),
-    exclude: []
+    omitPaths: []
   }
 
   const { logger, omitPaths } = Object.assign({}, defaults, opts)

--- a/packages/input-output-logger/index.js
+++ b/packages/input-output-logger/index.js
@@ -1,21 +1,29 @@
+import omit from 'lodash/omit'
+
 module.exports = (opts) => {
   const defaults = {
-    logger: data => console.log(JSON.stringify(data, null, 2))
+    logger: data => console.log(JSON.stringify(data, null, 2)),
+    exclude: []
   }
 
-  const options = Object.assign({}, defaults, opts)
+  const { logger, exclude } = Object.assign({}, defaults, opts)
+
+  const omitAndLog = data => {
+    const message = omit(data, exclude)
+    logger(message)
+  }
 
   return ({
     before: (handler, next) => {
-      if (typeof options.logger === 'function') {
-        options.logger({ event: handler.event })
+      if (typeof logger === 'function') {
+        omitAndLog({ event: handler.event })
       }
 
       return next()
     },
     after: (handler, next) => {
-      if (typeof options.logger === 'function') {
-        options.logger({ response: handler.response })
+      if (typeof logger === 'function') {
+        omitAndLog({ response: handler.response })
       }
 
       return next()

--- a/packages/input-output-logger/package-lock.json
+++ b/packages/input-output-logger/package-lock.json
@@ -5,24 +5,36 @@
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.9.tgz",
-      "integrity": "sha512-u4B/PLqxgw4bh5+I6tnnja6edM9xDFvOYbQmvhbUo0fbzSczaVwD1vAR/WwaNzKUT4b0GxaY1+t3cx5ptM26Uw==",
+      "version": "1.0.0-beta.10",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0-beta.10.tgz",
+      "integrity": "sha512-P0RFdKWxBF9z/v8T4+jcR7eoQkrGMUt4DkEUUXT74Abz0D5OPcmNoFtuXw2EyUrk0Yux5KFZ1GVbGl0hNMbcTg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
     },
+    "@types/lodash": {
+      "version": "4.14.149",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
+      "dev": true
+    },
     "@types/node": {
       "version": "10.14.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.1.tgz",
-      "integrity": "sha512-Rymt08vh1GaW4vYB6QP61/5m/CFLGnFZP++bJpWbiNxceNa6RBipDmb413jvtSf/R1gg5a/jQVl2jY4XVRscEA=="
+      "integrity": "sha512-Rymt08vh1GaW4vYB6QP61/5m/CFLGnFZP++bJpWbiNxceNa6RBipDmb413jvtSf/R1gg5a/jQVl2jY4XVRscEA==",
+      "dev": true
     },
     "es6-promisify": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.0.2.tgz",
       "integrity": "sha512-eO6vFm0JvqGzjWIQA6QVKjxpmELfhWbDUWHm1rPfIbn55mhKPiAa5xpLmQWJrNa629ZIeQ8ZvMAi13kvrjK6Mg==",
       "dev": true
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "once": {
       "version": "1.4.0",

--- a/packages/input-output-logger/package.json
+++ b/packages/input-output-logger/package.json
@@ -44,10 +44,12 @@
     "aws-sdk": ">=2.221.1"
   },
   "dependencies": {
-    "@types/node": "^10.0.8"
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@middy/core": "^1.0.0-beta.10",
+    "@types/node": "^10.0.8",
+    "@types/lodash": "^4.14.149",
     "es6-promisify": "^6.0.2"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds the ability to exclude paths from input/output logger.  
Very useful to reduce log verbosity and scrub-off secrets or sensitive data.  

Where has this been tested?
---------------------------
**Node.js Versions:** v12.16.1

**Middy Versions:** 1.0.0-beta

**AWS SDK Versions:** 2.556.0

Todo list
---------

- [x] Feature/Fix fully implemented
- [x] Added tests
- [x] Updated relevant documentation
- [x] Updated relevant examples
