### PR TITLE
Add the boolean check for a truncated file upload

### DIFF
--- a/packages/http-multipart-body-parser/index.js
+++ b/packages/http-multipart-body-parser/index.js
@@ -55,6 +55,7 @@ const parseMultipartData = (event, options) => {
           chunks.push(data)
         })
         file.on('end', () => {
+          attachment.truncated = file.truncated
           attachment.content = Buffer.concat(chunks)
           multipartData[fieldname] = attachment
         })


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
Busboy includes a boolean for a truncated file upload. I need that, so I'm adding it into the appropriate package.

Does this close any currently open issues?
------------------------------------------
No idea.

Any relevant logs, error output, etc?
-------------------------------------
Nope.

Any other comments?
-------------------
See issue and a link to the docs here:
https://github.com/mscdex/busboy/issues/76

Where has this been tested?
---------------------------
**Node.js Versions:** v12.16.2

**Middy Versions:** 1.0.0

**AWS SDK Versions:** aws-cli/2.0.18 Python/3.8.3 Darwin/19.5.0 botocore/2.0.0dev22

Todo list
---------

[x] Feature/Fix fully implemented
[ ] Added tests
[ ] Updated relevant documentation
[ ] Updated relevant examples
