### PR TITLE
fix(zh): The zh-TW is not for zh, it's should be zh (#1)

### DIFF
--- a/packages/validator/__tests__/index.js
+++ b/packages/validator/__tests__/index.js
@@ -130,25 +130,33 @@ test('It should handle invalid schema as a BadRequest in a different language', 
     })
   )
 
-  // invokes the handler, note that property foo is missing
-  const event = {
-    preferredLanguage: 'fr',
-    body: JSON.stringify({ something: 'somethingelse' })
-  }
+  const cases = [
+    { lang: 'fr', message: 'requiert la propriété foo' },
+    { lang: 'zh', message: '应当有必需属性 foo' },
+    { lang: 'zh-TW', message: '應該有必須屬性 foo' }
+  ]
 
-  try {
-    await handler(event)
-  } catch (err) {
-    t.is(err.message, 'Event object failed validation')
-    t.deepEqual(err.details, [
-      {
-        instancePath: '',
-        keyword: 'required',
-        message: 'requiert la propriété foo',
-        params: { missingProperty: 'foo' },
-        schemaPath: '#/required'
-      }
-    ])
+  for (const c of cases) {
+    // invokes the handler, note that property foo is missing
+    const event = {
+      preferredLanguage: c.lang,
+      body: JSON.stringify({ something: 'somethingelse' })
+    }
+
+    try {
+      await handler(event)
+    } catch (err) {
+      t.is(err.message, 'Event object failed validation')
+      t.deepEqual(err.details, [
+        {
+          instancePath: '',
+          keyword: 'required',
+          message: c.message,
+          params: { missingProperty: 'foo' },
+          schemaPath: '#/required'
+        }
+      ])
+    }
   }
 })
 

--- a/packages/validator/index.js
+++ b/packages/validator/index.js
@@ -90,7 +90,6 @@ const languageNormalizationMap = {
   'pt-br': 'pt-BR',
   pt_BR: 'pt-BR',
   pt_br: 'pt-BR',
-  zh: 'zh',
   'zh-tw': 'zh-TW',
   zh_TW: 'zh-TW',
   zh_tw: 'zh-TW'

--- a/packages/validator/index.js
+++ b/packages/validator/index.js
@@ -90,7 +90,7 @@ const languageNormalizationMap = {
   'pt-br': 'pt-BR',
   pt_BR: 'pt-BR',
   pt_br: 'pt-BR',
-  zh: 'zh-TW',
+  zh: 'zh',
   'zh-tw': 'zh-TW',
   zh_TW: 'zh-TW',
   zh_tw: 'zh-TW'


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
This change is to fix the i18n for Chinese simplified `zh`,  for `zh`, the ajv i18n language should be `zh`, not `zh-TW` which is for Chinese traditional. 
FYI https://github.com/ajv-validator/ajv-i18n/blob/master/messages/index.js#L612


Does this close any currently open issues?
------------------------------------------
No.


Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Node.js Versions:** v17.2.0

**Middy Versions:**  main branch (latest?)

**AWS SDK Versions:** 2.9

Todo list
---------

[ ] Feature/Fix fully implemented
[x] Added tests
[ ] Updated relevant documentation
[ ] Updated relevant examples
