### PR TITLE
types(input-output-logger): support awsContext

### DIFF
--- a/packages/input-output-logger/index.d.ts
+++ b/packages/input-output-logger/index.d.ts
@@ -2,6 +2,7 @@ import middy from '@middy/core'
 
 interface Options {
   logger?: (message: any) => void
+  awsContext?: boolean
   omitPaths?: string[]
 }
 

--- a/packages/input-output-logger/index.test-d.ts
+++ b/packages/input-output-logger/index.test-d.ts
@@ -9,6 +9,7 @@ expectType<middy.MiddlewareObj>(middleware)
 // use with all options
 middleware = inputOutputLogger({
   logger: console.log,
+  awsContext: true,
   omitPaths: ['a', 'b', 'c']
 })
 expectType<middy.MiddlewareObj>(middleware)


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
It fix `index.d.ts` of `@middy/input-output-logger` to support `awsContext`.

Does this close any currently open issues?
------------------------------------------
No.


Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------
N/A

Where has this been tested?
---------------------------
**Node.js Versions:** 16.2.0

**Middy Versions:** 2.4.2

**AWS SDK Versions:** …

Todo list
---------

- [x] Feature/Fix fully implemented
- [x] Added tests
- [x] Updated relevant documentation
- [x] Updated relevant examples
