### PR TITLE
fix(lint): disable "no-empty" rule  in looping.js and fix lint issues.

### DIFF
--- a/benchmark/tests/looping.js
+++ b/benchmark/tests/looping.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-empty */
+
 'use strict'
 const forIncrement = (arr) => {
   for (let idx = 0, l = arr.length; idx < l; idx++) {

--- a/packages/http-multipart-body-parser/__tests__/index.js
+++ b/packages/http-multipart-body-parser/__tests__/index.js
@@ -224,7 +224,7 @@ test('It should parse an array from a multipart/form-data request with ASCII das
   }
   const response = await handler(event)
 
-  t.deepEqual(response, {PartName:'{"foo":"bar-"}'})
+  t.deepEqual(response, { PartName: '{"foo":"bar-"}' })
 })
 
 test('It should parse an array from a multipart/form-data request en dash (utf8)', async (t) => {
@@ -244,7 +244,7 @@ test('It should parse an array from a multipart/form-data request en dash (utf8)
   }
   const response = await handler(event)
 
-  t.deepEqual(response, {PartName:'{"foo":"bar–"}'})
+  t.deepEqual(response, { PartName: '{"foo":"bar–"}' })
 })
 
 test('It should parse a field with multiple files successfully', async (t) => {

--- a/packages/http-multipart-body-parser/index.js
+++ b/packages/http-multipart-body-parser/index.js
@@ -24,7 +24,7 @@ const httpMultipartBodyParserMiddleware = (opts = {}) => {
       .catch((e) => {
         const { createError } = require('@middy/util')
         // UnprocessableEntity
-        throw createError(422, 'Invalid or malformed multipart/form-data was provided - '+e.message)
+        throw createError(422, 'Invalid or malformed multipart/form-data was provided - ' + e.message)
       })
   }
 

--- a/packages/sqs-partial-batch-failure/index.js
+++ b/packages/sqs-partial-batch-failure/index.js
@@ -39,7 +39,7 @@ const sqsPartialBatchFailureMiddleware = (opts = {}) => {
 
     // deleteMessageBatch only supports 10 messages at a time
     // https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_DeleteMessageBatch.html
-    var i; var j; var chunk = 10
+    let i; let j; const chunk = 10
     for (i = 0, j = Entries.length; i < j; i += chunk) {
       const chunkedEntries = Entries.slice(i, i + chunk)
       promises.push(client.deleteMessageBatch({ Entries: chunkedEntries, QueueUrl }).promise())


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fix the lint issue which break the pipeline already (https://github.com/middyjs/middy/runs/4638685138?check_suite_focus=true)

Does this close any currently open issues?
------------------------------------------
No, but it will fix the pipeline "Lint" action.


Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Node.js Versions:** …

**Middy Versions:** …

**AWS SDK Versions:** …

Todo list
---------

[ ] Feature/Fix fully implemented
[ ] Added tests
[ ] Updated relevant documentation
[ ] Updated relevant examples
