### PR TITLE
Add posibility to use ajv-errors without i18n

### DIFF
--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -57,7 +57,7 @@ npm install --save @middy/validator
    to validate the output (`request.response`) of the Lambda handler.
  - `ajvOptions` (object) (optional): Options to pass to [ajv](https://ajv.js.org/docs/api.html#options)
     class constructor. Defaults are `{ strict: true, coerceTypes: 'array', allErrors: true, useDefaults: 'empty', messages: false, defaultLanguage: 'en' }`.
-
+ - `i18nEnabled` (boolean) (optional): Option to disable i18n default package
 NOTES:
 - At least one of `inputSchema` or `outputSchema` is required.
 - **Important** Compiling schemas on the fly will cause a 50-100ms performance hit during cold start for simple JSON Schemas. Precompiling is highly recommended.

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -57,7 +57,7 @@ npm install --save @middy/validator
    to validate the output (`request.response`) of the Lambda handler.
  - `ajvOptions` (object) (optional): Options to pass to [ajv](https://ajv.js.org/docs/api.html#options)
     class constructor. Defaults are `{ strict: true, coerceTypes: 'array', allErrors: true, useDefaults: 'empty', messages: false, defaultLanguage: 'en' }`.
- - `i18nEnabled` (boolean) (optional): Option to disable i18n default package
+ - `i18nEnabled` (boolean) (optional): Option to disable i18n default package. Defaults to `true`
 NOTES:
 - At least one of `inputSchema` or `outputSchema` is required.
 - **Important** Compiling schemas on the fly will cause a 50-100ms performance hit during cold start for simple JSON Schemas. Precompiling is highly recommended.

--- a/packages/validator/__tests__/index.js
+++ b/packages/validator/__tests__/index.js
@@ -208,6 +208,54 @@ test('It should handle invalid schema as a BadRequest in a different language (w
   }
 })
 
