### PR TITLE
Add lodash cloneDeep to support arrays in omitPaths

### DIFF
--- a/packages/input-output-logger/__tests__/index.js
+++ b/packages/input-output-logger/__tests__/index.js
@@ -49,5 +49,23 @@ describe('📦 Middleware Input Output Logger', () => {
       expect(logger).toHaveBeenCalledWith({ event: { foo: 'bar', fuu: 'baz' } })
       expect(logger).toHaveBeenCalledWith({ response: 'yo' })
     })
+
+    test('Skipped parts should be present in the response', async () => {
+      const logger = jest.fn()
+
+      const handler = middy((event, context, cb) => {
+        cb(null, { foo: [{ foo: 'bar', fuu: 'baz' }] })
+      })
+
+      handler
+        .use(inputOutputLogger({ logger, omitPaths: ['event.zooloo', 'event.foo.hoo', 'response.foo[0].foo'] }))
+
+      const response = await invoke(handler, { foo: 'bar', fuu: 'baz' })
+
+      expect(logger).toHaveBeenCalledWith({ event: { foo: 'bar', fuu: 'baz' } })
+      expect(logger).toHaveBeenCalledWith({ response: { foo: [{ fuu: 'baz' }] } })
+
+      expect(response).toMatchObject({ foo: [{ foo: 'bar', fuu: 'baz' }] })
+    })
   })
 })

--- a/packages/input-output-logger/index.js
+++ b/packages/input-output-logger/index.js
@@ -1,4 +1,5 @@
 const omit = require('lodash/omit')
+const cloneDeep = require('lodash/cloneDeep')
 
 module.exports = (opts) => {
   const defaults = {
@@ -9,7 +10,8 @@ module.exports = (opts) => {
   const { logger, omitPaths } = Object.assign({}, defaults, opts)
 
   const omitAndLog = message => {
-    const redactedMessage = omit(message, omitPaths)
+    const messageClone = cloneDeep(message)
+    const redactedMessage = omit(messageClone, omitPaths)
     logger(redactedMessage)
   }
 

--- a/packages/input-output-logger/index.js
+++ b/packages/input-output-logger/index.js
@@ -1,5 +1,4 @@
 const omit = require('lodash/omit')
-const cloneDeep = require('lodash/cloneDeep')
 
 module.exports = (opts) => {
   const defaults = {
@@ -9,8 +8,10 @@ module.exports = (opts) => {
 
   const { logger, omitPaths } = Object.assign({}, defaults, opts)
 
+  const cloneMessage = message => JSON.parse(JSON.stringify(message))
+
   const omitAndLog = message => {
-    const messageClone = cloneDeep(message)
+    const messageClone = cloneMessage(message)
     const redactedMessage = omit(messageClone, omitPaths)
     logger(redactedMessage)
   }


### PR DESCRIPTION
… and unit test with the case.

(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
----------------------------------------------------

While working with the middleware I discovered that, when adding a path to omitPaths which is apart of an array ("response.users[0].email"), the field was deleted form the log but also from the response.

Using cloneDeep fixes this behaviour (unit test added).

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Node.js Versions:** …
--12.4--
**Middy Versions:** …

**AWS SDK Versions:** …

Todo list
---------

[ X] Feature/Fix fully implemented
[ X] Added tests
[ NA] Updated relevant documentation
[ NA] Updated relevant examples
