### PR TITLE
Secretes Manager: Add ability to set string secret as environment variable

### DIFF
--- a/packages/secrets-manager/README.md
+++ b/packages/secrets-manager/README.md
@@ -54,6 +54,7 @@ npm install --save @middy/secrets-manager
   Example: `{secrets: {RDS_LOGIN: 'dev/rds_login'}}`
 - `awsSdkOptions` (object) (optional): Options to pass to AWS.SecretsManager class constructor.
 - `throwOnFailedCall` (boolean) (optional): Defaults to `false`. Set it to `true` if you want your lambda to fail in case call to AWS Secrets Manager fails (secrets don't exist or internal error). It will only print error if secrets are not already cached.
+- `setEnvironment` (boolean) (optional): Defaults to `false`. Set it to `true` if you want to set the secrets as environment variables in addition to the context parameter. Praticularly useful for string secrets.
 
 NOTES:
 * Lambda is required to have IAM permission for `secretsmanager:GetSecretValue` action

--- a/packages/secrets-manager/__tests__/index.js
+++ b/packages/secrets-manager/__tests__/index.js
@@ -116,6 +116,26 @@ describe('🔒 SecretsManager Middleware', () => {
     })
   })
 
+  test('It should set string secrets to process.env when setEnvironment is true', async () => {
+    await testScenario({
+      mockResponse: {
+        SecretString: 'secret-api-key'
+      },
+      middlewareOptions: {
+        secrets: {
+          API_KEY: 'api_key'
+        },
+        setEnvironment: true
+      },
+      callbacks: [
+        (_, __) => {
+          hasStringKey(process.env, 'secret-api-key')
+          expect(getSecretValueMock).toBeCalled()
+        }
+      ]
+    })
+  })
+
   test('It should set string secrets to context when it is invalid JSON', async () => {
     await testScenario({
       mockResponse: {

--- a/packages/secrets-manager/index.d.ts
+++ b/packages/secrets-manager/index.d.ts
@@ -7,6 +7,7 @@ interface ISecretsManagerOptions {
   secrets?: { [key: string]: string; };
   awsSdkOptions?: Partial<SecretsManager.Types.ClientConfiguration>;
   throwOnFailedCall?: boolean;
+  setEnvironment?: boolean
 }
 
 declare const secretsManager : middy.Middleware<ISecretsManagerOptions, any, any>

--- a/packages/secrets-manager/index.js
+++ b/packages/secrets-manager/index.js
@@ -10,7 +10,8 @@ module.exports = opts => {
     cacheExpiryInMillis: undefined,
     secretsLoaded: false,
     secretsCache: undefined,
-    secretsLoadedAt: new Date(0)
+    secretsLoadedAt: new Date(0),
+    setEnvironment: false
   }
 
   const options = Object.assign({}, defaults, opts)
@@ -20,7 +21,7 @@ module.exports = opts => {
       // if there're cached secrets already, then use it in case refresh fails
       if (options.secretsCache) {
         options.secretsCache.forEach(object => {
-          Object.assign(handler.context, object)
+          setSecret(handler, object, options)
         })
       }
 
@@ -45,7 +46,7 @@ module.exports = opts => {
       return Promise.all(secretsPromises)
         .then(objectsToMap => {
           objectsToMap.forEach(object => {
-            Object.assign(handler.context, object)
+            setSecret(handler, object, options)
           })
 
           options.secretsLoaded = true
@@ -92,6 +93,11 @@ const shouldFetchFromSecretsManager = ({
 
   // otherwise, don't bother
   return false
+}
+
+function setSecret ({ context }, object, { setEnvironment }) {
+  Object.assign(context, object)
+  if (setEnvironment) Object.entries(object).forEach(([key, value]) => { process.env[key] = String(value) })
 }
 
 function safeParse (secretString) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds the ability to set string secret as environment variable.
It's often useful to have some secrets available on `process.env` in addition to the lambda's `context` instead of cascading it down a deeply nested function call stack.  

Todo list
---------

- [x] Feature/Fix fully implemented
- [x] Added tests
- [x] Updated relevant documentation
- [x] Updated relevant examples
