### PR TITLE
fix(core): moving unhandled error throw

### DIFF
--- a/packages/core/__tests__/index.js
+++ b/packages/core/__tests__/index.js
@@ -572,10 +572,7 @@ test('It should be able to short circuit a before middleware', async (t) => {
 
 test('It should run mutiple times', async (t) => {
   const before = sinon.spy(() => {})
-  const handler = middy(() => {
-    return { foo: 'bar' }
-  })
-  .before(before)
+  const handler = middy().before(before)
   await handler()
   await handler()
   t.is(before.callCount, 2)
@@ -629,6 +626,7 @@ test('It will stop invoking all the onError handlers if one of them returns a pr
   }
 })
 
+
 // https://github.com/middyjs/middy/pull/687
 test('It should throw unhandled exceptions without wrapping', async (t) => {
   const e =  new Error('something bad happened');
@@ -657,9 +655,7 @@ test('Should trigger all plugin hooks', async (t) => {
     requestEnd: sinon.spy()
   }
   const beforeMiddleware = sinon.spy()
-  const baseHandler = middy((event, context) => {
-    return { foo: 'bar' }
-  })
+  const baseHandler = sinon.spy()
   const afterMiddleware = sinon.spy()
 
   const handler = middy(baseHandler, plugin)

--- a/packages/core/__tests__/index.js
+++ b/packages/core/__tests__/index.js
@@ -642,6 +642,24 @@ test('It should throw unhandled exceptions without wrapping', async (t) => {
   }
 })
 
+test('It should throw the error set by middleware if not handled', async (t) => {
+  const updatedError = new Error('something bad happened')
+  const handler = middy((event, context) => {
+    throw new Error('original error')
+  }).use({
+    onError: (request) => {
+     request.error = updatedError;
+    }
+  }
+)
+
+  try {
+    await handler()
+  } catch (err) {
+    t.is(updatedError, err)
+  }
+})
+
 // Plugin
 test('Should trigger all plugin hooks', async (t) => {
   const plugin = {

--- a/packages/core/__tests__/index.js
+++ b/packages/core/__tests__/index.js
@@ -648,10 +648,10 @@ test('It should throw the error set by middleware if not handled', async (t) => 
     throw new Error('original error')
   }).use({
     onError: (request) => {
-     request.error = updatedError;
+      request.error = updatedError
     }
   }
-)
+  )
 
   try {
     await handler()

--- a/packages/core/__tests__/index.js
+++ b/packages/core/__tests__/index.js
@@ -626,20 +626,19 @@ test('It will stop invoking all the onError handlers if one of them returns a pr
   }
 })
 
-
 // https://github.com/middyjs/middy/pull/687
 test('It should throw unhandled exceptions without wrapping', async (t) => {
-  const e =  new Error('something bad happened');
+  const e = new Error('something bad happened')
   const handler = middy((event, context) => {
-    throw e;
+    throw e
   })
 
   try {
     await handler()
   } catch (err) {
-     // Can we stringify
-     JSON.stringify(err)
-    t.is(e, err)   
+    // Can we stringify
+    JSON.stringify(err)
+    t.is(e, err)
   }
 })
 

--- a/packages/core/__tests__/index.js
+++ b/packages/core/__tests__/index.js
@@ -639,9 +639,9 @@ test('It should throw unhandled exceptions without wrapping', async (t) => {
   try {
     await handler()
   } catch (err) {
-    t.is(e, err)
-    // Can we stringify
-    JSON.stringify(err)
+     // Can we stringify
+     JSON.stringify(err)
+    t.is(e, err)   
   }
 })
 

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -104,7 +104,7 @@ const runRequest = async (
       throw request.error
     }
     // Catch if onError stack hasn't handled the error
-    if (request.response === undefined) throw request.error || e
+    if (request.response === undefined) throw request.error
   } finally {
     await plugin?.requestEnd?.()
   }

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -104,7 +104,7 @@ const runRequest = async (
       throw request.error
     }
     // Catch if onError stack hasn't handled the error
-    if (request.error && request.response === undefined) throw request.error
+    if (request.response === undefined) throw request.error || e
   } finally {
     await plugin?.requestEnd?.()
   }

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -103,11 +103,12 @@ const runRequest = async (
 
       throw request.error
     }
+    // Catch if onError stack hasn't handled the error
+    if (request.error && request.response === undefined) throw request.error
   } finally {
     await plugin?.requestEnd?.()
   }
-  // Catch if onError stack hasn't handled the error
-  if (request.error && request.response === undefined) throw request.error
+
   return request.response
 }
 

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -96,8 +96,6 @@ const runRequest = async (
     request.error = e
     try {
       await runMiddlewares(request, onErrorMiddlewares, plugin)
-      // Catch if onError stack hasn't handled the error
-      if (request.response === undefined) throw request.error
     } catch (e) {
       // Save error that wasn't handled
       e.originalError = request.error
@@ -107,6 +105,8 @@ const runRequest = async (
   } finally {
     await plugin?.requestEnd?.()
   }
+  // Catch if onError stack hasn't handled the error
+  if (request.response === undefined) throw request.error
   return request.response
 }
 

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -100,6 +100,7 @@ const runRequest = async (
       // Save error that wasn't handled
       e.originalError = request.error
       request.error = e
+
       throw request.error
     }
   } finally {

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -107,7 +107,7 @@ const runRequest = async (
     await plugin?.requestEnd?.()
   }
   // Catch if onError stack hasn't handled the error
-  if (request.response === undefined) throw request.error
+  if (request.error && request.response === undefined) throw request.error
   return request.response
 }
 


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------

When an error was unhandled by the error middleware, it was being re-thrown and added to itself. 
This was causing issues with downstream testing libraries which JSON.stringify the error and blow up as it's a circular dep.
Polluting logging having duplicate errors inside itself.

Does this close any currently open issues?
------------------------------------------
No




Where has this been tested?
---------------------------

CI/CD

Todo list
---------

[x] Feature/Fix fully implemented
[TODO ] Added tests

