### PR TITLE
docs: correct url to guide for upgrading from 0.x to 1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 Middy 1.x, with support for Node.js 10 & 12 will soon replace Middy 0.x.
 
-You can already use Middy 1.x, check out [branch `1.0.0-beta`](https://github.com/middyjs/middy/tree/1.0.0-beta) for documentation and source code. If you have a project running on Middy 0.x that you need to port to Middy 1.x, you can also check out the [upgrade guide](https://github.com/middyjs/middy/blob/1.0.0-beta/UPGRADE.md).
+You can already use Middy 1.x, check out [release `1.2.0'](https://github.com/middyjs/middy/tree/1.2.0) for documentation and source code. If you have a project running on Middy 0.x that you need to port to Middy 1.x, you can also check out the [upgrade guide](https://github.com/middyjs/middy/blob/1.2.0/UPGRADE.md).
 
 This is the expected timeline for the future releases:
 


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes the url for guide for upgrading from 0.x to 1.x + points to the latest stable release tree.

Does this close any currently open issues?
------------------------------------------
Yes. https://github.com/middyjs/middy/issues/554


Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Node.js Versions:** …

**Middy Versions:** …

**AWS SDK Versions:** …

Todo list
---------

[ ] Feature/Fix fully implemented
[ ] Added tests
[ ] Updated relevant documentation
[ ] Updated relevant examples
