### PR TITLE
New Middleware: http-content-encoding

### DIFF
--- a/packages/http-content-encoding/README.md
+++ b/packages/http-content-encoding/README.md
@@ -1,0 +1,94 @@
+# Middy http-content-encoding middleware
+
+<div align="center">
+  <img alt="Middy logo" src="https://raw.githubusercontent.com/middyjs/middy/main/docs/img/middy-logo.png"/>
+</div>
+
+<div align="center">
+  <p><strong>HTTP content encoding middleware for the middy framework, the stylish Node.js middleware engine for AWS Lambda</strong></p>
+</div>
+
+<div align="center">
+<p>
+  <a href="http://badge.fury.io/js/%40middy%2Fhttp-content-encoding">
+    <img src="https://badge.fury.io/js/%40middy%2Fhttp-content-encoding.svg" alt="npm version" style="max-width:100%;">
+  </a>
+  <a href="https://snyk.io/test/github/middyjs/middy">
+    <img src="https://snyk.io/test/github/middyjs/middy/badge.svg" alt="Known Vulnerabilities" data-canonical-src="https://snyk.io/test/github/middyjs/middy" style="max-width:100%;">
+  </a>
+  <a href="https://standardjs.com/">
+    <img src="https://img.shields.io/badge/code_style-standard-brightgreen.svg" alt="Standard Code Style"  style="max-width:100%;">
+  </a>
+  <a href="https://gitter.im/middyjs/Lobby">
+    <img src="https://badges.gitter.im/gitterHQ/gitter.svg" alt="Chat on Gitter"  style="max-width:100%;">
+  </a>
+</p>
+</div>
+
+This middleware take the `preferredEncoding` output from `@middy/http-content-negotiation` and applies the encoding to `response.body` when a string.
+
+## Install
+
+To install this middleware you can use NPM:
+
+```bash
+npm install --save @middy/http-content-encoding
+```
+
+## Options
+- `br` (object) (optional): `zlib.createBrotliCompress` [brotliOptions](https://nodejs.org/api/zlib.html#zlib_class_brotlioptions)
+- `gzip` (object) (optional): `zlib.createGzip` [gzipOptions](https://nodejs.org/api/zlib.html#zlib_class_options)
+- `deflate` (object) (optional): `zlib.createDeflate` [deflateOptions](https://nodejs.org/api/zlib.html#zlib_class_options)
+- `overridePreferredEncoding` (array[string]) (optional): Override the preferred encoding order, most browsers prefer `gzip` over `br`, even though `br` has higher compression. Default: `[]`
+
+NOTES:
+- **Important** For `br` encoding NodeJS defaults to `11`. Levels `10` & `11` have been shown to have lower performance for the level of compression they apply. Testing is recommended to ensure the right balance of compression & performance.
+
+## Sample usage
+
+```javascript
+import middy from '@middy/core'
+import httpContentNegotiation from '@middy/http-content-negotiation'
+import httpContentEncoding from '@middy/http-content-encoding'
+import { constants } from 'zlib'
+
+const handler = middy((event, context) => {
+  return {
+    statusCode: 200,
+    body: '{...}'
+  }
+})
+
+handler
+  .use(httpHeaderNormalizer())
+  .use(httpCompressMiddleware({
+    br: {
+      params: {
+        [constants.BROTLI_PARAM_MODE]: constants.BROTLI_MODE_TEXT,  // adjusted for UTF-8 text
+        [constants.BROTLI_PARAM_QUALITY]: 7
+      }
+    },
+    overridePreferredEncoding: ['br', 'gzip', 'deflate']
+  }))
+
+module.exports = { handler }
+```
+
+
+## Middy documentation and examples
+
+For more documentation and examples, refers to the main [Middy monorepo on GitHub](https://github.com/middyjs/middy) or [Middy official website](https://middy.js.org).
+
+
+## Contributing
+
+Everyone is very welcome to contribute to this repository. Feel free to [raise issues](https://github.com/middyjs/middy/issues) or to [submit Pull Requests](https://github.com/middyjs/middy/pulls).
+
+
+## License
+
+Licensed under [MIT License](LICENSE). Copyright (c) 2017-2021 Luciano Mammino, will Farrell, and the [Middy team](https://github.com/middyjs/middy/graphs/contributors).
+
+<a href="https://app.fossa.io/projects/git%2Bgithub.com%2Fmiddyjs%2Fmiddy?ref=badge_large">
+  <img src="https://app.fossa.io/api/projects/git%2Bgithub.com%2Fmiddyjs%2Fmiddy.svg?type=large" alt="FOSSA Status"  style="max-width:100%;">
+</a>

--- a/packages/http-content-encoding/__tests__/index.js
+++ b/packages/http-content-encoding/__tests__/index.js
@@ -2,6 +2,8 @@ const test = require('ava')
 const middy = require('../../core/index.js')
 const httpContentEncoding = require('../index.js')
 
+const { brotliCompressSync, gzipSync, deflateSync } = require('zlib')
+
 const compressibleBody = JSON.stringify(new Array(100).fill(0))
 
 test('It should encode using br', async (t) => {
@@ -18,7 +20,7 @@ test('It should encode using br', async (t) => {
   const response = await handler(event)
 
   t.deepEqual(response, {
-    body: 'G8gA+KVZYLa6lCKahQH/xA==',
+    body: brotliCompressSync(body).toString('base64'),
     headers: { 'Content-Encoding': 'br' },
     isBase64Encoded: true
   })
@@ -38,7 +40,7 @@ test('It should encode using gzip', async (t) => {
   const response = await handler(event)
 
   t.deepEqual(response, {
-    body: 'H4sIAAAAAAAAE4s20BkWMBYAa63RJckAAAA=',
+    body: gzipSync(body).toString('base64'),
     headers: { 'Content-Encoding': 'gzip' },
     isBase64Encoded: true
   })
@@ -58,7 +60,7 @@ test('It should encode using deflate', async (t) => {
   const response = await handler(event)
 
   t.deepEqual(response, {
-    body: 'eJyLNtAZFjAWAGW/JH0=',
+    body: deflateSync(body).toString('base64'),
     headers: { 'Content-Encoding': 'deflate' },
     isBase64Encoded: true
   })
@@ -81,7 +83,7 @@ test('It should encode using br when event.preferredEncoding is gzip, but has ov
   const response = await handler(event)
 
   t.deepEqual(response, {
-    body: 'G8gA+KVZYLa6lCKahQH/xA==',
+    body: brotliCompressSync(body).toString('base64'),
     headers: { 'Content-Encoding': 'br' },
     isBase64Encoded: true
   })

--- a/packages/http-content-encoding/__tests__/index.js
+++ b/packages/http-content-encoding/__tests__/index.js
@@ -148,4 +148,3 @@ test('It should not encode when response.body is empty', async (t) => {
 
   t.deepEqual(response, { body, headers: {} })
 })
-

--- a/packages/http-content-encoding/__tests__/index.js
+++ b/packages/http-content-encoding/__tests__/index.js
@@ -114,7 +114,7 @@ test('It should not encode when response.isBase64Encoded is already set to true'
 
   const response = await handler(event)
 
-  t.deepEqual(response, { body, isBase64Encoded: true })
+  t.deepEqual(response, { body, headers: {}, isBase64Encoded: true })
 })
 
 test('It should not encode when response.body is not a string', async (t) => {
@@ -130,7 +130,7 @@ test('It should not encode when response.body is not a string', async (t) => {
 
   const response = await handler(event)
 
-  t.deepEqual(response, { body })
+  t.deepEqual(response, { body, headers: {} })
 })
 
 test('It should not encode when response.body is empty', async (t) => {
@@ -146,6 +146,6 @@ test('It should not encode when response.body is empty', async (t) => {
 
   const response = await handler(event)
 
-  t.deepEqual(response, { body })
+  t.deepEqual(response, { body, headers: {} })
 })
 

--- a/packages/http-content-encoding/__tests__/index.js
+++ b/packages/http-content-encoding/__tests__/index.js
@@ -1,0 +1,151 @@
+const test = require('ava')
+const middy = require('../../core/index.js')
+const httpContentEncoding = require('../index.js')
+
+const compressibleBody = JSON.stringify(new Array(100).fill(0))
+
+test('It should encode using br', async (t) => {
+  const body = compressibleBody
+  const handler = middy((event, context) => ({ body }))
+  handler.use(
+    httpContentEncoding()
+  )
+
+  const event = {
+    preferredEncoding: 'br'
+  }
+
+  const response = await handler(event)
+
+  t.deepEqual(response, {
+    body: 'G8gA+KVZYLa6lCKahQH/xA==',
+    headers: { 'Content-Encoding': 'br' },
+    isBase64Encoded: true
+  })
+})
+
+test('It should encode using gzip', async (t) => {
+  const body = compressibleBody
+  const handler = middy((event, context) => ({ body }))
+  handler.use(
+    httpContentEncoding()
+  )
+
+  const event = {
+    preferredEncoding: 'gzip'
+  }
+
+  const response = await handler(event)
+
+  t.deepEqual(response, {
+    body: 'H4sIAAAAAAAAE4s20BkWMBYAa63RJckAAAA=',
+    headers: { 'Content-Encoding': 'gzip' },
+    isBase64Encoded: true
+  })
+})
+
+test('It should encode using deflate', async (t) => {
+  const body = compressibleBody
+  const handler = middy((event, context) => ({ body }))
+  handler.use(
+    httpContentEncoding()
+  )
+
+  const event = {
+    preferredEncoding: 'deflate'
+  }
+
+  const response = await handler(event)
+
+  t.deepEqual(response, {
+    body: 'eJyLNtAZFjAWAGW/JH0=',
+    headers: { 'Content-Encoding': 'deflate' },
+    isBase64Encoded: true
+  })
+})
+
+test('It should encode using br when event.preferredEncoding is gzip, but has overridePreferredEncoding set', async (t) => {
+  const body = compressibleBody
+  const handler = middy((event, context) => ({ body }))
+  handler.use(
+    httpContentEncoding({
+      overridePreferredEncoding: ['br', 'gzip', 'deflate']
+    })
+  )
+
+  const event = {
+    preferredEncoding: 'gzip',
+    preferredEncodings: ['gzip', 'deflate', 'br']
+  }
+
+  const response = await handler(event)
+
+  t.deepEqual(response, {
+    body: 'G8gA+KVZYLa6lCKahQH/xA==',
+    headers: { 'Content-Encoding': 'br' },
+    isBase64Encoded: true
+  })
+})
+
+test('It should not encode when missing event.preferredEncoding', async (t) => {
+  const body = 'test'
+  const handler = middy((event, context) => ({ body }))
+  handler.use(
+    httpContentEncoding()
+  )
+
+  const event = {}
+
+  const response = await handler(event)
+
+  t.deepEqual(response, { body })
+})
+
+test('It should not encode when response.isBase64Encoded is already set to true', async (t) => {
+  const body = 'test'
+  const handler = middy((event, context) => ({ body, isBase64Encoded: true }))
+  handler.use(
+    httpContentEncoding()
+  )
+
+  const event = {
+    preferredEncoding: 'br'
+  }
+
+  const response = await handler(event)
+
+  t.deepEqual(response, { body, isBase64Encoded: true })
+})
+
+test('It should not encode when response.body is not a string', async (t) => {
+  const body = 0
+  const handler = middy((event, context) => ({ body }))
+  handler.use(
+    httpContentEncoding()
+  )
+
+  const event = {
+    preferredEncoding: 'br'
+  }
+
+  const response = await handler(event)
+
+  t.deepEqual(response, { body })
+})
+
+test('It should not encode when response.body is empty', async (t) => {
+  const body = ''
+  const handler = middy((event, context) => ({ body }))
+  handler.use(
+    httpContentEncoding()
+  )
+
+  const event = {
+    preferredEncoding: 'br'
+  }
+
+  const response = await handler(event)
+
+  t.deepEqual(response, { body })
+})
+

--- a/packages/http-content-encoding/index.d.ts
+++ b/packages/http-content-encoding/index.d.ts
@@ -1,0 +1,12 @@
+import middy from '@middy/core'
+
+interface Options {
+  br?: any
+  gzip?: any
+  deflate?: any
+  overridePreferredEncoding?: string[]
+}
+
+declare function httpContentEncoding (options?: Options): middy.MiddlewareObj
+
+export default httpContentEncoding

--- a/packages/http-content-encoding/index.js
+++ b/packages/http-content-encoding/index.js
@@ -39,13 +39,14 @@ const httpContentEncodingMiddleware = (opts) => {
     if (response.isBase64Encoded) { return }
 
     let contentLength, readStream
-    if (typeof response.body == 'string') {
+    if (typeof response.body === 'string') {
       contentLength = response.body.length
       readStream = Readable.from(response.body, { objectMode: false })
-    }/*else if (isReadableStream(response.body)) {
+    /* } else if (isReadableStream(response.body)) {
       contentLength = 0 // will need Transform stream to calculate
       readStream = response.body
-    }*/ else {
+     */
+    } else {
       return
     }
 
@@ -87,7 +88,7 @@ const httpContentEncodingMiddleware = (opts) => {
   }
 }
 
-/*const isReadableStream = (stream) =>
+/* const isReadableStream = (stream) =>
   typeof stream?.pipe === 'function' &&
   stream.readable !== false &&
   typeof stream._read === 'function' &&

--- a/packages/http-content-encoding/index.js
+++ b/packages/http-content-encoding/index.js
@@ -1,0 +1,83 @@
+/*
+ * `zstd` disabled due to lack of support in browsers
+ * https://github.com/Fyrd/caniuse/issues/4065
+ */
+
+const { Readable, Writable } = require('stream')
+// const {pipeline} = require('stream/promises')  // available in node >=15
+const { promisify } = require('util')
+const { pipeline: pipelineCallback } = require('stream')
+
+const pipeline = promisify(pipelineCallback)
+const { createBrotliCompress, createGzip, createDeflate } = require('zlib')
+// const {compressStream: createZstdCompress} = require('node-zstd2')
+
+const { normalizeHttpResponse } = require('@middy/util')
+
+const contentEncodingStreams = {
+  br: (opts = {}) => createBrotliCompress(opts),
+  // zstd: (opt = {}) => createZstdCompress(opts),
+  gzip: (opts = {}) => createGzip(opts),
+  deflate: (opts = {}) => createDeflate(opts)
+}
+
+const defaults = {
+  br: undefined,
+  // zstd: undefined,
+  gzip: undefined,
+  deflate: undefined,
+  overridePreferredEncoding: []
+}
+
+const httpContentEncodingMiddleware = (opts) => {
+  const options = { ...defaults, ...opts }
+
+  const httpContentEncodingMiddlewareAfter = async (request) => {
+    const { event, response } = request
+    if (!event.preferredEncoding) { return }
+    if (response.isBase64Encoded) { return }
+    if (typeof response?.body !== 'string') { return }
+
+    const contentLength = response.body.length
+    const readStream = Readable.from(response.body, { objectMode: false })
+
+    let contentEncodingStream = contentEncodingStreams[event.preferredEncoding](options[event.preferredEncoding])
+    let contentEncoding = event.preferredEncoding
+    for (const encoding of options.overridePreferredEncoding) {
+      if (!event.preferredEncodings.includes(encoding)) continue
+      contentEncodingStream = contentEncodingStreams[encoding](options[encoding])
+      contentEncoding = encoding
+      break
+    }
+
+    const chunks = []
+    const writeStream = new Writable({
+      write (chunk, encoding, callback) {
+        chunks.push(chunk)
+        callback()
+      }
+    })
+
+    await pipeline(
+      readStream,
+      contentEncodingStream,
+      writeStream
+    )
+
+    const body = Buffer.concat(chunks).toString('base64')
+
+    // Only apply encoding if it's smaller
+    if (body.length < contentLength) {
+      request.response = normalizeHttpResponse(request.response)
+      response.headers['Content-Encoding'] = contentEncoding
+      response.body = body
+      response.isBase64Encoded = true
+    }
+  }
+
+  return {
+    after: httpContentEncodingMiddlewareAfter
+  }
+}
+
+module.exports = httpContentEncodingMiddleware

--- a/packages/http-content-encoding/index.test-d.ts
+++ b/packages/http-content-encoding/index.test-d.ts
@@ -1,0 +1,16 @@
+import { expectType } from 'tsd'
+import middy from '@middy/core'
+import httpContentEncodingMiddleware from '.'
+
+// use with default options
+let middleware = httpContentEncodingMiddleware()
+expectType<middy.MiddlewareObj>(middleware)
+
+// use with all options
+middleware = httpContentEncodingMiddleware({
+  br: {},
+  gzip: {},
+  deflate: {},
+  overridePreferredEncoding: ['br', 'gzip', 'deflate']
+})
+expectType<middy.MiddlewareObj>(middleware)

--- a/packages/http-content-encoding/package.json
+++ b/packages/http-content-encoding/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@middy/http-content-encoding",
+  "version": "2.5.0",
+  "description": "Http content encoding middleware for the middy framework",
+  "type": "commonjs",
+  "engines": {
+    "node": ">=12"
+  },
+  "engineStrict": true,
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "index.js",
+  "types": "index.d.ts",
+  "files": [
+    "index.d.ts"
+  ],
+  "scripts": {
+    "test": "npm run test:unit",
+    "test:unit": "ava"
+  },
+  "license": "MIT",
+  "keywords": [
+    "Lambda",
+    "Middleware",
+    "Serverless",
+    "Framework",
+    "AWS",
+    "AWS Lambda",
+    "Middy",
+    "HTTP",
+    "API",
+    "Content Encoding",
+    "gzip",
+    "brotli",
+    "deflate"
+  ],
+  "author": {
+    "name": "Middy contributors",
+    "url": "https://github.com/middyjs/middy/graphs/contributors"
+  },
+  "repository": {
+    "type": "git",
+    "url": "github:middyjs/middy",
+    "directory": "packages/http-content-encoding"
+  },
+  "bugs": {
+    "url": "https://github.com/middyjs/middy/issues"
+  },
+  "homepage": "https://github.com/middyjs/middy#readme",
+  "dependencies": {
+    "@middy/util": "^2.5.0"
+  },
+  "devDependencies": {
+    "@middy/core": "^2.5.0"
+  },
+  "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"
+}


### PR DESCRIPTION
Closes: #186

Questions:
- [ ] Should it accept `{body:Readable}`?
- [ ] Should it set `response.body = Readable`, and require converting to string in elsewhere (ie `http-response-serializer`)?
- [ ] Can it be faster?