### PR TITLE
fix(core): before middlewares should be able to change context

### DIFF
--- a/packages/core/__tests__/index.js
+++ b/packages/core/__tests__/index.js
@@ -197,6 +197,27 @@ describe('🛵  Middy test suite', () => {
     })
   })
 
+  test('"before" middlewares should be able to change context', (endTest) => {
+    const handler = middy((event, context, callback) => {
+      return callback(null, { foo: 'bar' })
+    })
+
+    const changeEventMiddleware = (handler, next) => {
+      handler.context = {
+        ...handler.context,
+        modified: true
+      }
+      next()
+    }
+
+    handler.before(changeEventMiddleware)
+
+    handler({}, {}, () => {
+      expect(handler.context.modified).toBe(true)
+      endTest()
+    })
+  })
+
   test('"after" middlewares should be able to change response', (endTest) => {
     const handler = middy((event, context, callback) => {
       return callback(null, { foo: 'bar' })

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -186,7 +186,7 @@ const middy = (handler) => {
           })
         })
 
-        const handlerReturnValue = handler.call(instance, instance.event, context, (err, response) => {
+        const handlerReturnValue = handler.call(instance, instance.event, instance.context, (err, response) => {
           if (err) return onHandlerError(err)
           onHandlerSuccess(response)
         })


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
middlewares should be able to change the context that is passed to handlers

Does this close any currently open issues?
------------------------------------------
#484 


Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Node.js Versions:** …

**Middy Versions:** …

**AWS SDK Versions:** …

Todo list
---------

[X] Feature/Fix fully implemented
[X] Added tests
[ ] Updated relevant documentation
[ ] Updated relevant examples
