### PR TITLE
Fix esbuild compatibility issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middy-monorepo",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "🛵 The stylish Node.js middleware engine for AWS Lambda",
   "engines": {
     "node": ">=10"

--- a/packages/validator/index.js
+++ b/packages/validator/index.js
@@ -121,7 +121,7 @@ function initAjv (options, pluginsOptions) {
       pluginsInstances[p] = require(`ajv-${p}`)
     } catch (e) {
       /* Fixes issue with esbuild */
-      getPlugins(p);
+      getPlugins(p)
     }
 
     if (typeof pluginsInstances[p] === 'function') {
@@ -134,12 +134,12 @@ function initAjv (options, pluginsOptions) {
   previousConstructorOptions = options
 }
 
-function getPlugins(p) {
+function getPlugins (p) {
   try {
     /* Fixes #560: Webpack needs explicit paths for dynamic imports */
     const pckJson = require(`../../ajv-${p}/package.json`)
     pluginsInstances[p] = require(`../../ajv-${p}/${pckJson.main}`)
   } catch (e) {
-    console.error(`Error getting plugins ${e.message}`);
+    console.error(`Error getting plugins ${e.message}`)
   }
 }

--- a/packages/validator/index.js
+++ b/packages/validator/index.js
@@ -120,9 +120,8 @@ function initAjv (options, pluginsOptions) {
     try {
       pluginsInstances[p] = require(`ajv-${p}`)
     } catch (e) {
-      /* Fixes #560: Webpack needs explicit paths for dynamic imports */
-      const pckJson = require(`../../ajv-${p}/package.json`)
-      pluginsInstances[p] = require(`../../ajv-${p}/${pckJson.main}`)
+      /* Fixes issue with esbuild */
+      getPlugins(p);
     }
 
     if (typeof pluginsInstances[p] === 'function') {
@@ -133,4 +132,14 @@ function initAjv (options, pluginsOptions) {
   availableLanguages = Object.keys(pluginsInstances.i18n || {})
 
   previousConstructorOptions = options
+}
+
+function getPlugins(p) {
+  try {
+    /* Fixes #560: Webpack needs explicit paths for dynamic imports */
+    const pckJson = require(`../../ajv-${p}/package.json`)
+    pluginsInstances[p] = require(`../../ajv-${p}/${pckJson.main}`)
+  } catch (e) {
+    console.error(`Error getting plugins ${e.message}`);
+  }
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
`require()` staments that use string interpolation are not compatible with `esbuild` unless the code is surrounded with a try-catch block.

Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, etc?
-------------------------------------
```
Serverless: Compiling with esbuild...
 > node_modules/@middy/validator/index.js: warning: This call to "require" will not be bundled because the argument is not a string literal (surround with a try/catch to silence this warning)
    124 │       const pckJson = require(`../../ajv-${p}/package.json`)
        ╵                       ~~~~~~~

 > node_modules/@middy/validator/index.js: warning: This call to "require" will not be bundled because the argument is not a string literal (surround with a try/catch to silence this warning)
    125 │       pluginsInstances[p] = require(`../../ajv-${p}/${pckJson.main}`)
        ╵                             ~~~~~~~

2 warnings
```

Where has this been tested?
---------------------------
**Node.js Versions: v12.10.0

**Middy Versions: 1.5.0

**AWS SDK Versions: 2.820.0

Todo list
---------

[X] Feature/Fix fully implemented