### PR TITLE
fix(http-security-headers): support array responses

### DIFF
--- a/packages/http-security-headers/__tests__/index.js
+++ b/packages/http-security-headers/__tests__/index.js
@@ -37,6 +37,8 @@ const createHeaderObjectResponse = () =>
     }
   )
 
+const createArrayResponse = () => [{ firstname: 'john', lastname: 'doe' }]
+
   test('It should return default security headers', async (t) => {
     const handler = middy((event, context) => createDefaultObjectResponse()
     )
@@ -153,4 +155,29 @@ const createHeaderObjectResponse = () =>
 
     const response = await handler(event)
     t.is(response.statusCode,500)
+  })
+
+  test('It should support array responses', async (t) => {
+    const handler = middy((event, context) => createArrayResponse())
+
+    handler.use(httpSecurityHeaders())
+
+    const event = {
+      httpMethod: 'GET'
+    }
+
+    const response = await handler(event)
+
+    t.deepEqual(response.body,[{ firstname: 'john', lastname: 'doe' }])
+    t.is(response.statusCode,undefined)
+    t.is(response.headers['X-DNS-Prefetch-Control'],'off')
+    t.is(response.headers['X-Powered-By'],undefined)
+    t.is(response.headers['Strict-Transport-Security'],'max-age=15552000; includeSubDomains; preload')
+    t.is(response.headers['X-Download-Options'],'noopen')
+    t.is(response.headers['X-Content-Type-Options'],'nosniff')
+    t.is(response.headers['Referrer-Policy'],'no-referrer')
+    t.is(response.headers['X-Permitted-Cross-Domain-Policies'],'none')
+
+    t.is(response.headers['X-Frame-Options'],undefined)
+    t.is(response.headers['X-XSS-Protection'],undefined)
   })

--- a/packages/http-security-headers/index.js
+++ b/packages/http-security-headers/index.js
@@ -121,11 +121,18 @@ helmetHtmlOnly.xssFilter = (headers, config) => {
   return headers
 }
 
+const normalizeResponse = (response) => {
+  return Array.isArray(response)
+    ? { body: response }
+    : response ??
+      { statusCode: 500 } // catch thrown errors, prevent default statusCode
+}
+
 module.exports = (opts = {}) => {
   const options = { ...defaults, ...opts }
 
   const httpSecurityHeadersMiddlewareAfter = async (handler) => {
-    handler.response = handler.response ?? { statusCode: 500 } // catch thrown errors, prevent default statusCode
+    handler.response = normalizeResponse(handler.response)
     handler.response.headers = handler.response?.headers ?? {}
 
     Object.keys(helmet).forEach(key => {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Add support for handlers returning arrays as responses. Typically, API Gateway response shape and serialization are handled by other middlewares down the chain. In its current form, `http-security-headers` restricts flexibility by expecting an object as `handler.response`, producing malformed responses if it's not.


Any other comments?
-------------------
- Unrelated to this PR, but I noticed that, sadly, all exported functions within `middy` are anonymous. I was really tempted to change the `module.exports` for `http-security-headers` to a proper named `function` - but didn't to keep changes to the point. I could start a new PR to address this issue for all `@middy/core` and `@middy/*` individual middlewares if there's any interest for it.
- Would be nice to have some sort of coding standard (besides a manual linter run). `middy` could greatly benefit from having an `eslint`, `prettier` and `.editorconfig` config files.
- The `"husky"` config is calling `git add` manually, which is no longer needed and raises a warning.

```sh
⚠ Some of your tasks use `git add` command. Please remove it from the config since all modifications made by tasks will be automatically added to the git commit index.
```

- The `test:packages:typings` script was failing for me, which causes `npm test` to also fail. Maybe I was doing something wrong or missing a step?

Where has this been tested?
---------------------------
**Node.js Versions:** v14.15.4

**Middy Versions:** Any version.

**AWS SDK Versions:** Not relevant.

Todo list
--------- 

- [x] Feature/Fix fully implemented
- [x] Added tests
- [ ] Updated relevant documentation 
- [ ] Updated relevant examples

> Did not notice any "relevant documentation" or "examples" with regards to this. If you point me to them, I'll be more than happy to amend them.
