### PR TITLE
Custom serlializer for response body for http-error-handler

### DIFF
--- a/packages/http-error-handler/index.js
+++ b/packages/http-error-handler/index.js
@@ -33,7 +33,7 @@ const httpErrorHandlerMiddleware = (opts = {}) => {
     if (request.error?.expose) {
       request.response = normalizeHttpResponse(request.response)
       request.response.statusCode = request.error?.statusCode
-      request.response.body = request.error?.message
+      request.response.body = typeof options.serializer === "function" ? options.serializer(request.error) : request.error?.message
       request.response.headers['Content-Type'] =
         typeof jsonSafeParse(request.response.body) === 'string'
           ? 'plain/text'


### PR DESCRIPTION
I want to throw errors in my code like this:

```javascript
throw createHttpError(StatusCodes.BAD_REQUEST, "Validation error", { errors: validation.errors });
```

In my logs I want `BadRequest: Validation error`

but in my api response I want:

```JSON
{
  "message": "Validation error",
  "errors": [{ ... }]
}
```

Unfortunately I can only achieve either of the two, but not both with the current implementation of http-error-handler, because the current implementation uses the `error.message` as the response body.

(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
…

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Node.js Versions:** …

**Middy Versions:** …

**AWS SDK Versions:** …

Todo list
---------

[ ] Feature/Fix fully implemented
[ ] Added tests
[ ] Updated relevant documentation
[ ] Updated relevant examples
