### PR TITLE
fix: Chunk deleteMessageBatch requests. Fixes #722.

### DIFF
--- a/packages/sqs-partial-batch-failure/index.js
+++ b/packages/sqs-partial-batch-failure/index.js
@@ -34,7 +34,18 @@ const sqsPartialBatchFailureMiddleware = (opts = {}) => {
     const Entries = getEntries(fulfilledRecords)
     const { eventSourceARN } = fulfilledRecords[0]
     const QueueUrl = getQueueUrl(eventSourceARN)
-    return client.deleteMessageBatch({ Entries, QueueUrl }).promise() // Required for aws-sdk v2
+
+    const promises = []
+
+    // deleteMessageBatch only supports 10 messages at a time
+    // https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_DeleteMessageBatch.html
+    var i; var j; var chunk = 10
+    for (i = 0, j = Entries.length; i < j; i += chunk) {
+      const chunkedEntries = Entries.slice(i, i + chunk)
+      promises.push(client.deleteMessageBatch({ Entries: chunkedEntries, QueueUrl }).promise())
+    }
+
+    return Promise.allSettled(promises)
   }
 
   let client


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
#722 

AWS' [deleteMessageBatch](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_DeleteMessageBatch.html) API only supports 10 messages per request.  This PR chunks up entries in groups of 10 in order to support larger batch es.  



Does this close any currently open issues?
------------------------------------------
#722 

Any other comments?
-------------------
This bug only surfaces when there is a group of more than 10 messages and at least one failure.

Where has this been tested?
---------------------------
**Node.js Versions:** 14.7

**Middy Versions:** …

**AWS SDK Versions:** …

Todo list
---------

[x] Feature/Fix fully implemented
[x] Added tests
[x] Updated relevant documentation
[x] Updated relevant examples
