### PR TITLE
Typescript: Typed Context

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -17,9 +17,9 @@ interface PluginObject {
   requestEnd?: PluginHookPromise
 }
 
-interface Request<TEvent = any, TResult = any, TErr = Error> {
+interface Request<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> {
   event: TEvent
-  context: LambdaContext
+  context: TContext
   response: TResult | null
   error: TErr | null
   internal: {
@@ -27,41 +27,43 @@ interface Request<TEvent = any, TResult = any, TErr = Error> {
   }
 }
 
-declare type MiddlewareFn<TEvent = any, TResult = any, TErr = Error> = (request: Request<TEvent, TResult, TErr>) => any
+declare type MiddlewareFn<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = any> = (request: Request<TEvent, TResult, TErr, TContext>) => any
 
-export interface MiddlewareObj<TEvent = any, TResult = any, TErr = Error> {
-  before?: MiddlewareFn<TEvent, TResult, TErr>
-  after?: MiddlewareFn<TEvent, TResult, TErr>
+export interface MiddlewareObj<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = any> {
+  before?: MiddlewareFn<TEvent, TResult, TErr, TContext>
+  after?: MiddlewareFn<TEvent, TResult, TErr, TContext>
   onError?: MiddlewareFn<TEvent, TResult, TErr>
 }
 
-export interface MiddyfiedHandler<TEvent = any, TResult = any, TErr = Error> {
-  use: UseFn<TEvent, TResult, TErr>
-  applyMiddleware: AttachMiddlewareObj<TEvent, TResult, TErr>
-  before: AttachMiddlewareFn<TEvent, TResult, TErr>
-  after: AttachMiddlewareFn<TEvent, TResult, TErr>
-  onError: AttachMiddlewareFn<TEvent, TResult, TErr>
+export interface MiddyfiedHandler<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = any> {
+  use: UseFn<TEvent, TResult, TErr, TContext>
+  applyMiddleware: AttachMiddlewareObj<TEvent, TResult, TErr, TContext>
+  before: AttachMiddlewareFn<TEvent, TResult, TErr, TContext>
+  after: AttachMiddlewareFn<TEvent, TResult, TErr, TContext>
+  onError: AttachMiddlewareFn<TEvent, TResult, TErr, TContext>
   __middlewares: {
-    before: Array<MiddlewareFn<TEvent, TResult, TErr>>
-    after: Array<MiddlewareFn<TEvent, TResult, TErr>>
-    onError: Array<MiddlewareFn<TEvent, TResult, TErr>>
+    before: Array<MiddlewareFn<TEvent, TResult, TErr, TContext>>
+    after: Array<MiddlewareFn<TEvent, TResult, TErr, TContext>>
+    onError: Array<MiddlewareFn<TEvent, TResult, TErr, TContext>>
   }
-  (event: TEvent, context: LambdaContext): Promise<TResult>
+  (event: TEvent, context: TContext): Promise<TResult>
 }
 
-declare type AttachMiddlewareFn<TEvent = any, TResult = any, TErr = Error> = (middleware: MiddlewareFn) => MiddyfiedHandler<TEvent, TResult, TErr>
+declare type AttachMiddlewareFn<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> = (middleware: MiddlewareFn) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
 
-declare type AttachMiddlewareObj<TEvent = any, TResult = any, TErr = Error> = (middleware: MiddlewareObj) => MiddyfiedHandler<TEvent, TResult, TErr>
+declare type AttachMiddlewareObj<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> = (middleware: MiddlewareObj) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
 
-declare type UseFn<TEvent = any, TResult = any, TErr = Error> =
-  (middlewares: MiddlewareObj<TEvent, TResult, TErr> | Array<MiddlewareObj<TEvent, TResult, TErr>>) => MiddyfiedHandler<TEvent, TResult, TErr>
+declare type UseFn<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> =
+  (middlewares: MiddlewareObj<TEvent, TResult, TErr, TContext> | Array<MiddlewareObj<TEvent, TResult, TErr, TContext>>) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
 
 /**
  * Middy factory function. Use it to wrap your existing handler to enable middlewares on it.
  * @param handler your original AWS Lambda function
  * @param plugin wraps around each middleware and handler to add custom lifecycle behaviours (e.g. to profile performance)
+ *
+ * NOTE: LambdaHandler<TEvent, TResult, TContext> depends on update to @types/aws-lambda
  */
-declare function middy<TEvent = any, TResult = any, TErr = Error> (handler?: LambdaHandler<TEvent, TResult>, plugin?: PluginObject): MiddyfiedHandler<TEvent, TResult, TErr>
+declare function middy<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = any> (handler?: LambdaHandler<TEvent, TResult, TContext>, plugin?: PluginObject): MiddyfiedHandler<TEvent, TResult, TErr, TContext>
 
 declare namespace middy {
   export {

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -35,7 +35,9 @@ export interface MiddlewareObj<TEvent = any, TResult = any, TErr = Error, TConte
   onError?: MiddlewareFn<TEvent, TResult, TErr>
 }
 
-export interface MiddyfiedHandler<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = any> {
+type MiddyInputHandler<TEvent, TResult, TContext extends LambdaContext> = (event: TEvent, context: TContext) => Promise<TResult> | void;
+
+export interface MiddyfiedHandler<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = any> extends MiddyInputHandler<TEvent, TResult, TContext> {
   use: UseFn<TEvent, TResult, TErr, TContext>
   applyMiddleware: AttachMiddlewareObj<TEvent, TResult, TErr, TContext>
   before: AttachMiddlewareFn<TEvent, TResult, TErr, TContext>

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -35,7 +35,7 @@ export interface MiddlewareObj<TEvent = any, TResult = any, TErr = Error, TConte
   onError?: MiddlewareFn<TEvent, TResult, TErr>
 }
 
-type MiddyInputHandler<TEvent, TResult, TContext> = (event: TEvent, context: TContext) => Promise<TResult> | void;
+type MiddyInputHandler<TEvent, TResult, TContext> = (event: TEvent, context: TContext) => Promise<TResult>
 
 export interface MiddyfiedHandler<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = any> extends MiddyInputHandler<TEvent, TResult, TContext> {
   use: UseFn<TEvent, TResult, TErr, TContext>
@@ -61,14 +61,14 @@ declare type UseFn<TEvent = any, TResult = any, TErr = Error, TContext extends L
 declare type MiddlewareHandler<THandler extends LambdaHandler<any, any>, TContext> =
   THandler extends LambdaHandler<infer TEvent, infer TResult> // always true
     ? (event: TEvent, context: TContext) => Promise<TResult>
-    : never;
+    : never
 
 /**
  * Middy factory function. Use it to wrap your existing handler to enable middlewares on it.
  * @param handler your original AWS Lambda function
  * @param plugin wraps around each middleware and handler to add custom lifecycle behaviours (e.g. to profile performance)
  */
-declare function middy<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = any> (handler?: MiddlewareHandler<LambdaHandler<TEvent,TResult>, TContext>, plugin?: PluginObject): MiddyfiedHandler<TEvent, TResult, TErr, TContext>
+declare function middy<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = any> (handler?: MiddlewareHandler<LambdaHandler<TEvent, TResult>, TContext>, plugin?: PluginObject): MiddyfiedHandler<TEvent, TResult, TErr, TContext>
 
 declare namespace middy {
   export {

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -17,7 +17,7 @@ interface PluginObject {
   requestEnd?: PluginHookPromise
 }
 
-interface Request<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> {
+interface Request<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = any> {
   event: TEvent
   context: TContext
   response: TResult | null
@@ -35,7 +35,7 @@ export interface MiddlewareObj<TEvent = any, TResult = any, TErr = Error, TConte
   onError?: MiddlewareFn<TEvent, TResult, TErr>
 }
 
-type MiddyInputHandler<TEvent, TResult, TContext extends LambdaContext> = (event: TEvent, context: TContext) => Promise<TResult> | void;
+type MiddyInputHandler<TEvent, TResult, TContext> = (event: TEvent, context: TContext) => Promise<TResult> | void;
 
 export interface MiddyfiedHandler<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = any> extends MiddyInputHandler<TEvent, TResult, TContext> {
   use: UseFn<TEvent, TResult, TErr, TContext>
@@ -51,19 +51,24 @@ export interface MiddyfiedHandler<TEvent = any, TResult = any, TErr = Error, TCo
   (event: TEvent, context: TContext): Promise<TResult>
 }
 
-declare type AttachMiddlewareFn<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> = (middleware: MiddlewareFn) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
+declare type AttachMiddlewareFn<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = any> = (middleware: MiddlewareFn) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
 
-declare type AttachMiddlewareObj<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> = (middleware: MiddlewareObj) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
+declare type AttachMiddlewareObj<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = any> = (middleware: MiddlewareObj) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
 
-declare type UseFn<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> =
+declare type UseFn<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = any> =
   (middlewares: MiddlewareObj<TEvent, TResult, TErr, TContext> | Array<MiddlewareObj<TEvent, TResult, TErr, TContext>>) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
+
+declare type MiddlewareHandler<THandler extends LambdaHandler<any, any>, TContext> =
+  THandler extends LambdaHandler<infer TEvent, infer TResult> // always true
+    ? (event: TEvent, context: TContext) => Promise<TResult>
+    : never;
 
 /**
  * Middy factory function. Use it to wrap your existing handler to enable middlewares on it.
  * @param handler your original AWS Lambda function
  * @param plugin wraps around each middleware and handler to add custom lifecycle behaviours (e.g. to profile performance)
  */
-declare function middy<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = any> (handler?: LambdaHandler<TEvent, TResult, TContext>, plugin?: PluginObject): MiddyfiedHandler<TEvent, TResult, TErr, TContext>
+declare function middy<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = any> (handler?: MiddlewareHandler<LambdaHandler<TEvent,TResult>, TContext>, plugin?: PluginObject): MiddyfiedHandler<TEvent, TResult, TErr, TContext>
 
 declare namespace middy {
   export {

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -62,8 +62,6 @@ declare type UseFn<TEvent = any, TResult = any, TErr = Error, TContext extends L
  * Middy factory function. Use it to wrap your existing handler to enable middlewares on it.
  * @param handler your original AWS Lambda function
  * @param plugin wraps around each middleware and handler to add custom lifecycle behaviours (e.g. to profile performance)
- *
- * NOTE: LambdaHandler<TEvent, TResult, TContext> depends on update to @types/aws-lambda
  */
 declare function middy<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = any> (handler?: LambdaHandler<TEvent, TResult, TContext>, plugin?: PluginObject): MiddyfiedHandler<TEvent, TResult, TErr, TContext>
 

--- a/packages/core/index.test-d.ts
+++ b/packages/core/index.test-d.ts
@@ -176,14 +176,17 @@ handler = middy(mutableContextDependantHandler)
 const mutableContextMiddleware = {
   before: (request: MutableContextRequest) => {
     request.context.name = 'Foo'
-  },
-  after: (request: MutableContextRequest) => {
-    request.context.name = 'Baz'
-  },
-  onError: (request: MutableContextRequest) => {
-    request.context.name = 'Bar'
-  },
+  }
 }
 
 handler = handler.use(mutableContextMiddleware)
 expectType<MutableContextHandler>(handler)
+
+const typeErrorMiddleware = {
+  before: (request: MutableContextRequest) => {
+    // @ts-expect-error
+    request.context.test = 'Bar'
+  }
+}
+
+handler = handler.use(typeErrorMiddleware)

--- a/packages/core/index.test-d.ts
+++ b/packages/core/index.test-d.ts
@@ -161,7 +161,7 @@ interface MutableContext extends Context {
   name: string
 }
 
-type MutableContextHandler = middy.MiddyfiedHandler<APIGatewayProxyEvent, APIGatewayProxyResult, Error>
+type MutableContextHandler = middy.MiddyfiedHandler<APIGatewayProxyEvent, APIGatewayProxyResult, Error, MutableContext>
 type MutableContextRequest = middy.Request<APIGatewayProxyEvent, APIGatewayProxyResult, Error, MutableContext>
 
 async function mutableContextDependantHandler (event: APIGatewayProxyEvent, context: MutableContext): Promise<APIGatewayProxyResult> {
@@ -171,7 +171,10 @@ async function mutableContextDependantHandler (event: APIGatewayProxyEvent, cont
   }
 }
 
-handler = middy(mutableContextDependantHandler)
+// @ts-expect-error
+handler = middy<APIGatewayProxyEvent, APIGatewayProxyResult, Error, Context>(mutableContextDependantHandler)
+
+handler = middy<APIGatewayProxyEvent, APIGatewayProxyResult, Error, MutableContext>(mutableContextDependantHandler)
 
 const mutableContextMiddleware = {
   before: (request: MutableContextRequest) => {
@@ -180,7 +183,7 @@ const mutableContextMiddleware = {
 }
 
 handler = handler.use(mutableContextMiddleware)
-expectType<MutableContextHandler>(handler)
+expectType<Handler>(handler)
 
 const typeErrorMiddleware = {
   before: (request: MutableContextRequest) => {

--- a/packages/core/index.test-d.ts
+++ b/packages/core/index.test-d.ts
@@ -1,4 +1,4 @@
-import { expectError, expectType } from 'tsd'
+import { expectType } from 'tsd'
 import middy from '.'
 import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda'
 
@@ -171,10 +171,11 @@ async function mutableContextDependantHandler (event: APIGatewayProxyEvent, cont
   }
 }
 
-// @ts-expect-error
-handler = middy<APIGatewayProxyEvent, APIGatewayProxyResult, Error, Context>(mutableContextDependantHandler)
+let customCtxHandler = middy<APIGatewayProxyEvent, APIGatewayProxyResult, Error, MutableContext>(mutableContextDependantHandler)
+expectType<MutableContextHandler>(customCtxHandler)
 
-handler = middy<APIGatewayProxyEvent, APIGatewayProxyResult, Error, MutableContext>(mutableContextDependantHandler)
+// @ts-expect-error
+customCtxHandler = middy<APIGatewayProxyEvent, APIGatewayProxyResult, Error, Context>(mutableContextDependantHandler)
 
 const mutableContextMiddleware = {
   before: (request: MutableContextRequest) => {
@@ -182,8 +183,8 @@ const mutableContextMiddleware = {
   }
 }
 
-handler = handler.use(mutableContextMiddleware)
-expectType<Handler>(handler)
+customCtxHandler = customCtxHandler.use(mutableContextMiddleware)
+expectType<MutableContextHandler>(customCtxHandler)
 
 const typeErrorMiddleware = {
   before: (request: MutableContextRequest) => {
@@ -192,4 +193,4 @@ const typeErrorMiddleware = {
   }
 }
 
-handler = handler.use(typeErrorMiddleware)
+customCtxHandler = customCtxHandler.use(typeErrorMiddleware)

--- a/packages/core/index.test-d.ts
+++ b/packages/core/index.test-d.ts
@@ -194,3 +194,4 @@ const typeErrorMiddleware = {
 }
 
 customCtxHandler = customCtxHandler.use(typeErrorMiddleware)
+expectType<MutableContextHandler>(customCtxHandler)


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------

Some middleware adds extra fields to the context. Typescript will complain if the fields are not declared optional, even if the middleware guarantees they are set before invoking the next step. With this pull request you can specify a custom Context type, including those fields.

This is not yet fully automated inference of the Context type by combining types from each middleware (see https://github.com/middyjs/middy/issues/589) but rather a first step towards it. You still have to update the type manually as you add/remove middleware.

The original PR was https://github.com/middyjs/middy/pull/666 by @JimiPedros. I have just rebased and fixed the automatic type tests.

First define your context type:

```typescript
interface CustomContext extends Context {
  name: string
}
```

and then use it in your handler:

```typescript
async function customHandler(event: APIGatewayProxyEvent, context: CustomContext): Promise<APIGatewayProxyResult> {
  return {
    statusCode: 200,
    body: `Hello from ${context.name}`
  }
}

handler = middy(customHandler)
```

You can also use the custom type when defining middleware:

```typescript
let customMiddleware = {
  before: (request: CustomContext) => {
    request.context.name = 'Foo'
  },
}

handler = handler.use(customMiddleware)
```

Accessing a field that does not exist on the context is a failure (in Typescript `strict` mode):

```typescript
async function handler (event: ..., context: CustomContext): Promise<APIGatewayProxyResult> {
  return {
    statusCode: 200,
    body: `Hello from ${context.value}` // Fails
  }
}

...

let customMiddleware = {
  before: (request: CustomContext) => {
    request.context.value = 'Foo' // Fails
  },
}
```

Does this close any currently open issues?
------------------------------------------

No. It may cause issues for existing Typescript users however I've verified it works on a @lego-shop and at worst we could back out the changes or fix forward.