### PR TITLE
feat: add ssm.onChange support back to 1.x

### DIFF
--- a/packages/ssm/README.md
+++ b/packages/ssm/README.md
@@ -55,6 +55,7 @@ npm install --save @middy/ssm
 - `cacheExpiryInMillis` (int) (optional): Defaults to `undefined`. Use this option to invalidate cached parameter values from SSM
 - `names` (object) (optional*): Map of parameters to fetch from SSM, where the key is the destination, and value is param name in SSM.
   Example: `{names: {DB_URL: '/dev/service/db_url'}}`
+- `onChange` (function) (optional): Callback triggered when call was made to SSM. Useful when you need to regenerate something with different data. Example: `{ onChange: () => { console.log('New data available')} }`
 - `awsSdkOptions` (object) (optional): Options to pass to AWS.SSM class constructor.
   Defaults to `{ maxRetries: 6, retryDelayOptions: {base: 200} }`
 - `setToContext` (boolean) (optional): This will assign parameters to the `context` object
@@ -93,6 +94,31 @@ handler(event, context, (_, response) => {
 })
 ```
 
+Export parameters to context object, override AWS region.
+
+```javascript
+const middy = require('middy')
+const { ssm } = require('middy/middlewares')
+
+const handler = middy((event, context, cb) => {
+  cb(null, {})
+})
+
+handler.use(
+  ssm({
+    cache: true,
+    names: {
+      SOME_ACCESS_TOKEN: '/dev/service_name/access_token'
+    },
+    awsSdkOptions: { region: 'us-west-1' },
+    setToContext: true
+  })
+)
+
+handler(event, context, (_, response) => {
+  expect(context.SOME_ACCESS_TOKEN).toEqual('some-access-token')
+})
+```
 
 ## Middy documentation and examples
 

--- a/packages/ssm/index.d.ts
+++ b/packages/ssm/index.d.ts
@@ -2,6 +2,7 @@ import { SSM } from 'aws-sdk'
 import middy from '@middy/core'
 
 interface ISSMOptions {
+  onChange?: () => void;
   cache?: boolean;
   cacheExpiryInMillis?: number;
   paths?: { [key: string]: string; };

--- a/packages/ssm/index.js
+++ b/packages/ssm/index.js
@@ -7,6 +7,7 @@ module.exports = opts => {
       maxRetries: 6, // lowers a chance to hit service rate limits, default is 3
       retryDelayOptions: { base: 200 }
     },
+    onChange: undefined,
     paths: {},
     names: {},
     getParamNameFromPath: getParamNameFromPathDefault,
@@ -72,6 +73,10 @@ module.exports = opts => {
         objectsToMap.forEach(object => {
           Object.assign(targetParamsObject, object)
         })
+
+        if (typeof options.onChange === 'function') {
+          options.onChange()
+        }
         options.paramsLoaded = true
         options.paramsCache = objectsToMap
         options.paramsLoadedAt = new Date()


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
The `onChange` support for SSM middleware was missed from the 0.x branch, this PR adds it back in.

Does this close any currently open issues?
------------------------------------------
No.


Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
No.

Where has this been tested?
---------------------------
**Node.js Versions:** …

**Middy Versions:** …

**AWS SDK Versions:** …

Todo list
---------

[x] Feature/Fix fully implemented
[x] Added tests
[x] Updated relevant documentation
[x] Updated relevant examples
