### PR TITLE
fix(db-manager): improve type definition

### DIFF
--- a/packages/db-manager/index.d.ts
+++ b/packages/db-manager/index.d.ts
@@ -1,3 +1,4 @@
+import middy from '@middy/core';
 import Knex from 'knex';
 
 export interface DbManagerOptions {
@@ -9,3 +10,7 @@ export interface DbManagerOptions {
   secretsParam?: string,
   secretsPath?: string
 }
+
+declare const dbManager: middy.Middleware<DbManagerOptions, any, any>
+
+export default dbManager


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
[[@middy/db-manager](https://github.com/middyjs/middy/tree/master/packages/db-manager)] Provide default type definition like [@middy/secrets-manager](https://github.com/middyjs/middy/blob/master/packages/secrets-manager/index.d.ts).

Then, default import  is available in TypeScript.

```ts
import middy from '@middy/core'
import lambda from 'aws-lambda'
import Knex from 'knex'
import dbManager from '@middy/db-manager'

interface Context extends lambda.Context {
  db: Knex
}

const handler = middy(async (
  event: any,
  context: Context,
  callback: lambda.Callback<any>
): Promise<void> => {
  const { db } = context
  const users = await db.select('*').from('users')
  console.log(users)
})

handler.use(dbManager({
  config: {
    client: 'mysql',
    connection: {
      host: '127.0.0.1',
      user: 'your_database_user',
      password: 'your_database_password',
      database: 'myapp_test'
    }
  }
}))
```

Does this close any currently open issues?
------------------------------------------
- close #533
- close #536

Any relevant logs, error output, etc?
-------------------------------------
none

Any other comments?
-------------------
none

Where has this been tested?
---------------------------
**Node.js Versions:** v12.14.0

**Middy Versions:** 1.0.0

**AWS SDK Versions:** 2.656.0

Todo list
---------
none
