### PR TITLE
Add optional identifier to input and output logging

### DIFF
--- a/packages/input-output-logger/README.md
+++ b/packages/input-output-logger/README.md
@@ -46,6 +46,7 @@ npm install --save @middy/input-output-logger
 
 `logger` property accept a function (default `console.log`)
 `omitPaths` property accepts an array of paths that will be used to remove particular fields from the logged objects. This could serve as a simple way to redact sensitive data from logs (default []).
+`identifier` property accepts a string value to add to logged input and output messages.
 
 
 ## Sample usage

--- a/packages/input-output-logger/__tests__/index.js
+++ b/packages/input-output-logger/__tests__/index.js
@@ -1,7 +1,6 @@
 const { invoke } = require('../../test-helpers')
 const middy = require('../../core')
-const inputOutputLogger = require('../');
-const { async } = require('regenerator-runtime');
+const inputOutputLogger = require('../')
 
 describe('📦 Middleware Input Output Logger', () => {
   test('It should log event and response', async () => {

--- a/packages/input-output-logger/__tests__/index.js
+++ b/packages/input-output-logger/__tests__/index.js
@@ -1,6 +1,7 @@
 const { invoke } = require('../../test-helpers')
 const middy = require('../../core')
-const inputOutputLogger = require('../')
+const inputOutputLogger = require('../');
+const { async } = require('regenerator-runtime');
 
 describe('📦 Middleware Input Output Logger', () => {
   test('It should log event and response', async () => {
@@ -34,6 +35,21 @@ describe('📦 Middleware Input Output Logger', () => {
       expect(logger).toHaveBeenCalledWith({ event: { fuu: 'baz' } })
       expect(logger).toHaveBeenCalledWith({ response: { message: 'hello world' } })
     })
+    test('It should include identifier if supplied', async () => {
+      const logger = jest.fn()
+
+      const handler = middy((event, context, cb) => {
+        cb(null, { message: 'hello world', bar: 'bi' })
+      })
+
+      handler
+        .use(inputOutputLogger({ logger, omitPaths: ['event.foo', 'response.bar'], identifier: '123' }))
+
+      await invoke(handler, { foo: 'bar', fuu: 'baz' })
+
+      expect(logger).toHaveBeenCalledWith({ identifier: '123', event: { fuu: 'baz' } })
+      expect(logger).toHaveBeenCalledWith({ identifier: '123', response: { message: 'hello world' } })
+    })
     test('It should skip paths that do not exist', async () => {
       const logger = jest.fn()
 
@@ -49,7 +65,6 @@ describe('📦 Middleware Input Output Logger', () => {
       expect(logger).toHaveBeenCalledWith({ event: { foo: 'bar', fuu: 'baz' } })
       expect(logger).toHaveBeenCalledWith({ response: 'yo' })
     })
-
     test('Skipped parts should be present in the response', async () => {
       const logger = jest.fn()
 

--- a/packages/input-output-logger/index.d.ts
+++ b/packages/input-output-logger/index.d.ts
@@ -3,6 +3,7 @@ import middy from '@middy/core';
 interface IInputOutputLoggerOptions {
   logger?: (message: any) => void;
   omitPaths?: string[];
+  identifier?: string;
 }
 
 declare const inputOutputLogger : middy.Middleware<IInputOutputLoggerOptions, any, any>

--- a/packages/input-output-logger/index.d.ts
+++ b/packages/input-output-logger/index.d.ts
@@ -1,4 +1,4 @@
-import middy from '@middy/core';
+import middy from '@middy/core'
 
 interface IInputOutputLoggerOptions {
   logger?: (message: any) => void;
@@ -8,4 +8,4 @@ interface IInputOutputLoggerOptions {
 
 declare const inputOutputLogger : middy.Middleware<IInputOutputLoggerOptions, any, any>
 
-export default inputOutputLogger;
+export default inputOutputLogger

--- a/packages/input-output-logger/index.js
+++ b/packages/input-output-logger/index.js
@@ -3,17 +3,19 @@ const omit = require('lodash/omit')
 module.exports = (opts) => {
   const defaults = {
     logger: data => console.log(JSON.stringify(data, null, 2)),
-    omitPaths: []
+    omitPaths: [],
+    identifier: ''
   }
 
-  const { logger, omitPaths } = Object.assign({}, defaults, opts)
+  const { logger, omitPaths, identifier } = Object.assign({}, defaults, opts)
 
   const cloneMessage = message => JSON.parse(JSON.stringify(message))
 
   const omitAndLog = message => {
     const messageClone = cloneMessage(message)
     const redactedMessage = omit(messageClone, omitPaths)
-    logger(redactedMessage)
+
+    identifier ? logger({ identifier, ...redactedMessage }) : logger(redactedMessage)
   }
 
   return ({


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds the ability to supply an identifier to the logged input and output messages, useful when indexing logs or trying to connect input messages to their output.

Does this close any currently open issues?
------------------------------------------
No

Where has this been tested?
---------------------------
Node.js Versions: node v14.15.4

Middy Versions: 1.5.1

AWS SDK Versions: Not relevant

Todo list
---------

[x] Feature/Fix fully implemented
[x] Added tests
[x] Updated relevant documentation
[x] Updated relevant examples
