### PR TITLE
Handling base64 event bodies

### DIFF
--- a/packages/http-json-body-parser/index.js
+++ b/packages/http-json-body-parser/index.js
@@ -10,7 +10,11 @@ module.exports = (opts) => ({
         const { type } = contentType.parse(contentTypeHeader)
         if (type === 'application/json') {
           try {
-            handler.event.body = JSON.parse(handler.event.body, opts.reviver)
+            const data = handler.event.isBase64Encoded
+              ? Buffer.from(handler.event.body, 'base64').toString()
+              : handler.event.body
+
+            handler.event.body = JSON.parse(data, opts.reviver)
           } catch (err) {
             throw new createError.UnprocessableEntity('Content type defined as JSON but an invalid JSON was provided')
           }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
The [input of a Lambda](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html) function can be encoded with base64. This PR handles base64 encoded events on the `http-json-body-parser` middleware.

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
No

Any other comments?
-------------------
No

Where has this been tested?
---------------------------
**Node.js Versions:** 12.13.1

**Middy Versions:** 1.0.0

**AWS SDK Versions:** 2.689.0

Todo list
---------

[x] Feature/Fix fully implemented
[x] Added tests
[x] Updated relevant documentation
[x] Updated relevant examples
