### PR TITLE
[http-multipart-body-parser] Parse array from multipart form data

### DIFF
--- a/packages/http-multipart-body-parser/__tests__/index.js
+++ b/packages/http-multipart-body-parser/__tests__/index.js
@@ -164,4 +164,24 @@ describe('📦  Middleware Multipart Form Data Body Parser', () => {
     const response = await invoke(handler, event)
     expect(response).toEqual('LS0tLS0tV2ViS2l0Rm9ybUJvdW5kYXJ5cHBzUUV3ZjJCVkplQ2UwTQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImZvbyIKCmJhcgotLS0tLS1XZWJLaXRGb3JtQm91bmRhcnlwcHNRRXdmMkJWSmVDZTBNLS0=')
   })
+
+  test('It should parse an array from a multipart/form-data request', async () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, event.body) // propagates the body as a response
+    })
+
+    handler.use(httpMultipartBodyParser())
+
+    const event = {
+      headers: {
+        'content-type': 'multipart/form-data; boundary=----WebKitFormBoundaryppsQEwf2BVJeCe0M'
+      },
+      body: 'LS0tLS0tV2ViS2l0Rm9ybUJvdW5kYXJ5cHBzUUV3ZjJCVkplQ2UwTQ0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJmb29bXSINCg0Kb25lDQotLS0tLS1XZWJLaXRGb3JtQm91bmRhcnlwcHNRRXdmMkJWSmVDZTBNDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImZvb1tdIg0KDQp0d28NCi0tLS0tLVdlYktpdEZvcm1Cb3VuZGFyeXBwc1FFd2YyQlZKZUNlME0tLQ==',
+      isBase64Encoded: true
+    }
+    const response = await invoke(handler, event)
+
+    expect(Object.keys(response)).toContain('foo')
+    expect(response.foo.length).toEqual(2)
+  })
 })

--- a/packages/http-multipart-body-parser/index.js
+++ b/packages/http-multipart-body-parser/index.js
@@ -59,7 +59,17 @@ const parseMultipartData = (event, options) => {
           multipartData[fieldname] = attachment
         })
       })
-      .on('field', (fieldname, value) => { multipartData[fieldname] = value })
+      .on('field', (fieldname, value) => {
+        const matches = fieldname.match(/(.+)\[(.*)]$/)
+        if (!matches) {
+          multipartData[fieldname] = value
+        } else {
+          if (!multipartData[matches[1]]) {
+            multipartData[matches[1]] = []
+          }
+          multipartData[matches[1]].push(value)
+        }
+      })
       .on('finish', () => resolve(multipartData))
       .on('error', err => reject(err))
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
When receiving formdata with an array (eg. checkboxes), only the last value is used. A simple way to test is by trying out the following:
```
curl -X POST -F 'foo[]=one' -F 'foo[]=two' http://localhost
```

Currently this would parse as
```
'foo[]': 'two'
```

With this change, the result is:
```
'foo': [ 'one', 'two' ]
```

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
n/a

Any other comments?
-------------------
I originally created #508 but rebasing was causing some issues on my end. Made a clean branch and put the changes here instead.

Where has this been tested?
---------------------------
**Node.js Versions:** 13.12.0

**Middy Versions:** 1.0.0

**AWS SDK Versions:** n/a

Todo list
---------

[x] Feature/Fix fully implemented
[x] Added tests
[ ] Updated relevant documentation
[ ] Updated relevant examples
