### PR TITLE
docs: fix typos and clarify example

### DIFF
--- a/packages/secrets-manager/README.md
+++ b/packages/secrets-manager/README.md
@@ -71,17 +71,21 @@ const handler = middy((event, context) => {
   return {}
 })
 
- handler.use(secretsManager({
-   fetchData: {
+handler.use(secretsManager({
+  fetchData: {
     apiToken: 'dev/api_token'
-  }
+  },
+  awsClientOptions: {
+    region: 'us-east-1',
+  },
+  setToContext: true,
 }))
 
 // Before running the function handler, the middleware will fetch from Secrets Manager
 handler(event, context, (_, response) => {
-  // assuming the dev/rds_login has two keys, 'Username' and 'Password'
-  t.is(context.RDS_LOGIN.Username,'username')
-  t.is(context.RDS_LOGIN.Password,'password')
+  // assuming the dev/api_token has two keys, 'Username' and 'Password'
+  t.is(context.apiToken.Username,'username')
+  t.is(context.apiToken.Password,'password')
 })
 ```
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes and clarifies Secrets Manager middleware example. The names of the secrets and the resulting context were incorrect and causing confusion. Also added missing parameters to the middleware to clarify its usage.

Todo list
---------

- [x] Feature/Fix fully implemented
- [ ] Added tests
- [x] Updated relevant documentation
- [x] Updated relevant examples
