### PR TITLE
[#774] `@middy/http-cors` TypeScript getOrigin

### DIFF
--- a/packages/http-cors/index.d.ts
+++ b/packages/http-cors/index.d.ts
@@ -1,6 +1,7 @@
 import middy from '@middy/core'
 
-interface Options {
+export interface Options {
+  getOrigin?: (incomingOrigin: string, options: Options) => string;
   credentials?: boolean | string
   headers?: string
   methods?: string

--- a/packages/http-cors/index.test-d.ts
+++ b/packages/http-cors/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd'
 import middy from '@middy/core'
-import httpCors from '.'
+import httpCors, { Options } from '.'
 
 // use with default options
 let middleware = httpCors()
@@ -17,6 +17,9 @@ middleware = httpCors({
   maxAge: 600, // Access-Control-Max-Age
   requestHeaders: 'X-PINGOTHER, Content-Type', // Access-Control-Request-Headers
   requestMethods: 'POST', // Access-Control-Request-Methods
-  cacheControl: 'proxy-revalidate' // Cache-Control
+  cacheControl: 'proxy-revalidate', // Cache-Control,
+  getOrigin: (incomingOrigin: string, options: Options) => {
+    return "foo.bar.com"
+  }
 })
 expectType<middy.MiddlewareObj>(middleware)


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR adds the `getOrigin` option to the `index.d.ts` file, enabling the TypeScript applications to use the `getOrigin` option.

Does this close any currently open issues?
------------------------------------------
#774 

Where has this been tested?
---------------------------
**Node.js Versions:**

- v12.22.2

**Middy Versions:**

- v2.5.4

**AWS SDK Versions:**

- node14x Lambda runtime AWS SDK version.

Todo list
---------

[x] Feature/Fix fully implemented
[x] Added tests
[ ] Updated relevant documentation
[ ] Updated relevant examples
