### PR TITLE
#569 Allow fetching parameters from a different account via STS

### DIFF
--- a/packages/ssm/index.d.ts
+++ b/packages/ssm/index.d.ts
@@ -1,4 +1,4 @@
-import { SSM } from 'aws-sdk'
+import { SSM, STS } from 'aws-sdk'
 import middy from '@middy/core'
 
 interface ISSMOptions {
@@ -11,6 +11,12 @@ interface ISSMOptions {
   setToContext?: boolean;
   paramsLoaded?: Boolean;
   getParamNameFromPath?: (path: string, name: string, prefix: string) => string;
+  stsOptions?: ISTSOptions
+}
+
+interface ISTSOptions {
+  assumeRoleOptions: Partial<STS.Types.AssumeRoleRequest>;
+  awsSdkOptions?: Partial<STS.Types.ClientConfiguration>
 }
 
 declare const ssm : middy.Middleware<ISSMOptions, any, any>


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------
The PR implements a #569 which allows `@middy/ssm` to assume a role before fetching parameters. The config was changed but kept backward compatible with the current version.

Does this close any currently open issues?
------------------------------------------
Yes, it does.


Where has this been tested?
---------------------------
**Node.js Versions:** 12.14.1

**Middy Versions:** 1.4.0

**AWS SDK Versions:** 2.774.0

Todo list
---------

[x] Feature/Fix fully implemented
[x] Added tests
[x] Updated relevant documentation
[x] Updated relevant examples
