### PR TITLE
feat/types/remove-aws-xray-sdk-deps

### DIFF
--- a/packages/rds-signer/index.d.ts
+++ b/packages/rds-signer/index.d.ts
@@ -1,19 +1,8 @@
 import { RDS } from 'aws-sdk'
-import { captureAWSClient } from 'aws-xray-sdk'
 import middy from '@middy/core'
+import { Options as MiddyOptions } from '@middy/util'
 
-interface Options<Signer = RDS.Signer> {
-  AwsClient?: new() => Signer
-  awsClientOptions?: Partial<RDS.Types.ClientConfiguration>
-  awsClientAssumeRole?: string
-  awsClientCapture?: typeof captureAWSClient
-  fetchData?: { [key: string]: string }
-  disablePrefetch?: boolean
-  cacheKey?: string
-  cacheExpiry?: number
-  setToEnv?: boolean
-  setToContext?: boolean
-}
+interface Options<Signer = RDS.Signer> extends MiddyOptions<Signer, RDS.Types.ClientConfiguration> {}
 
 declare function rdsSigner (options?: Options): middy.MiddlewareObj
 

--- a/packages/s3-object-response/index.d.ts
+++ b/packages/s3-object-response/index.d.ts
@@ -1,13 +1,10 @@
 import { S3 } from 'aws-sdk'
-import { captureAWSClient } from 'aws-xray-sdk'
 import middy from '@middy/core'
+import { Options as MiddyOptions } from '@middy/util'
 
