### PR TITLE
Add support for API Gateway HTTP API payload format v2.0 in http-event-normalizer middleware

### DIFF
--- a/packages/http-event-normalizer/README.md
+++ b/packages/http-event-normalizer/README.md
@@ -43,6 +43,8 @@ when no parameter is available), this way you don't have to worry about adding e
 statements before trying to read a property and calling `event.pathParameters.userId` will
 result in `undefined` when no path parameter is available, but not in an error.
 
+> Important note : API Gateway HTTP API format 2.0 doesn't have `multiValueQueryStringParameters` fields. Duplicate query strings are combined with commas and included in the `queryStringParameters` field.
+
 
 ## Install
 
@@ -55,7 +57,7 @@ npm install --save @middy/http-event-normalizer
 
 ## Options
 
-This middleware does not have any option
+- payloadFormatVersion (number) (optional): Defaults to `1 `. Set it to `2` to use API Gateway HTTP API v2.0 event payload (https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html).
 
 
 ## Sample usage

--- a/packages/http-event-normalizer/__tests__/index.js
+++ b/packages/http-event-normalizer/__tests__/index.js
@@ -2,7 +2,8 @@ const { invoke } = require('../../test-helpers')
 const middy = require('../../core')
 const httpEventNormalizer = require('../')
 
-const handler = middy((event, context, cb) => cb(null, event)).use(httpEventNormalizer())
+const handlerRestApi = middy((event, context, cb) => cb(null, event)).use(httpEventNormalizer())
+const handlerHttpApi = middy((event, context, cb) => cb(null, event)).use(httpEventNormalizer({ payloadFormatVersion: 2 }))
 
 describe('📦 Middleware normalize HTTP event', () => {
   test('It should do nothing if not HTTP event', async () => {
@@ -10,7 +11,7 @@ describe('📦 Middleware normalize HTTP event', () => {
       source: 's3'
     }
 
-    const normalizedEvent = await invoke(handler, nonEvent)
+    const normalizedEvent = await invoke(handlerRestApi, nonEvent)
 
     expect(normalizedEvent).toEqual(nonEvent)
     expect(normalizedEvent.queryStringParameters).toBeUndefined()
@@ -21,7 +22,21 @@ describe('📦 Middleware normalize HTTP event', () => {
       httpMethod: 'GET'
     }
 
-    const normalizedEvent = await invoke(handler, event)
+    const normalizedEvent = await invoke(handlerRestApi, event)
+
+    expect(normalizedEvent).toHaveProperty('queryStringParameters', {})
+  })
+
+  test('It should default queryStringParameters with HTTP API', async () => {
+    const event = {
+      requestContext: {
+        http: {
+          method: 'GET'
+        }
+      }
+    }
+
+    const normalizedEvent = await invoke(handlerHttpApi, event)
 
     expect(normalizedEvent).toHaveProperty('queryStringParameters', {})
   })
@@ -31,7 +46,7 @@ describe('📦 Middleware normalize HTTP event', () => {
       httpMethod: 'GET'
     }
 
-    const normalizedEvent = await invoke(handler, event)
+    const normalizedEvent = await invoke(handlerRestApi, event)
 
     expect(normalizedEvent).toHaveProperty('multiValueQueryStringParameters', {})
   })
@@ -41,7 +56,21 @@ describe('📦 Middleware normalize HTTP event', () => {
       httpMethod: 'GET'
     }
 
-    const normalizedEvent = await invoke(handler, event)
+    const normalizedEvent = await invoke(handlerRestApi, event)
+
+    expect(normalizedEvent).toHaveProperty('pathParameters', {})
+  })
+
+  test('It should default pathParameters with HTTP API', async () => {
+    const event = {
+      requestContext: {
+        http: {
+          method: 'GET'
+        }
+      }
+    }
+
+    const normalizedEvent = await invoke(handlerHttpApi, event)
 
     expect(normalizedEvent).toHaveProperty('pathParameters', {})
   })
@@ -52,7 +81,22 @@ describe('📦 Middleware normalize HTTP event', () => {
       queryStringParameters: { param: '123' }
     }
 
-    const normalizedEvent = await invoke(handler, event)
+    const normalizedEvent = await invoke(handlerRestApi, event)
+
+    expect(normalizedEvent).toHaveProperty('queryStringParameters', { param: '123' })
+  })
+
+  test('It should not overwrite queryStringParameters with HTTP API', async () => {
+    const event = {
+      requestContext: {
+        http: {
+          method: 'GET'
+        }
+      },
+      queryStringParameters: { param: '123' }
+    }
+
+    const normalizedEvent = await invoke(handlerHttpApi, event)
 
     expect(normalizedEvent).toHaveProperty('queryStringParameters', { param: '123' })
   })
@@ -63,7 +107,7 @@ describe('📦 Middleware normalize HTTP event', () => {
       multiValueQueryStringParameters: { param: ['123'] }
     }
 
-    const normalizedEvent = await invoke(handler, event)
+    const normalizedEvent = await invoke(handlerRestApi, event)
 
     expect(normalizedEvent).toHaveProperty('multiValueQueryStringParameters', { param: ['123'] })
   })
