### PR TITLE
Update http-cors `credentials` documentation.

### DIFF
--- a/packages/http-cors/README.md
+++ b/packages/http-cors/README.md
@@ -41,7 +41,7 @@ npm install --save @middy/http-cors
 
 ## Options
 
- - `credentials` (bool) (optional): if true, sets the `Access-Control-Allow-Origin` as request header `Origin`, if present (default `false`)
+ - `credentials` (bool) (optional): if true, sets `Access-Control-Allow-Credentials` (default `false`)
  - `headers` (string) (optional): value to put in `Access-Control-Allow-Headers` (default: `false`)
  - `methods` (string) (optional): value to put in `Access-Control-Allow-Mehtods` (default: `false`)
  - `getOrigin` (function(incomingOrigin:string, options)) (optional): take full control of the generating the returned origin. Defaults to using the origin or origins option.


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Updates documentation for the @middy/http-cors `credentials` option.

Does this close any currently open issues?
------------------------------------------
No.


Any relevant logs, error output, etc?
-------------------------------------


Any other comments?
-------------------
I'm not sure about the original documentation. The `getOrigin` function also [does something](https://github.com/middyjs/middy/blob/main/packages/http-cors/index.js#L11) with `options.credentials` but I feel like the information that the `Acess-Control-Allow-Credentials` is also being set with this is certainly missing. I am happy to rephrase the line to also talk about the change to `Origin` if required.

Where has this been tested?
---------------------------
*Just a documetation change*

Todo list
---------

[ ] Feature/Fix fully implemented
[ ] Added tests
[ ] Updated relevant documentation
[ ] Updated relevant examples
