### PR TITLE
add: http-multipart-body-parser parse single keys with multiple files

### DIFF
--- a/packages/http-multipart-body-parser/__tests__/index.js
+++ b/packages/http-multipart-body-parser/__tests__/index.js
@@ -184,4 +184,27 @@ describe('📦  Middleware Multipart Form Data Body Parser', () => {
     expect(Object.keys(response)).toContain('foo')
     expect(response.foo.length).toEqual(2)
   })
+
+  test('It should parse a field with multiple files succesfullly', async () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, event.body) // propagates the body as a response
+    })
+
+    handler.use(httpMultipartBodyParser())
+
+    const event = {
+      headers: {
+        'content-type': 'multipart/form-data; boundary=---------------------------237588144631607450464127370583'
+      },
+      body: 'LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0yMzc1ODgxNDQ2MzE2MDc0NTA0NjQxMjczNzA1ODMNCkNvbnRlbnQtRGlzcG9zaXRpb246IGZvcm0tZGF0YTsgbmFtZT0iZmlsZXMiOyBmaWxlbmFtZT0idDIudHh0Ig0KQ29udGVudC1UeXBlOiB0ZXh0L3BsYWluDQoNCg0KLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0yMzc1ODgxNDQ2MzE2MDc0NTA0NjQxMjczNzA1ODMNCkNvbnRlbnQtRGlzcG9zaXRpb246IGZvcm0tZGF0YTsgbmFtZT0iZmlsZXMiOyBmaWxlbmFtZT0idDEudHh0Ig0KQ29udGVudC1UeXBlOiB0ZXh0L3BsYWluDQoNCg0KLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0yMzc1ODgxNDQ2MzE2MDc0NTA0NjQxMjczNzA1ODMNCkNvbnRlbnQtRGlzcG9zaXRpb246IGZvcm0tZGF0YTsgbmFtZT0iZmlsZXMiOyBmaWxlbmFtZT0idDMudHh0Ig0KQ29udGVudC1UeXBlOiB0ZXh0L3BsYWluDQoNCg0KLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0yMzc1ODgxNDQ2MzE2MDc0NTA0NjQxMjczNzA1ODMtLQ0K',
+      isBase64Encoded: true
+    }
+    const response = await invoke(handler, event)
+    // response:
+    // {
+    //   files: [ {filename: 't1.txt'}, {filename: 't2.txt'}, {filename: 't3.txt'} ]   -- and other properties inside each object
+    // }
+    expect(Object.keys(response)).toContain('files')
+    expect(response.files.length).toEqual(3)
+  })
 })

--- a/packages/http-multipart-body-parser/index.js
+++ b/packages/http-multipart-body-parser/index.js
@@ -57,7 +57,12 @@ const parseMultipartData = (event, options) => {
         file.on('end', () => {
           attachment.truncated = file.truncated
           attachment.content = Buffer.concat(chunks)
-          multipartData[fieldname] = attachment
+          if (!multipartData[fieldname]) {
+            multipartData[fieldname] = attachment
+          } else {
+            const current = multipartData[fieldname]
+            multipartData[fieldname] = [attachment].concat(current)
+          }
         })
       })
       .on('field', (fieldname, value) => {


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
Single key with multiple file parser, but the key is not annotated with array:
Pseudo code for the request on client site:
```js
const formData = new FormData()
  fileList.forEach((file) => {
    formData.append('files', file)   // no [] here
  })
  
reqwest({
  url: 'http://localhost:3000/upload',
  method: 'post',
  data: formData,
  // others
}
```

Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
Currently, if the request similar to what I described above, it would take only the last file.
If there's only single file per key, it is still an object, not an array to keep things, so fully compatible

Where has this been tested?
---------------------------
**Node.js Versions:**

**Middy Versions:**

**AWS SDK Versions:** …

Todo list
---------

[ ] Feature/Fix fully implemented
[ ] Added tests
[ ] Updated relevant documentation
[ ] Updated relevant examples