@@ -74,7 +118,22 @@ describe('📦 Middleware normalize HTTP event', () => {
       pathParameters: { param: '123' }
     }
 
-    const normalizedEvent = await invoke(handler, event)
+    const normalizedEvent = await invoke(handlerRestApi, event)
+
+    expect(normalizedEvent).toHaveProperty('pathParameters', { param: '123' })
+  })
+
+  test('It should not overwrite pathParameters with HTTP API', async () => {
+    const event = {
+      requestContext: {
+        http: {
+          method: 'GET'
+        }
+      },
+      pathParameters: { param: '123' }
+    }
+
+    const normalizedEvent = await invoke(handlerHttpApi, event)
 
     expect(normalizedEvent).toHaveProperty('pathParameters', { param: '123' })
   })

--- a/packages/http-event-normalizer/index.d.ts
+++ b/packages/http-event-normalizer/index.d.ts
@@ -1,5 +1,9 @@
 import middy from '@middy/core'
 
-declare const httpEventNormalizer : middy.Middleware<any, any, any>
+interface IHttpEventNormalizerOptions {
+  payloadFormatVersion?: number;
+}
+
+declare const httpEventNormalizer : middy.Middleware<IHttpEventNormalizerOptions, any, any>
 
 export default httpEventNormalizer

--- a/packages/http-event-normalizer/index.js
+++ b/packages/http-event-normalizer/index.js
@@ -1,13 +1,37 @@
-module.exports = () => ({
-  before: (handler, next) => {
-    const { event } = handler
-
-    if (Object.prototype.hasOwnProperty.call(event, 'httpMethod')) {
-      event.queryStringParameters = event.queryStringParameters || {}
-      event.multiValueQueryStringParameters = event.multiValueQueryStringParameters || {}
-      event.pathParameters = event.pathParameters || {}
-    }
-
-    return next()
+module.exports = opts => {
+  const defaults = {
+    payloadFormatVersion: 1
   }
-})
+
+  const options = Object.assign({}, defaults, opts)
+
+  return {
+    before: (handler, next) => {
+      const { event } = handler
+      let isHttpEvent = false
+
+      switch (options.payloadFormatVersion) {
+        case 1:
+          isHttpEvent = Object.prototype.hasOwnProperty.call(event, 'httpMethod')
+          break
+        case 2:
+          isHttpEvent = Object.prototype.hasOwnProperty.call(event, 'requestContext') &&
+            Object.prototype.hasOwnProperty.call(event.requestContext, 'http') &&
+            Object.prototype.hasOwnProperty.call(event.requestContext.http, 'method')
+          break
+        default:
+          throw new Error('Unknow API Gateway Payload format. Please use value 1 or 2.')
+      }
+
+      if (isHttpEvent) {
+        event.queryStringParameters = event.queryStringParameters || {}
+        event.pathParameters = event.pathParameters || {}
+        if (options.payloadFormatVersion === 1) {
+          event.multiValueQueryStringParameters = event.multiValueQueryStringParameters || {}
+        }
+      }
+
+      return next()
+    }
+  }
+}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Add new option for http-event-normalizer to enable use of  API Gateway HTTP API payload format v2.0 event.
This middleware "recognize" incoming event from API Gateway using the existence of `httpMethod` parameter on input event object. With HTTP API v2.0, this parameter does not exist anymore, and is replaced with `requestContext.http.method`

Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, etc?
-------------------------------------
No

Any other comments?
-------------------
No

Where has this been tested?
---------------------------
**Node.js Versions:** 12

**Middy Versions:** 1.0.0

**AWS SDK Versions:** N/A

Todo list
---------

[ x ] Feature/Fix fully implemented
[ x ] Added tests
[ x ] Updated relevant documentation
[ ] Updated relevant examples
