### PR TITLE
feat: http-json-body-parser handles JSON Media Type Suffix

### DIFF
--- a/packages/http-json-body-parser/__tests__/index.js
+++ b/packages/http-json-body-parser/__tests__/index.js
@@ -23,6 +23,26 @@ describe('📦  Middleware JSON Body Parser', () => {
     expect(body).toEqual({ foo: 'bar' })
   })
 
+  test('It should parse a JSON with a suffix MediaType request', async () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, event.body) // propagates the body as a response
+    })
+
+    handler.use(jsonBodyParser())
+
+    // invokes the handler
+    const event = {
+      headers: {
+        'Content-Type': 'application/vnd+json'
+      },
+      body: JSON.stringify({ foo: 'bar' })
+    }
+
+    const body = await invoke(handler, event)
+
+    expect(body).toEqual({ foo: 'bar' })
+  })
+
   test('It should use a reviver when parsing a JSON request', async () => {
     const handler = middy((event, context, cb) => {
       cb(null, event.body) // propagates the body as a response

--- a/packages/http-json-body-parser/index.js
+++ b/packages/http-json-body-parser/index.js
@@ -8,7 +8,7 @@ module.exports = (opts) => ({
       const contentTypeHeader = handler.event.headers['content-type'] || handler.event.headers['Content-Type']
       if (contentTypeHeader) {
         const { type } = contentType.parse(contentTypeHeader)
-        if (type === 'application/json') {
+        if (type.match(/^application\/(.*\+)?json$/)) {
           try {
             const data = handler.event.isBase64Encoded
               ? Buffer.from(handler.event.body, 'base64').toString()


### PR DESCRIPTION
This change the http-json-body-parser to also automatically accept request
bodies that have a media type like 'application/vnd+json'

(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------

This augments the http-json-body-parser to also automatically parse any request bodies that have a JSON
content type that is included like a suffix. For example "application/vnd.api+json".

For more information please see [RFC 6839](https://tools.ietf.org/html/rfc6839)

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------

Any other comments?
-------------------

Where has this been tested?
---------------------------
**Node.js Versions:** 12.18.0

**Middy Versions:** 1.3.1

**AWS SDK Versions:** 2.656.0

Todo list
---------

[X] Feature/Fix fully implemented
[X] Added tests
[-] Updated relevant documentation
[-] Updated relevant examples
