### PR TITLE
feat: customisable aws-sdk instance of SSM

### DIFF
--- a/packages/ssm/README.md
+++ b/packages/ssm/README.md
@@ -57,6 +57,7 @@ npm install --save @middy/ssm
   Example: `{names: {DB_URL: '/dev/service/db_url'}}`
 - `onChange` (function) (optional): Callback triggered when call was made to SSM. Useful when you need to regenerate something with different data. Example: `{ onChange: () => { console.log('New data available')} }`
 - `awsSdkOptions` (object) (optional): Options to pass to AWS.SSM class constructor.
+- `awsSdkInstance` (object) (optional): an alternative instance of AWS.SSM to use (e.g. that has been instrumented with AWS XRay)
   Defaults to `{ maxRetries: 6, retryDelayOptions: {base: 200} }`
 - `setToContext` (boolean) (optional): This will assign parameters to the `context` object
   of the function handler rather than to `process.env`. Defaults to `false`

--- a/packages/ssm/index.d.ts
+++ b/packages/ssm/index.d.ts
@@ -8,6 +8,7 @@ interface ISSMOptions {
   paths?: { [key: string]: string; };
   names?: { [key: string]: string; };
   awsSdkOptions?: Partial<SSM.Types.ClientConfiguration>;
+  awsSdkInstance?: SSM;
   setToContext?: boolean;
   paramsLoaded?: Boolean;
   getParamNameFromPath?: (path: string, name: string, prefix: string) => string;

--- a/packages/ssm/index.js
+++ b/packages/ssm/index.js
@@ -7,6 +7,7 @@ module.exports = opts => {
       maxRetries: 6, // lowers a chance to hit service rate limits, default is 3
       retryDelayOptions: { base: 200 }
     },
+    awsSdkInstance: undefined,
     onChange: undefined,
     paths: {},
     names: {},
@@ -33,7 +34,7 @@ module.exports = opts => {
         return next()
       }
 
-      ssmInstance = ssmInstance || new SSM(options.awsSdkOptions)
+      ssmInstance = options.awsSdkInstance || ssmInstance || new SSM(options.awsSdkOptions)
 
       const ssmPromises = Object.keys(options.paths).reduce(
         (aggregator, prefix) => {


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------

Adds support for customising the SSM instance used by the @middy/ssm middleware. The purpose of doing this is to enable tracing tools to add hooks to the instantiated instance, such as AWS XRay.

Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------


Where has this been tested?
---------------------------
**Node.js Versions:** nodejs 12.x

**Middy Versions:** version in master

**AWS SDK Versions:** 2.772.0

Todo list
---------

[ X ] Feature/Fix fully implemented
[ N/A ] Added tests
[ X ] Updated relevant documentation
[N/A] Updated relevant examples