+test('It should handle invalid schema as a BadRequest without i18n', async (t) => {
+  const handler = middy((event, context) => {
+    return event.body // propagates the body as a response
+  })
+
+  const schema = {
+    type: 'object',
+    required: ['body', 'foo'],
+    properties: {
+      // this will pass validation
+      body: {
+        type: 'string'
+      },
+      // this won't as it won't be in the event
+      foo: {
+        type: 'string'
+      }
+    }
+  }
+
+  handler.use(
+    validator({
+      inputSchema: schema,
+      isI18NEnabled: false
+    })
+  )
+
+  // invokes the handler, note that property foo is missing
+  const event = {
+    preferredLanguage: 'pt',
+    body: JSON.stringify({ something: 'somethingelse' })
+  }
+
+  try {
+    await handler(event)
+  } catch (err) {
+    t.is(err.message, 'Event object failed validation')
+    t.deepEqual(err.details, [
+      {
+        instancePath: '',
+        keyword: 'required',
+        params: { missingProperty: 'foo' },
+        schemaPath: '#/required'
+      }
+    ])
+  }
+})
+
 test('It should validate response', async (t) => {
   const expectedResponse = {
     body: 'Hello world',

--- a/packages/validator/__tests__/index.js
+++ b/packages/validator/__tests__/index.js
@@ -231,7 +231,7 @@ test('It should handle invalid schema as a BadRequest without i18n', async (t) =
   handler.use(
     validator({
       inputSchema: schema,
-      isI18NEnabled: false
+      i18nEnabled: false
     })
   )
 

--- a/packages/validator/index.d.ts
+++ b/packages/validator/index.d.ts
@@ -8,7 +8,7 @@ interface Options {
   ajvOptions?: Partial<AjvOptions>
   ajvInstance?: Ajv
   defaultLanguage?: string
-  isI18NEnabled?: boolean
+  i18nEnabled?: boolean
 }
 
 declare function validator (options?: Options): middy.MiddlewareObj

--- a/packages/validator/index.d.ts
+++ b/packages/validator/index.d.ts
@@ -8,6 +8,7 @@ interface Options {
   ajvOptions?: Partial<AjvOptions>
   ajvInstance?: Ajv
   defaultLanguage?: string
+  isI18NEnabled?: boolean
 }
 
 declare function validator (options?: Options): middy.MiddlewareObj

--- a/packages/validator/index.js
+++ b/packages/validator/index.js
@@ -21,7 +21,7 @@ const defaults = {
   ajvOptions: {},
   ajvInstance: undefined,
   defaultLanguage: 'en',
-  isI18NEnabled: true
+  i18nEnabled: true
 }
 
 const validatorMiddleware = (opts = {}) => {
@@ -31,7 +31,7 @@ const validatorMiddleware = (opts = {}) => {
     ajvOptions,
     ajvInstance,
     defaultLanguage,
-    isI18NEnabled
+    i18nEnabled
   } = { ...defaults, ...opts }
   inputSchema = compile(inputSchema, ajvOptions, ajvInstance)
   outputSchema = compile(outputSchema, ajvOptions, ajvInstance)
@@ -44,7 +44,7 @@ const validatorMiddleware = (opts = {}) => {
       const error = createError(400, 'Event object failed validation')
       request.event.headers = { ...request.event.headers }
 
-      if (isI18NEnabled) {
+      if (i18nEnabled) {
         const language = chooseLanguage(request.event, defaultLanguage)
         localize[language](inputSchema.errors)  
       }

--- a/packages/validator/index.js
+++ b/packages/validator/index.js
@@ -20,7 +20,8 @@ const defaults = {
   outputSchema: undefined,
   ajvOptions: {},
   ajvInstance: undefined,
-  defaultLanguage: 'en'
+  defaultLanguage: 'en',
+  isI18NEnabled: true
 }
 
 const validatorMiddleware = (opts = {}) => {
@@ -29,7 +30,8 @@ const validatorMiddleware = (opts = {}) => {
     outputSchema,
     ajvOptions,
     ajvInstance,
-    defaultLanguage
+    defaultLanguage,
+    isI18NEnabled
   } = { ...defaults, ...opts }
   inputSchema = compile(inputSchema, ajvOptions, ajvInstance)
   outputSchema = compile(outputSchema, ajvOptions, ajvInstance)
@@ -42,8 +44,10 @@ const validatorMiddleware = (opts = {}) => {
       const error = createError(400, 'Event object failed validation')
       request.event.headers = { ...request.event.headers }
 
-      const language = chooseLanguage(request.event, defaultLanguage)
-      localize[language](inputSchema.errors)
+      if (isI18NEnabled) {
+        const language = chooseLanguage(request.event, defaultLanguage)
+        localize[language](inputSchema.errors)  
+      }
 
       error.details = inputSchema.errors
       throw error

--- a/packages/validator/index.test-d.ts
+++ b/packages/validator/index.test-d.ts
@@ -18,6 +18,6 @@ middleware = validator({
   },
   ajvInstance: new Ajv(),
   defaultLanguage: 'en',
-  isI18NEnabled: false
+  i18nEnabled: false
 })
 expectType<middy.MiddlewareObj>(middleware)

--- a/packages/validator/index.test-d.ts
+++ b/packages/validator/index.test-d.ts
@@ -17,6 +17,7 @@ middleware = validator({
     strictTuples: true
   },
   ajvInstance: new Ajv(),
-  defaultLanguage: 'en'
+  defaultLanguage: 'en',
+  isI18NEnabled: false
 })
 expectType<middy.MiddlewareObj>(middleware)


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds a flag to disable localization. Must-have for ajv-errors working as-is from 1.x versions
Big codebases can have huge troubles to migrate from 1.x version to 2.x versions without such option

Does this close any currently open issues?
------------------------------------------
Not really, simple enhancement of the 2.x version to be more flexible 


Any relevant logs, error output, etc?
-------------------------------------
`"must pass \"errorMessage\" keyword validation"`
Message popping up with i18n enabled and attempt to use ajv-errors 

Where has this been tested?
---------------------------
**Node.js Versions:** 
14
**Middy Versions:** …
latest
**AWS SDK Versions:** …
latest


[ X ] Feature/Fix fully implemented
[ X ] Added tests
[ X ] Updated relevant documentation
[ X ] Updated relevant examples
