### PR TITLE
fix: fix typing on core middy handler

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,7 @@ on:
       - "**"
     tags-ignore:
       - "*.*.*"
+  pull_request: {}
 
 jobs:
   tests:

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -35,7 +35,7 @@ interface MiddlewareObj<TEvent = any, TResult = any, TErr = Error> {
   onError?: MiddlewareFn<TEvent, TResult, TErr>
 }
 
-interface MiddyfiedHandler<TEvent = any, TResult = any, TErr = Error>  extends LambdaHandler<TEvent, TResult> {
+interface MiddyfiedHandler<TEvent = any, TResult = any, TErr = Error> {
   use: UseFn<TEvent, TResult, TErr>
   applyMiddleware: AttachMiddlewareObj<TEvent, TResult, TErr>
   before: AttachMiddlewareFn<TEvent, TResult, TErr>
@@ -46,6 +46,7 @@ interface MiddyfiedHandler<TEvent = any, TResult = any, TErr = Error>  extends L
     after: Array<MiddlewareFn<TEvent, TResult, TErr>>
     onError: Array<MiddlewareFn<TEvent, TResult, TErr>>
   }
+  (event: TEvent, context: LambdaContext): Promise<TResult>
 }
 
 declare type AttachMiddlewareFn<TEvent = any, TResult = any, TErr = Error> = (middleware: MiddlewareFn) => MiddyfiedHandler<TEvent, TResult, TErr>

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -35,7 +35,7 @@ interface MiddlewareObj<TEvent = any, TResult = any, TErr = Error> {
   onError?: MiddlewareFn<TEvent, TResult, TErr>
 }
 
-interface MiddyfiedHandler<TEvent = any, TResult = any, TErr = Error> {
+interface MiddyfiedHandler<TEvent = any, TResult = any, TErr = Error>  extends LambdaHandler<TEvent, TResult> {
   use: UseFn<TEvent, TResult, TErr>
   applyMiddleware: AttachMiddlewareObj<TEvent, TResult, TErr>
   before: AttachMiddlewareFn<TEvent, TResult, TErr>

--- a/packages/core/index.test-d.ts
+++ b/packages/core/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd'
 import middy from '.'
-import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda'
+import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda'
 
 async function baseHandler (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
   return {
@@ -37,6 +37,81 @@ handler = middy(baseHandler, {
   async requestEnd () { console.log('requestEnd') }
 })
 expectType<Handler>(handler)
+
+// invokes the handler to test that it is callable
+async function invokeHandler (): Promise<APIGatewayProxyResult> {
+  const sampleEvent: APIGatewayProxyEvent = {
+    resource: '/',
+    path: '/',
+    httpMethod: 'GET',
+    requestContext: {
+      resourcePath: '/',
+      httpMethod: 'GET',
+      path: '/Prod/',
+      accountId: 'x',
+      apiId: 'y',
+      authorizer: {},
+      protocol: 'p',
+      identity: {
+        accessKey: '',
+        accountId: '',
+        apiKey: '',
+        apiKeyId: '',
+        caller: '',
+        cognitoAuthenticationProvider: '',
+        cognitoAuthenticationType: '',
+        cognitoIdentityId: '',
+        cognitoIdentityPoolId: '',
+        principalOrgId: '',
+        sourceIp: '',
+        user: '',
+        userAgent: '',
+        userArn: ''
+      },
+      stage: '',
+      requestId: '',
+      requestTimeEpoch: 12345567,
+      resourceId: ''
+    },
+    headers: {
+      accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
+      'accept-encoding': 'gzip, deflate, br',
+      Host: '70ixmpl4fl.execute-api.us-east-2.amazonaws.com',
+      'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36',
+      'X-Amzn-Trace-Id': 'Root=1-5e66d96f-7491f09xmpl79d18acf3d050'
+    },
+    multiValueHeaders: {
+      accept: [
+        'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9'
+      ],
+      'accept-encoding': [
+        'gzip, deflate, br'
+      ]
+    },
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    pathParameters: null,
+    stageVariables: null,
+    body: null,
+    isBase64Encoded: false
+  }
+  const sampleContext: Context = {
+    callbackWaitsForEmptyEventLoop: true,
+    functionName: '',
+    functionVersion: '',
+    invokedFunctionArn: '',
+    memoryLimitInMB: '234',
+    awsRequestId: '',
+    logGroupName: '',
+    logStreamName: '',
+    getRemainingTimeInMillis: (): number => 1,
+    done: () => { },
+    fail: (_) => { },
+    succeed: () => { }
+  }
+  return await handler(sampleEvent, sampleContext)
+}
+invokeHandler().catch(console.error)
 
 const middlewareObj = {
   before: (request: Request) => {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
With current Typescript definition it is not possible to locally execute the handler function, either from a local file to debug, or from unit tests, without getting a Typescript error:
```
This expression is not callable.
  Type 'MiddyfiedHandler<APIGatewayProxyEvent, APIGatewayProxyResult, Error>' has no call signatures.
```
I believe the issue is that the Typescript definition of the `MiddyfiedHandler` does not extend the Lambda Handler so is not a callable function.

Fix is to add `LambdaHandler` to the `MiddyfiedHandler` interface definition. 

Does this close any currently open issues?
------------------------------------------
closes #628 

Any relevant logs, error output, etc?
-------------------------------------


Any other comments?
-------------------
Looking for someone else to validate this fix. Since it is only typing, it does not affect core functionality. 


Where has this been tested?
---------------------------
**Node.js Versions:** v14.15.5

**Middy Versions:** 2.0.0.beta.0

**AWS SDK Versions:** v2/v3

Todo list
---------

[ ] Feature/Fix fully implemented
[ ] Added tests
[ ] Updated relevant documentation
[ ] Updated relevant examples
