### PR TITLE
The `httpResponseSerializer` needs to find a serializer for a `type` by searching all the `types`

### DIFF
--- a/packages/http-response-serializer/__tests__/index.js
+++ b/packages/http-response-serializer/__tests__/index.js
@@ -119,6 +119,32 @@ describe('📦  Middleware Http Response Serializer', () => {
     })
   })
 
+  test('It should use the default when no matching accept preferences are found', async () => {
+    const handler = middy((event, context, cb) => {
+      event.preferredContentType = 'text/java'
+
+      cb(null, createHttpResponse())
+    })
+
+    handler.use(httpResponseSerializer(standardConfiguration))
+
+    const event = {
+      headers: {
+        Accept: 'application/java, text/x-dvi; q=0.8, text/x-c'
+      }
+    }
+
+    const response = await invoke(handler, event)
+
+    expect(response).toEqual({
+      statusCode: 200,
+      headers: {
+        'Content-Type': standardConfiguration.default
+      },
+      body: '{"message":"Hello World"}'
+    })
+  })
+
   test('It should use `event.preferredContentType` instead of the default', async () => {
     const handler = middy((event, context, cb) => {
       event.preferredContentType = 'text/plain'

--- a/packages/http-response-serializer/index.js
+++ b/packages/http-response-serializer/index.js
@@ -37,7 +37,7 @@ const middleware = (opts, handler, next) => {
   }
 
   // find in order of first preferred type that has a matching serializer
-  types.find(type => opts.serializers.map(s => {
+  types.find(type => opts.serializers.find(s => {
     const test = s.regex.test(type)
 
     if (!test) { return false }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

And all the `opts.serializers` too.

[`Array.prototype.find`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find) short circuits on truthy return values of its callback, which means that we only would've ever traversed the array for the first element of `types` since `opts.serializers.map` just returns an array of booleans right?

Fix this typo and add a test to cover my use case of wanting to fall back to a default if no preferred serializer is found.

Does this close any currently open issues?
------------------------------------------

Nothing that I could find from my quick searching. I just needed this for myself right now.

Any relevant logs, error output, etc?
-------------------------------------

N/A

Any other comments?
-------------------

None.

Where has this been tested?
---------------------------
**Node.js Versions:** 12

**Middy Versions:** 1

**AWS SDK Versions:** N/A

Todo list
---------

- [x] Feature/Fix fully implemented
- [x] Added tests
- [x] Updated relevant documentation
- [x] Updated relevant examples
