### PR TITLE
docs: update middy SSM description on assigning to process.env

### DIFF
--- a/packages/ssm/README.md
+++ b/packages/ssm/README.md
@@ -29,7 +29,7 @@ This middleware fetches parameters from [AWS Systems Manager Parameter Store](ht
 
 Parameters to fetch can be defined by path and by name (not mutually exclusive). See AWS docs [here](https://aws.amazon.com/blogs/mt/organize-parameters-by-hierarchy-tags-or-amazon-cloudwatch-events-with-amazon-ec2-systems-manager-parameter-store/).
 
-By default parameters are assigned to the Node.js `process.env` object. They can instead be assigned to the function handler's `context` object by setting the `setToContext` flag to `true`. By default all parameters are added with uppercase names.
+Parameters can be assigned to the Node.js `process.env` object by setting the `setToEnv` flag to `true`. They can also be assigned to the function handler's `context` object by setting the `setToContext` flag to `true`. By default all parameters are added with uppercase names.
 
 The Middleware makes a single API request to fetch all the parameters defined by name, but must make an additional request per specified path. This is because the AWS SDK currently doesn't expose a method to retrieve parameters from multiple paths.
 


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR updates the Middy SSM README description on assigning to process.env. According to the options section, `setToEnv` is default `false`. So it's misleading to say that params are assigned Process.env by default.

Does this close any currently open issues?
------------------------------------------
I don't think so.


Any relevant logs, error output, etc?
-------------------------------------

N.A. 

Any other comments?
-------------------

N.A. 

Where has this been tested?
---------------------------
**Node.js Versions:** N.A. 

**Middy Versions:** N.A. 

**AWS SDK Versions:** N.A. 

Todo list
---------

[ ] Feature/Fix fully implemented
[ ] Added tests
[x] Updated relevant documentation
[ ] Updated relevant examples
