### PR TITLE
fix: :label: Added missing types for `modifyCache`

### DIFF
--- a/packages/util/index.d.ts
+++ b/packages/util/index.d.ts
@@ -43,3 +43,5 @@ declare function jsonSafeParse (string: string, reviver?: (key: string, value: a
 declare function normalizeHttpResponse (response: any, fallbackResponse?: any): any
 
 declare function createError (code: number, message: string, properties?: Record<string, any>): HttpError
+
+declare function modifyCache (cacheKey: string, value: any): void


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
We use the modify cache function and it's missing type declarations.

Does this close any currently open issues?
------------------------------------------
Doesn't close any issues but adds to the type system as help was needed


Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Node.js Versions:** …

**Middy Versions:** …

**AWS SDK Versions:** …

Todo list
---------

[ ] Feature/Fix fully implemented
[ ] Added tests
[ ] Updated relevant documentation
[ ] Updated relevant examples
