### PR TITLE
docs(db-manager): fix badge url

### DIFF
--- a/packages/db-manager/README.md
+++ b/packages/db-manager/README.md
@@ -10,8 +10,8 @@
 
 <div align="center">
 <p>
-  <a href="http://badge.fury.io/js/%40middy%2Fvalidator">
-    <img src="https://badge.fury.io/js/%40middy%2Fvalidator.svg" alt="npm version" style="max-width:100%;">
+  <a href="http://badge.fury.io/js/%40middy%2Fdb-manager">
+    <img src="https://badge.fury.io/js/%40middy%2Fdb-manager.svg" alt="npm version" style="max-width:100%;">
   </a>
   <a href="https://snyk.io/test/github/middyjs/middy">
     <img src="https://snyk.io/test/github/middyjs/middy/badge.svg" alt="Known Vulnerabilities" data-canonical-src="https://snyk.io/test/github/middyjs/middy" style="max-width:100%;">


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
--------------------------------------------------
Fix badge URL of [@middy/db-manager](https://github.com/middyjs/middy/tree/master/packages/db-manager)

Does this close any currently open issues?
------------------------------------------
no


Any relevant logs, error output, etc?
-------------------------------------
no

Any other comments?
-------------------
no

Where has this been tested?
---------------------------
no

Todo list
---------

[ ] Feature/Fix fully implemented
[ ] Added tests
[ ] Updated relevant documentation
[ ] Updated relevant examples