-interface Options<S = S3> {
-  AwsClient?: new() => S
-  awsClientOptions?: Partial<S3.Types.ClientConfiguration>
-  awsClientAssumeRole?: string
-  awsClientCapture?: typeof captureAWSClient
-  disablePrefetch?: boolean
+interface Options<S = S3>
+  extends Pick<MiddyOptions<S, S3.Types.ClientConfiguration>,
+  'AwsClient' | 'awsClientOptions' | 'awsClientAssumeRole' | 'awsClientCapture' | 'disablePrefetch'> {
   bodyType?: string
 }
 

--- a/packages/secrets-manager/index.d.ts
+++ b/packages/secrets-manager/index.d.ts
@@ -1,19 +1,8 @@
 import { SecretsManager } from 'aws-sdk'
-import { captureAWSClient } from 'aws-xray-sdk'
 import middy from '@middy/core'
+import { Options as MiddyOptions } from '@middy/util'
 
-interface Options<SM = SecretsManager> {
-  AwsClient?: new() => SM
-  awsClientOptions?: Partial<SecretsManager.Types.ClientConfiguration>
-  awsClientAssumeRole?: string
-  awsClientCapture?: typeof captureAWSClient
-  fetchData?: { [key: string]: string }
-  disablePrefetch?: boolean
-  cacheKey?: string
-  cacheExpiry?: number
-  setToEnv?: boolean
-  setToContext?: boolean
-}
+interface Options<SM = SecretsManager> extends MiddyOptions<SM, SecretsManager.Types.ClientConfiguration> {}
 
 declare function secretsManager (options?: Options): middy.MiddlewareObj
 

--- a/packages/sqs-partial-batch-failure/index.d.ts
+++ b/packages/sqs-partial-batch-failure/index.d.ts
@@ -1,13 +1,9 @@
 import middy from '@middy/core'
 import { SQS } from 'aws-sdk'
-import { captureAWSClient } from 'aws-xray-sdk'
+import { Options as MiddyOptions } from '@middy/util'
 
-interface Options<S = SQS> {
-  AwsClient?: new() => S
-  awsClientOptions?: Partial<SQS.Types.ClientConfiguration>
-  awsClientAssumeRole?: string
-  awsClientCapture?: typeof captureAWSClient
-  disablePrefetch?: boolean
+interface Options<S = SQS> extends Pick<MiddyOptions<S, SQS.Types.ClientConfiguration>,
+'AwsClient' | 'awsClientOptions' | 'awsClientAssumeRole' | 'awsClientCapture' | 'disablePrefetch'> {
 }
 
 declare function sqsPartialBatchFailure (options?: Options): middy.MiddlewareObj

--- a/packages/ssm/index.d.ts
+++ b/packages/ssm/index.d.ts
@@ -1,19 +1,8 @@
 import { SSM } from 'aws-sdk'
-import { captureAWSClient } from 'aws-xray-sdk'
+import { Options as MiddyOptions } from '@middy/util'
 import middy from '@middy/core'
 
-interface Options<S = SSM> {
-  AwsClient?: new() => S
-  awsClientOptions?: Partial<SSM.Types.ClientConfiguration>
-  awsClientAssumeRole?: string
-  awsClientCapture?: typeof captureAWSClient
-  fetchData?: { [key: string]: string }
-  disablePrefetch?: boolean
-  cacheKey?: string
-  cacheExpiry?: number
-  setToEnv?: boolean
-  setToContext?: boolean
-}
+interface Options<S = SSM> extends MiddyOptions<S, SSM.Types.ClientConfiguration> {}
 
 declare function ssm (options?: Options): middy.MiddlewareObj
 

--- a/packages/sts/index.d.ts
+++ b/packages/sts/index.d.ts
@@ -1,18 +1,11 @@
 import { STS } from 'aws-sdk'
-import { captureAWSClient } from 'aws-xray-sdk'
 import middy from '@middy/core'
+import { Options as MiddyOptions } from '@middy/util'
 
-interface Options<S = STS> {
-  AwsClient?: new() => S
-  awsClientOptions?: Partial<STS.Types.ClientConfiguration>
-  // awsClientAssumeRole?: string,
-  awsClientCapture?: typeof captureAWSClient
-  fetchData?: { [key: string]: string }
-  disablePrefetch?: boolean
-  cacheKey?: string
-  cacheExpiry?: number
-  // setToEnv?: boolean,
-  setToContext?: boolean
+interface Options<S = STS>
+  extends Pick<MiddyOptions<S, STS.Types.ClientConfiguration>,
+  'AwsClient' | 'awsClientOptions' | 'awsClientCapture' |
+  'fetchData' | 'disablePrefetch' | 'cacheKey' | 'cacheExpiry' | 'setToContext'> {
 }
 
 declare function sts (options?: Options): middy.MiddlewareObj

--- a/packages/util/index.d.ts
+++ b/packages/util/index.d.ts
@@ -1,11 +1,10 @@
 import middy from '@middy/core'
-import { captureAWSClient } from 'aws-xray-sdk'
 
 interface Options<Client, ClientOptions> {
   AwsClient?: new() => Client
   awsClientOptions?: Partial<ClientOptions>
   awsClientAssumeRole?: string
-  awsClientCapture?: typeof captureAWSClient
+  awsClientCapture?: (service: Client) => Client
   fetchData?: { [key: string]: string }
   disablePrefetch?: boolean
   cacheKey?: string


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
In several plugin definitions `aws-xray-sdk` was used. The problem is that we need to be able to continue using those plugins without being dependent on `aws-xray-sdk`.

In this PR I propose to remove this dependency, and to use the `Options` interface defined in `utils` to define the interfaces of each dependent plugins.
This allows a simpler management of types, in case of update of `aws-xray-sdk` (or other changes), we will have only one element to modify. The type of `awsClientCapture` in `utils.Options` (or other attribute types...)

There are some plugins that use only some attributes of the "Options" interface, for this case I use the typescript utility type : [`Pick`](https://www.typescriptlang.org/docs/handbook/utility-types.html#picktype-keys)

Does this close any currently open issues?
------------------------------------------
[Typescript comment related](https://github.com/middyjs/middy/issues/589#issuecomment-968989688)

Where has this been tested?
---------------------------
- npm run test ✔️ 
