### PR TITLE
Export middy interfaces directly

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -29,13 +29,13 @@ interface Request<TEvent = any, TResult = any, TErr = Error> {
 
 declare type MiddlewareFn<TEvent = any, TResult = any, TErr = Error> = (request: Request<TEvent, TResult, TErr>) => any
 
-interface MiddlewareObj<TEvent = any, TResult = any, TErr = Error> {
+export interface MiddlewareObj<TEvent = any, TResult = any, TErr = Error> {
   before?: MiddlewareFn<TEvent, TResult, TErr>
   after?: MiddlewareFn<TEvent, TResult, TErr>
   onError?: MiddlewareFn<TEvent, TResult, TErr>
 }
 
-interface MiddyfiedHandler<TEvent = any, TResult = any, TErr = Error> {
+export interface MiddyfiedHandler<TEvent = any, TResult = any, TErr = Error> {
   use: UseFn<TEvent, TResult, TErr>
   applyMiddleware: AttachMiddlewareObj<TEvent, TResult, TErr>
   before: AttachMiddlewareFn<TEvent, TResult, TErr>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Exporting the interfaces directly gives the users of the middy package the flexibility to choose how they would like to import.

Does this close any currently open issues?
------------------------------------------
fixes #645

Does not impact any functional behaviour of middy
