### PR TITLE
Explicit path on implicit require error

### DIFF
--- a/packages/validator/index.js
+++ b/packages/validator/index.js
@@ -120,6 +120,7 @@ function initAjv (options, pluginsOptions) {
     try {
       pluginsInstances[p] = require(`ajv-${p}`)
     } catch (e) {
+      /* Fixes #560: Webpack needs explicit paths for dynamic imports */
       const pckJson = require(`../../ajv-${p}/package.json`)
       pluginsInstances[p] = require(`../../ajv-${p}/${pckJson.main}`)
     }

--- a/packages/validator/index.js
+++ b/packages/validator/index.js
@@ -117,7 +117,13 @@ function initAjv (options, pluginsOptions) {
   ajv = new Ajv(options)
 
   Object.keys(pluginsOptions).forEach(p => {
-    pluginsInstances[p] = require(`ajv-${p}`)
+    try {
+      pluginsInstances[p] = require(`ajv-${p}`)
+    } catch (e) {
+      const pckJson = require(`../../ajv-${p}/package.json`)
+      pluginsInstances[p] = require(`../../ajv-${p}/${pckJson.main}`)
+    }
+
     if (typeof pluginsInstances[p] === 'function') {
       pluginsInstances[p](ajv, pluginsOptions[p])
     }


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
In order to instruct webpack to take into account certain required modules in a dynamic fashion, the path should be explicit. So first the conventional way to get the library is tried, if it fails, the code tries to go with an explicit path to the main file for the library.

Does this close any currently open issues?
------------------------------------------
Closes #560 

Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------
N/A

Where has this been tested?
---------------------------
**Node.js Versions:** 12.18.0

**Middy Versions:** 1.3.1

**AWS SDK Versions:** 2.656.0

Todo list
---------

[X] Feature/Fix fully implemented
N/A Added tests
N/A Updated relevant documentation
N/A Updated relevant examples
