### PR TITLE
http-json-body-parser: Add rawBody to event

### DIFF
--- a/packages/http-json-body-parser/README.md
+++ b/packages/http-json-body-parser/README.md
@@ -32,6 +32,8 @@ if used in combination with `httpErrorHandler`.
 It can also be used in combination with validator as a prior step to normalize the
 event body input as an object so that the content can be validated.
 
+If the body has been parsed as JSON, you can access the original body (e.g. for webhook signature validation) through the `request.event.rawBody`.
+
 
 ## Install
 

--- a/packages/http-json-body-parser/__tests__/index.js
+++ b/packages/http-json-body-parser/__tests__/index.js
@@ -5,7 +5,7 @@ const jsonBodyParser = require('../index.js')
 
 test('It should parse a JSON request', async (t) => {
   const handler = middy((event, context) => {
-    return event.body // propagates the body as a response
+    return event // propagates the processed event as a response
   })
 
   handler.use(jsonBodyParser())
@@ -18,14 +18,15 @@ test('It should parse a JSON request', async (t) => {
     body: JSON.stringify({ foo: 'bar' })
   }
 
-  const body = await handler(event)
+  const processedEvent = await handler(event)
 
-  t.deepEqual(body, { foo: 'bar' })
+  t.deepEqual(processedEvent.body, { foo: 'bar' })
+  t.deepEqual(processedEvent.rawBody, event.body)
 })
 
 test('It should parse a JSON with a suffix MediaType request', async (t) => {
   const handler = middy((event, context) => {
-    return event.body // propagates the body as a response
+    return event // propagates the processed event as a response
   })
 
   handler.use(jsonBodyParser())
@@ -38,9 +39,10 @@ test('It should parse a JSON with a suffix MediaType request', async (t) => {
     body: JSON.stringify({ foo: 'bar' })
   }
 
-  const body = await handler(event)
+  const processedEvent = await handler(event)
 
-  t.deepEqual(body, { foo: 'bar' })
+  t.deepEqual(processedEvent.body, { foo: 'bar' })
+  t.deepEqual(processedEvent.rawBody, event.body)
 })
 
 test('It should use a reviver when parsing a JSON request', async (t) => {

--- a/packages/http-json-body-parser/__tests__/index.js
+++ b/packages/http-json-body-parser/__tests__/index.js
@@ -15,13 +15,13 @@ test('It should parse a JSON request', async (t) => {
     headers: {
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({ foo: 'bar' })
+    body: '{ "foo" :   "bar"   }'
   }
 
   const processedEvent = await handler(event)
 
   t.deepEqual(processedEvent.body, { foo: 'bar' })
-  t.deepEqual(processedEvent.rawBody, event.body)
+  t.deepEqual(processedEvent.rawBody, '{ "foo" :   "bar"   }')
 })
 
 test('It should parse a JSON with a suffix MediaType request', async (t) => {
@@ -36,13 +36,13 @@ test('It should parse a JSON with a suffix MediaType request', async (t) => {
     headers: {
       'Content-Type': 'application/vnd+json'
     },
-    body: JSON.stringify({ foo: 'bar' })
+    body: '{ "foo" :   "bar"   }'
   }
 
   const processedEvent = await handler(event)
 
   t.deepEqual(processedEvent.body, { foo: 'bar' })
-  t.deepEqual(processedEvent.rawBody, event.body)
+  t.deepEqual(processedEvent.rawBody, '{ "foo" :   "bar"   }')
 })
 
 test('It should use a reviver when parsing a JSON request', async (t) => {

--- a/packages/http-json-body-parser/index.js
+++ b/packages/http-json-body-parser/index.js
@@ -18,7 +18,7 @@ const httpJsonBodyParserMiddleware = (opts = {}) => {
           ? Buffer.from(body, 'base64').toString()
           : body
 
-        request.event.rawBody = request.event.body
+        request.event.rawBody = body
         request.event.body = JSON.parse(data, options.reviver)
       } catch (err) {
         const { createError } = require('@middy/util')

--- a/packages/http-json-body-parser/index.js
+++ b/packages/http-json-body-parser/index.js
@@ -18,6 +18,7 @@ const httpJsonBodyParserMiddleware = (opts = {}) => {
           ? Buffer.from(body, 'base64').toString()
           : body
 
+        request.event.rawBody = request.event.body
         request.event.body = JSON.parse(data, options.reviver)
       } catch (err) {
         const { createError } = require('@middy/util')


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
For webhook signature validation, and other use cases, it is important to be able to access the original raw body. This is because parsing it as JSON loses information about whitespace etc. that may be important for things like cryptographic signatures.


Does this close any currently open issues?
------------------------------------------
Closes #740 


Any other comments?
-------------------
I've been using this in my own projects and it seems to be working well. I've found it useful for integrating with Slack and Stripe webhooks. For me, exposing this rawBody is preferable to adding middleware before the JSON parsing middleware as I want to be able to use standard middleware and be consistent across endpoints.

I don't believe these changes would break existing workflows or applications.


Where has this been tested?
---------------------------
**Node.js Versions:** v14.15.3

**Middy Versions:** v2.5.1

**AWS SDK Versions:** v3.34.0

Todo list
---------

[x] Feature/Fix fully implemented
[x] Added tests
[x] Updated relevant documentation
[x] Updated relevant examples
