### PR TITLE
Sqs batch failure error stack

### DIFF
--- a/packages/sqs-partial-batch-failure/index.js
+++ b/packages/sqs-partial-batch-failure/index.js
@@ -87,7 +87,7 @@ const sqsPartialBatchFailureMiddleware = (opts = {}) => {
 
 const getRejectedReasons = (response) => {
   const rejected = response.filter((r) => r.status === 'rejected')
-  const rejectedReasons = rejected.map((r) => r.reason?.message)
+  const rejectedReasons = rejected.map((r) => `${r.reason?.message} ${r.reason?.stack}`)
 
   return rejectedReasons
 }

--- a/packages/sqs-partial-batch-failure/package.json
+++ b/packages/sqs-partial-batch-failure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middy/sqs-partial-batch-failure",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "SQS partial batch failure middleware for the middy framework",
   "type": "commonjs",
   "engines": {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
It passes Error Stack along with message.

Does this close any currently open issues?
------------------------------------------
No

Any other comments?
-------------------
Currently, if any worker gets shared by multiple methods, then it's very difficult (sometimes impossible without running locally) to pinpoint the exact location where the error occurs. Hence adding the original stack of the error.

Where has this been tested?
---------------------------
**Node.js Versions:** 14.17.6
**Middy Versions:** 2.5.3
**AWS SDK Versions:** ^2.1014.0


