### PR TITLE
Add allowMethods options to @middy/http-cors

### DIFF
--- a/packages/http-cors/README.md
+++ b/packages/http-cors/README.md
@@ -51,6 +51,7 @@ npm install --save @middy/http-cors
  - `credentials` (bool) (optional): if true, sets the `Access-Control-Allow-Origin` as request header `Origin`, if present (default `false`)
  - `maxAge` (string) (optional): value to put in Access-Control-Max-Age header (default: `null`)
  - `cacheControl` (string) (optional): value to put in Cache-Control header on pre-flight (OPTIONS) requests (default: `null`)
+- `allowMethods` (string) (optional): value to put in Access-Control-Allow-Methods header on pre-flight (OPTIONS) requests (default: `null`)
 
 NOTES:
 - If another middleware does not handle and swallow errors, then it will bubble all the way up 

--- a/packages/http-cors/__tests__/index.js
+++ b/packages/http-cors/__tests__/index.js
@@ -555,10 +555,10 @@ describe('📦 Middleware CORS', () => {
       cb(null, { headers: { 'Access-Control-Allow-Methods': 'POST' } })
     })
 
-    handler.use(cors({ maxAge: '3600' }))
+    handler.use(cors({ allowMethods: 'GET,PUT,POST' }))
 
     const event = {
-      allowMethods: 'GET,PUT,POST'
+      httpMethod: 'POST'
     }
 
     const response = await invoke(handler, event)

--- a/packages/http-cors/__tests__/index.js
+++ b/packages/http-cors/__tests__/index.js
@@ -529,4 +529,44 @@ describe('📦 Middleware CORS', () => {
       }
     })
   })
+
+  test('it should set Access-Control-Allow-Methods header if present in config', async () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, {})
+    })
+
+    handler.use(cors({ allowMethods: 'GET,PUT,POST' }))
+
+    const event = {
+      httpMethod: 'GET'
+    }
+
+    const response = await invoke(handler, event)
+    expect(response).toEqual({
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET,PUT,POST'
+      }
+    })
+  })
+
+  test('it should not overwrite Access-Control-Allow-Methods header if already set', async () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, { headers: { 'Access-Control-Allow-Methods': 'POST' } })
+    })
+
+    handler.use(cors({ maxAge: '3600' }))
+
+    const event = {
+      allowMethods: 'GET,PUT,POST'
+    }
+
+    const response = await invoke(handler, event)
+    expect(response).toEqual({
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'POST'
+      }
+    })
+  })
 })

--- a/packages/http-cors/index.d.ts
+++ b/packages/http-cors/index.d.ts
@@ -7,6 +7,7 @@ interface ICorsOptions {
   credentials?: boolean;
   maxAge?: string;
   cacheControl?: string;
+  allowMethods?: string;
 }
 
 declare const cors : middy.Middleware<ICorsOptions, any, any>

--- a/packages/http-cors/index.js
+++ b/packages/http-cors/index.js
@@ -20,7 +20,7 @@ const defaults = {
   credentials: false,
   maxAge: null,
   cacheControl: null,
-  allowMethods: null,
+  allowMethods: null
 }
 
 const addCorsHeaders = (opts, handler, next) => {

--- a/packages/http-cors/index.js
+++ b/packages/http-cors/index.js
@@ -19,7 +19,8 @@ const defaults = {
   headers: null,
   credentials: false,
   maxAge: null,
-  cacheControl: null
+  cacheControl: null,
+  allowMethods: null,
 }
 
 const addCorsHeaders = (opts, handler, next) => {
@@ -52,6 +53,10 @@ const addCorsHeaders = (opts, handler, next) => {
 
     if (options.maxAge && !Object.prototype.hasOwnProperty.call(handler.response.headers, 'Access-Control-Max-Age')) {
       handler.response.headers['Access-Control-Max-Age'] = String(options.maxAge)
+    }
+
+    if (options.allowMethods && !Object.prototype.hasOwnProperty.call(handler.response.headers, 'Access-Control-Max-Age')) {
+      handler.response.headers['Access-Control-Allow-Methods'] = String(options.allowMethods)
     }
 
     if (handler.event.httpMethod === 'OPTIONS') {

--- a/packages/http-cors/index.js
+++ b/packages/http-cors/index.js
@@ -55,7 +55,7 @@ const addCorsHeaders = (opts, handler, next) => {
       handler.response.headers['Access-Control-Max-Age'] = String(options.maxAge)
     }
 
-    if (options.allowMethods && !Object.prototype.hasOwnProperty.call(handler.response.headers, 'Access-Control-Max-Age')) {
+    if (options.allowMethods && !Object.prototype.hasOwnProperty.call(handler.response.headers, 'Access-Control-Allow-Methods')) {
       handler.response.headers['Access-Control-Allow-Methods'] = String(options.allowMethods)
     }
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR adds the option to set an `allowMethods` option that allows setting the `Access-Control-Allow-Methods` header in the preflight CORS requests.

Does this close any currently open issues?
------------------------------------------
There is an already closed issue #43 that asks for this. But it was never really solved.

Where has this been tested?
---------------------------
**Node.js Versions:** 12.18.3

**Middy Versions:** 1.5.2

**AWS SDK Versions:** 

Todo list
---------

[x] Feature/Fix fully implemented
[x] Added tests
[x] Updated relevant documentation
[x] Updated relevant examples
