### PR TITLE
[http-header-normalizer] Respect canonical normalisation parameter for multiValueHeaders

### DIFF
--- a/packages/http-header-normalizer/index.js
+++ b/packages/http-header-normalizer/index.js
@@ -80,7 +80,7 @@ module.exports = (opts) => {
 
         Object.keys(handler.event.multiValueHeaders).forEach((key) => {
           rawHeaders[key] = handler.event.multiValueHeaders[key]
-          headers[options.normalizeHeaderKey(key)] = handler.event.multiValueHeaders[key]
+          headers[options.normalizeHeaderKey(key, options.canonical)] = handler.event.multiValueHeaders[key]
         })
 
         handler.event.multiValueHeaders = headers


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
`options.canonical` is only respected for single value headers. When it is set, multi value headers get lowercased.

Does this close any currently open issues?
------------------------------------------
Fixes #475 


Any relevant logs, error output, etc?
-------------------------------------
Logging `event` (shortened for brevity):

```
 headers: {
    Host: 'localhost:3000',
    'Accept-Encoding': 'gzip, deflate',
    DNT: '1',
  },
  multiValueHeaders: {
    host: [ 'localhost:3000' ],
    'accept-encoding': [ 'gzip, deflate' ],
    DNT: [ '1' ],
}
```

Where has this been tested?
---------------------------
**Node.js Versions:** not sure

**Middy Versions:** 1.0.0

**AWS SDK Versions:** not sure

Todo list
---------

[x] Feature/Fix fully implemented
[ ] Added tests
[ ] Updated relevant documentation
[ ] Updated relevant examples
