### PR TITLE
TypeScript: Align types with aws-lambda

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -35,6 +35,8 @@ export interface MiddlewareObj<TEvent = any, TResult = any, TErr = Error, TConte
   onError?: MiddlewareFn<TEvent, TResult, TErr>
 }
 
+// The AWS provided Handler type uses void | Promise<TResult> so we have no choice but to follow and suppress the linter warning
+// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 type MiddyInputHandler<TEvent, TResult, TContext extends LambdaContext = LambdaContext> = (event: TEvent, context: TContext, callback: LambdaCallback<TResult>) => void | Promise<TResult>
 
 export interface MiddyfiedHandler<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> extends MiddyInputHandler<TEvent, TResult, TContext> {

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -1,5 +1,6 @@
 import {
   Context as LambdaContext,
+  Handler as LambdaHandler,
   Callback as LambdaCallback
 } from 'aws-lambda'
 
@@ -59,12 +60,17 @@ declare type AttachMiddlewareObj<TEvent = any, TResult = any, TErr = Error, TCon
 declare type UseFn<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> =
   (middlewares: MiddlewareObj<TEvent, TResult, TErr, TContext> | Array<MiddlewareObj<TEvent, TResult, TErr, TContext>>) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
 
+declare type MiddlewareHandler<THandler extends LambdaHandler<any, any>, TContext extends LambdaContext = LambdaContext> =
+  THandler extends LambdaHandler<infer TEvent, infer TResult> // always true
+    ? MiddyInputHandler<TEvent, TResult, TContext>
+    : never
+
 /**
  * Middy factory function. Use it to wrap your existing handler to enable middlewares on it.
  * @param handler your original AWS Lambda function
  * @param plugin wraps around each middleware and handler to add custom lifecycle behaviours (e.g. to profile performance)
  */
-declare function middy<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> (handler?: MiddyInputHandler<TEvent, TResult, TContext>, plugin?: PluginObject): MiddyfiedHandler<TEvent, TResult, TErr, TContext>
+declare function middy<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> (handler?: MiddlewareHandler<LambdaHandler<TEvent, TResult>, TContext>, plugin?: PluginObject): MiddyfiedHandler<TEvent, TResult, TErr, TContext>
 
 declare namespace middy {
   export {

--- a/packages/core/index.test-d.ts
+++ b/packages/core/index.test-d.ts
@@ -44,6 +44,7 @@ handler = middy(baseHandler, {
 expectType<Handler>(handler)
 
 // invokes the handler to test that it is callable
+// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 async function invokeHandler (): Promise<void | APIGatewayProxyResult> {
   const sampleEvent: APIGatewayProxyEvent = {
     resource: '/',

--- a/packages/core/index.test-d.ts
+++ b/packages/core/index.test-d.ts
@@ -1,8 +1,13 @@
 import { expectType } from 'tsd'
 import middy from '.'
-import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda'
+import {
+  APIGatewayProxyEvent,
+  APIGatewayProxyResult,
+  Context,
+  Handler as LambdaHandler
+} from 'aws-lambda'
 
-async function baseHandler (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+const baseHandler: LambdaHandler<APIGatewayProxyEvent, APIGatewayProxyResult> = async (event) => {
   return {
     statusCode: 200,
     body: `Hello from ${event.path}`
@@ -39,7 +44,7 @@ handler = middy(baseHandler, {
 expectType<Handler>(handler)
 
 // invokes the handler to test that it is callable
-async function invokeHandler (): Promise<APIGatewayProxyResult> {
+async function invokeHandler (): Promise<void | APIGatewayProxyResult> {
   const sampleEvent: APIGatewayProxyEvent = {
     resource: '/',
     path: '/',
@@ -110,7 +115,7 @@ async function invokeHandler (): Promise<APIGatewayProxyResult> {
     fail: (_) => { },
     succeed: () => { }
   }
-  return await handler(sampleEvent, sampleContext)
+  return await handler(sampleEvent, sampleContext, () => {})
 }
 invokeHandler().catch(console.error)
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes #703.
A few things have changed with the types:
1. `MiddyInputHandler` is now a copy of `Handler` from `aws-lambda` but with a generic context
2. Updated the default value of the generic context from `any` to `Context` to align it with `aws-lambda`
3. Removed typings that didn't seem necessary anymore.

Testing:
Changed the base handler to be an `aws-lambda` `Handler` type.

Any relevant logs, error output, etc?
-------------------------------------
I'm getting some lint errors from the using `void` in the return type, but that's what `aws-lambda` `Handler` uses.
How do I ignore these?
```
ts-standard: Typescript Standard Style! (https://github.com/standard/ts-standard)
  .../middy/packages/core/index.d.ts:38:164: void is only valid as a return type or generic type variable (@typescript-eslint/no-invalid-void-type)
  .../middy/packages/core/index.test-d.ts:47:42: void is only valid as a return type or generic type variable (@typescript-eslint/no-invalid-void-type)
```
