### PR TITLE
fix: find case-insensitive content-type headers on body parser middle…

### DIFF
--- a/packages/http-json-body-parser/__tests__/index.js
+++ b/packages/http-json-body-parser/__tests__/index.js
@@ -87,6 +87,26 @@ test('It should parse a JSON request with lowercase header', async (t) => {
   t.deepEqual(body, { foo: 'bar' })
 })
 
+test('It should parse a JSON request with mixed-case header', async (t) => {
+  const handler = middy((event, context) => {
+    return event.body // propagates the body as a response
+  })
+
+  handler.use(jsonBodyParser())
+
+  // invokes the handler
+  const event = {
+    headers: {
+      'cOnTeNt-TyPe': 'application/json'
+    },
+    body: JSON.stringify({ foo: 'bar' })
+  }
+
+  const body = await handler(event)
+
+  t.deepEqual(body, { foo: 'bar' })
+})
+
 test('It should handle invalid JSON as an UnprocessableEntity', async (t) => {
   const handler = middy((event, context) => {
     return event.body // propagates the body as a response

--- a/packages/http-json-body-parser/index.js
+++ b/packages/http-json-body-parser/index.js
@@ -9,8 +9,8 @@ const httpJsonBodyParserMiddleware = (opts = {}) => {
   const httpJsonBodyParserMiddlewareBefore = async (request) => {
     const { headers, body } = request.event
 
-    const contentTypeHeader =
-      headers?.['Content-Type'] ?? headers?.['content-type']
+    const contentTypeHeaderName = Object.keys(headers || {}).find(header => header.toLowerCase() === 'content-type');
+    const contentTypeHeader = contentTypeHeaderName ? headers[contentTypeHeaderName] : undefined;
 
     if (mimePattern.test(contentTypeHeader)) {
       try {

--- a/packages/http-urlencode-body-parser/__tests__/index.js
+++ b/packages/http-urlencode-body-parser/__tests__/index.js
@@ -84,3 +84,22 @@ test('It should handle base64 body', async (t) => {
 
   t.deepEqual(body, { a: 'a', b: 'b' })
 })
+
+test('It should process the body if header name is mixed-case', async (t) => {
+  const handler = middy((event, context) => {
+    return event.body // propagates the body as a response
+  })
+
+  handler.use(urlEncodeBodyParser())
+
+  const event = {
+    headers: {
+      'cOnTeNt-TyPe': 'application/x-www-form-urlencoded; charset=UTF-8'
+    },
+    body: 'a=a&b=b'
+  }
+
+  const body = await handler(event)
+
+  t.deepEqual(body, { a: 'a', b: 'b' })
+})

--- a/packages/http-urlencode-body-parser/index.js
+++ b/packages/http-urlencode-body-parser/index.js
@@ -4,8 +4,9 @@ const mimePattern = /^application\/x-www-form-urlencoded(;.*)?$/
 
 const httpUrlencodeBodyParserMiddlewareBefore = async (request) => {
   const { headers, body } = request.event
-  const contentTypeHeader =
-    headers?.['Content-Type'] ?? headers?.['content-type']
+
+  const contentTypeHeaderName = Object.keys(headers || {}).find(header => header.toLowerCase() === 'content-type');
+  const contentTypeHeader = contentTypeHeaderName ? headers[contentTypeHeaderName] : undefined;
 
   if (mimePattern.test(contentTypeHeader)) {
     const data = request.event.isBase64Encoded


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Solves #767.

Does this close any currently open issues?
------------------------------------------

Solves #767.

Where has this been tested?
---------------------------
**Node.js Versions:** 14

**Middy Versions:** 2.5.4

Todo list
---------

- [X] Feature/Fix fully implemented
- [X] Added tests
