### PR TITLE
Pass TContext to the onError handler definition

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -33,7 +33,7 @@ declare type MiddlewareFn<TEvent = any, TResult = any, TErr = Error, TContext ex
 export interface MiddlewareObj<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> {
   before?: MiddlewareFn<TEvent, TResult, TErr, TContext>
   after?: MiddlewareFn<TEvent, TResult, TErr, TContext>
-  onError?: MiddlewareFn<TEvent, TResult, TErr>
+  onError?: MiddlewareFn<TEvent, TResult, TErr, TContext>
 }
 
 // The AWS provided Handler type uses void | Promise<TResult> so we have no choice but to follow and suppress the linter warning


### PR DESCRIPTION
It seems that it was overlooked because `TContext` is passed to `MiddyfiedHandler.onError`.

What does this implement/fix? Explain your changes.
---------------------------------------------------
It fixes type definition for MiddlewareObj.onError

Does this close any currently open issues?
------------------------------------------
IDK


Any relevant logs, error output, etc?
-------------------------------------
NA

Any other comments?
-------------------
NA

Where has this been tested?
---------------------------
**Node.js Versions:** 16

**Middy Versions:** 2.5.3

**AWS SDK Versions:** NA

Todo list
---------

[ ] Feature/Fix fully implemented
[ ] Added tests
[ ] Updated relevant documentation
[ ] Updated relevant examples
