### PR TITLE
Fix: Response Serializer does not replace entire object when falsey value is returned

### DIFF
--- a/packages/http-response-serializer/README.md
+++ b/packages/http-response-serializer/README.md
@@ -72,7 +72,7 @@ The function is passed the entire `response` object, and should return either a 
 
 If a string is returned, the `body` attribute of the response is updated.
 
-If an object is returned, the entire response object is replaced. This is useful if you want to manipulate headers or add additional attributes in the Lambda response.
+If an object with a `body` attribute is returned, the entire response object is replaced. This is useful if you want to manipulate headers or add additional attributes in the Lambda response.
 
 
 ## Content Type Negotiation

--- a/packages/http-response-serializer/__tests__/index.js
+++ b/packages/http-response-serializer/__tests__/index.js
@@ -234,7 +234,7 @@ test('It should not pass-through when request content-type is set', async (t) =>
   })
 })
 
-test('It should replace the response object when the serializer returns an object', async (t) => {
+test('It should replace the response object when the serializer returns an object with a "body" attribute', async (t) => {
   const handler = middy((event, context) => createHttpResponse())
 
   handler.use(
@@ -242,12 +242,11 @@ test('It should replace the response object when the serializer returns an objec
       serializers: [
         {
           regex: /^text\/plain$/,
-          serializer: (response) => {
-            Object.assign(response, {
-              isBase64Encoded: true
+          serializer: (response) =>
+            Object.assign({}, response, {
+              statusCode: 204,
+              body: null
             })
-            return Buffer.from(response.body).toString('base64')
-          }
         }
       ],
       default: 'text/plain'
@@ -257,12 +256,11 @@ test('It should replace the response object when the serializer returns an objec
   const response = await handler()
 
   t.deepEqual(response, {
-    statusCode: 200,
+    statusCode: 204,
     headers: {
       'Content-Type': 'text/plain'
     },
-    body: 'SGVsbG8gV29ybGQ=',
-    isBase64Encoded: true
+    body: null
   })
 })
 

--- a/packages/http-response-serializer/index.js
+++ b/packages/http-response-serializer/index.js
@@ -43,7 +43,7 @@ const httpResponseSerializerMiddleware = (opts = {}) => {
 
         request.response.headers['Content-Type'] = type
         const result = s.serializer(request.response)
-        if (result?.body) {
+        if (typeof result === 'object' && 'body' in result) {
           request.response = result
         } else {
           // otherwise only replace the body attribute


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
In an attempt to address #657, `body` was checked to determined wether or not the entire response should be replaced (by @willfarrell).  
The problem with that fix is that any falsy value in `body` would not replace the entire response as well (think `false`, 0, or even `null` or `undefined` body).  

Does this close any currently open issues?
------------------------------------------
Resolves #657 


Any relevant logs, error output, etc?
-------------------------------------
x

Any other comments?
-------------------
x

Where has this been tested?
---------------------------
**Node.js Versions:** 14

**Middy Versions:** 2.1.0


Todo list
---------

- [x] Feature/Fix fully implemented
- [x] Added tests
- [x] Updated relevant documentation
- [x] Updated relevant examples
