### PR TITLE
Prevent lambda timeouts or failure from not handled promise due to invalid SSM parameter(s)... Add throwOnFailedCall flag to the SSM middleware 

### DIFF
--- a/packages/ssm/README.md
+++ b/packages/ssm/README.md
@@ -60,6 +60,7 @@ npm install --save @middy/ssm
   Defaults to `{ maxRetries: 6, retryDelayOptions: {base: 200} }`
 - `setToContext` (boolean) (optional): This will assign parameters to the `context` object
   of the function handler rather than to `process.env`. Defaults to `false`
+- `throwOnFailedCall` (boolean) (optional): Defaults to `false`. Set it to `true` if you want your lambda to fail in case call to AWS SSM fails (parameters don't exist or internal error). It will only print error if parameters are not already cached.
 
 NOTES:
 * While you don't need _both_ `paths` and `names`, you do need at least one of them!

--- a/packages/ssm/__tests__/index.js
+++ b/packages/ssm/__tests__/index.js
@@ -292,7 +292,7 @@ describe('🔒 SSM Middleware', () => {
     })
   })
 
-  test('It should throw error when some SSM params are invalid', async () => {
+  test('It should throw error when some SSM params are invalid and "throwOnFailedCall" flag is set to true', async () => {
     await testScenario({
       ssmMockResponse: {
         InvalidParameters: ['invalid-smm-param-name', 'another-invalid-ssm-param']
@@ -301,11 +301,37 @@ describe('🔒 SSM Middleware', () => {
         names: {
           invalidParam: 'invalid-smm-param-name',
           anotherInvalidParam: 'another-invalid-ssm-param'
-        }
+        },
+        throwOnFailedCall: true
       },
       callbacks: [
         (error) => {
           expect(error.message).toEqual('InvalidParameters present: invalid-smm-param-name, another-invalid-ssm-param')
+        }
+      ]
+    })
+  })
+
+  test('It should resolve if "throwOnFailedCall" flag is not provided but some SSM params are invalid (will throw silently?)', async () => {
+    await testScenario({
+      ssmMockResponse: {
+        InvalidParameters: ['invalid-smm-param-name', 'another-invalid-ssm-param']
+      },
+      middlewareOptions: {
+        names: {
+          invalidParam: 'invalid-smm-param-name',
+          anotherInvalidParam: 'another-invalid-ssm-param'
+        },
+        throwOnFailedCall: false
+      },
+      callbacks: [
+        (_) => {
+          expect(_).toBeNull() // TODO: don't know how to test this properly... there is no mockObject to check whether was called or not! (Check if console.error prints '[Failed to get parameters from SSM] ...' ?)
+        },
+        () => {
+          expect(getParametersMock).toBeCalled()
+          expect(getParametersMock).toHaveBeenCalledTimes(2)
+          getParametersMock.mockClear()
         }
       ]
     })

--- a/packages/ssm/index.d.ts
+++ b/packages/ssm/index.d.ts
@@ -8,6 +8,7 @@ interface ISSMOptions {
   paths?: { [key: string]: string; };
   names?: { [key: string]: string; };
   awsSdkOptions?: Partial<SSM.Types.ClientConfiguration>;
+  throwOnFailedCall?: boolean;
   setToContext?: boolean;
   paramsLoaded?: Boolean;
   getParamNameFromPath?: (path: string, name: string, prefix: string) => string;

--- a/packages/ssm/index.js
+++ b/packages/ssm/index.js
@@ -7,6 +7,7 @@ module.exports = opts => {
       maxRetries: 6, // lowers a chance to hit service rate limits, default is 3
       retryDelayOptions: { base: 200 }
     },
+    throwOnFailedCall: false,
     onChange: undefined,
     paths: {},
     names: {},
@@ -81,6 +82,22 @@ module.exports = opts => {
         options.paramsCache = objectsToMap
         options.paramsLoadedAt = new Date()
       })
+        .catch(err => {
+          console.error(
+            '[Failed to get parameters from SSM] ',
+            err.message
+          )
+          // throw error if there is no params in cache already and flag throwOnFailedCall is provided
+          if (options.throwOnFailedCall && !options.paramsCache) {
+            throw err
+          }
+          // if we already have a cached params, then reset the timestamp so we don't
+          // keep retrying on every invocation which can cause performance problems
+          // when there's temporary problems with SSM
+          if (options.paramsCache) {
+            options.paramsLoadedAt = new Date()
+          }
+        })
     }
   }
 }

--- a/packages/ssm/package-lock.json
+++ b/packages/ssm/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@middy/core": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.3.2.tgz",
-      "integrity": "sha512-k+DBldh7VlhQ3NXBvOcFbv1p2JIV5sI9Em96zCPJhkVC8894B84UJhW3lJL7rnEE8GEprC76vUFlX36lrSJ9MQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-ek7sC1BVh11oPPoATrG44WDpqxws9dHnOY1Y2Kg/95+hCuIpH7mTWMf2ja3Hj5w81PVF9i/CmsIhK5RsOKNZVg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------
…
PR regarding #567 

If you provide a non-existent SSM parameter to the `@middy/ssm` middleware it will cause the function to go to timeout if you are not using `@middy/do-not-wait-for-empty-event-loop`, or with  `do-not-wait-for-empty-event-loop` in place, it will fail immediately (the error is thrown in the `handleInvalidParams()` function but it is not handled anywhere!) and not reach the original handler!

Changes: 
- Added optional `throwOnFailedCall` flag with default value `false` (Same implementation as Secret Manager middleware)
- Added catch to the main Promise.all(ssmPromises)
    - If  `throwOnFailedCall=false` it will just `console.error` the error and continue to the next middleware or main handler
    - If  `throwOnFailedCall=true` it will `console.error` the error and throw the error thrown from `handleInvalidParams()` 

p.s tested this implementation on AWS lambda with the code below... works as expected!
```js
const middy = require('@middy/core')
const doNotWaitForEmptyEventLoop = require('@middy/do-not-wait-for-empty-event-loop')
const httpEventNormalizer = require('@middy/http-event-normalizer')
const httpSecurityHeaders = require('@middy/http-security-headers')
const ssm = require('@middy/ssm')

const hello = async (event, context) => {
  console.log('EVENT: ', event)
  console.log('CONTEXT: ', context)
  
  const { testSecret } = context
  console.log('testSecret: ', testSecret)

  return {
        statusCode: 200,
        body: JSON.stringify(context)
  }
}

module.exports.default = middy(hello)
  .use(doNotWaitForEmptyEventLoop({ runOnError: true }))
  .use(httpSecurityHeaders())
  .use(httpEventNormalizer())
  .use(
    ssm({
      cache: true,
      cacheExpiryInMillis: 60 * 1000, 
      names: {
        testSecret: process.env.SSM_PARAM
      },
      setToContext: true,
      throwOnFailedCall: false
    })
  )

``` 

Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
@willfarrell let me know if something else is needed! Don't have much time to check the documentation for `do-not-wait-for-empty-event-loop`

Some additional tests might be needed for the new `throwOnFailedCall` flag!

Where has this been tested?
---------------------------
**Node.js Versions:** : Node v12.18.3 (npm v6.14.6)

**Middy Versions:** : v1.4.0

**AWS SDK Versions:**: ^2.771.0

Todo list
---------

- [x] Feature/Fix fully implemented
- [x] Added tests
- [ ] Add additional tests for `throwOnFailedCall` if needed
- [x] Updated relevant documentation
- [x] Updated relevant examples
