### PR TITLE
fix: :bug: Fixing an integration test issue

### DIFF
--- a/packages/validator/index.js
+++ b/packages/validator/index.js
@@ -77,6 +77,8 @@ const compile = (schema, ajvOptions, ajvInstance = null) => {
     ajv = ajvInstance ?? new Ajv(options)
     formats(ajv)
     formatsDraft2019(ajv)
+  } else {
+    ajv.opts = {...ajv.opts, ...options};
   }
   return ajv.compile(schema)
 }


### PR DESCRIPTION
Fixing an integration test issue when multiple lambda handlers are invoked in a single run. 

What does this implement/fix? Explain your changes.
---------------------------------------------------
`ajvOptions` of subsequent lambda handlers for the validator are ignored if the `ajv` object is compiled already. This is a simple fix to force the `ajvOptions` to be overwritten.

Does this close any currently open issues?
------------------------------------------
I don't know

Any relevant logs, error output, etc?
-------------------------------------
Here is a link to the git repo to illustrate the issue:
https://github.com/qualipsolutions/middy-test

Clone the repo, then:
1. `yarn`
2. `yarn server`

`app.js` imports two lambda functions. The first lambda import causes the `ajv` to be compiled and when the second lambda is imported, the `ajvOptions` are ignored and the validation passes instead of failing.

The schema is expecting `userNames` to be an `array` but the validation is passing when the value is set to `John`.

Where has this been tested?
---------------------------
**Node.js Versions:** …
v14.16.1

**Middy Versions:** …
2.2.0

**AWS SDK Versions:** …
2.892.0

