### PR TITLE
v3: HTTP Router

### DIFF
--- a/docs/patterns/aws-alb-event.js
+++ b/docs/patterns/aws-alb-event.js
@@ -1,0 +1,96 @@
+/**
+ * Trigger Lambda from AWS Event
+ * Elastic Load Balancer: https://docs.aws.amazon.com/lambda/latest/dg/services-alb.html
+ **/
+const middy = require('@middy/core')
+const httpRouterHandler = require('@middy/http-router')
+const errorLoggerMiddleware = require('@middy/error-logger')
+const inputOutputLoggerMiddleware = require('@middy/input-output-logger')
+const httpContentNegotiationMiddleware = require('@middy/http-content-negotiation')
+const httpContentEncodingMiddleware = require('@middy/http-content-encoding')
+const httpCorsMiddleware = require('@middy/http-cors')
+const httpErrorHandlerMiddleware = require('@middy/http-error-handler')
+const httpEventNormalizerMiddleware = require('@middy/http-event-normalizer')
+const httpHeaderNormalizerMiddleware = require('@middy/http-header-normalizer')
+const httpJsonBodyParserMiddleware = require('@middy/http-json-body-parser')
+const httpMultipartBodyParserMiddleware = require('@middy/http-multipart-body-parser')
+const httpPartialResponseMiddleware = require('@middy/http-partial-response')
+const httpResponseSerializerMiddleware = require('@middy/http-response-serializer')
+const httpSecurityHeadersMiddleware = require('@middy/http-security-headers')
+const httpUrlencodeBodyParserMiddleware = require('@middy/http-urlencode-body-parser')
+const httpUrlencodePathParametersParserMiddleware = require('@middy/http-urlencode-path-parser')
+const validatorMiddleware = require('validator') // or `middy-ajv`
+const warmupMiddleware = require('warmup')
+
+const config = {
+  timeoutEarlyInMillis: 50,
+  timeoutEarlyResponse: () => {
+    return {
+      statusCode: 408
+    }
+  }
+}
+
+const getHandler = middy((event, context) => {
+  return {
+    statusCode: 200,
+    body: '{...}'
+  }
+}, config)
+  .use(validatorMiddleware({inputSchema: {} }))
+
+const postHandler = middy((event, context) => {
+  return {
+    statusCode: 200,
+    body: '{...}'
+  }
+}, config)
+  .use(validatorMiddleware({inputSchema: {} }))
+
+const routes = [{
+  method: 'GET',
+  path: '/user/{id}',
+  handler: getHandler
+},
+  {
+    method: 'POST',
+    path: '/user',
+    handler: postHandler
+  }]
+
+const handler = middy(httpRouterHandler(routes))
+  .use(errorLoggerMiddleware())
+  .use(warmupMiddleware())
+  .use(inputOutputLoggerMiddleware())
+  .use(httpEventNormalizerMiddleware())
+  .use(httpHeaderNormalizerMiddleware())
+  .use(
+    httpContentNegotiationMiddleware({
+      availableLanguages: ['en-CA', 'fr-CA'],
+      availableMediaTypes: ['application/json']
+    })
+  )
+  .use(httpUrlencodePathParametersParserMiddleware())
+  // Start oneOf
+  .use(httpUrlencodeBodyParserMiddleware())
+  .use(httpJsonBodyParserMiddleware())
+  .use(httpMultipartBodyParserMiddleware())
+  // End oneOf
+  .use(httpSecurityHeadersMiddleware())
+  .use(httpCorsMiddleware())
+  .use(httpContentEncodingMiddleware())
+  .use(
+    httpResponseSerializerMiddleware({
+      serializers: [
+        {
+          regex: /^application\/json$/,
+          serializer: ({ body }) => JSON.stringify(body)
+        }
+      ],
+      default: 'application/json'
+    })
+  )
+  .use(httpPartialResponseMiddleware())
+  .use(httpErrorHandlerMiddleware())
+
+module.exports = { handler }

--- a/docs/patterns/aws-alb-event.js
+++ b/docs/patterns/aws-alb-event.js
@@ -37,7 +37,7 @@ const getHandler = middy((event, context) => {
     body: '{...}'
   }
 }, config)
-  .use(validatorMiddleware({inputSchema: {} }))
+  .use(validatorMiddleware({ inputSchema: {} }))
 
 const postHandler = middy((event, context) => {
   return {
@@ -45,18 +45,18 @@ const postHandler = middy((event, context) => {
     body: '{...}'
   }
 }, config)
-  .use(validatorMiddleware({inputSchema: {} }))
+  .use(validatorMiddleware({ inputSchema: {} }))
 
 const routes = [{
   method: 'GET',
   path: '/user/{id}',
   handler: getHandler
 },
-  {
-    method: 'POST',
-    path: '/user',
-    handler: postHandler
-  }]
+{
+  method: 'POST',
+  path: '/user',
+  handler: postHandler
+}]
 
 const handler = middy(httpRouterHandler(routes))
   .use(errorLoggerMiddleware())

--- a/packages/http-router/README.md
+++ b/packages/http-router/README.md
@@ -38,7 +38,7 @@ npm install --save @middy/http-router
 ## Options
 - `routes` (array[{method, path, handler}]) (required): Array of route objects.
   - `method` (string) (required): One of `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS` and `ANY` that will match to any method passed in
-  - `path` (string) (required): AWS formatted path starting with `/`. Variable: `{id}`, Wildcard: `{proxy+}`
+  - `path` (string) (required): AWS formatted path starting with `/`. Variable: `/{id}/`, Wildcard: `/{proxy+}`
   - `handler` (function) (required): Any `handler(event, context)` function
   
 ## Sample usage

--- a/packages/http-router/README.md
+++ b/packages/http-router/README.md
@@ -1,0 +1,101 @@
+# Middy http-router lambda handler
+
+<div align="center">
+  <img alt="Middy logo" src="https://raw.githubusercontent.com/middyjs/middy/main/docs/img/middy-logo.png"/>
+</div>
+
+<div align="center">
+  <p><strong>HTTP router for the middy framework, the stylish Node.js middleware engine for AWS Lambda</strong></p>
+</div>
+
+<div align="center">
+<p>
+  <a href="http://badge.fury.io/js/%40middy%2Fhttp-router">
+    <img src="https://badge.fury.io/js/%40middy%2Fhttp-router.svg" alt="npm version" style="max-width:100%;">
+  </a>
+  <a href="https://snyk.io/test/github/middyjs/middy">
+    <img src="https://snyk.io/test/github/middyjs/middy/badge.svg" alt="Known Vulnerabilities" data-canonical-src="https://snyk.io/test/github/middyjs/middy" style="max-width:100%;">
+  </a>
+  <a href="https://standardjs.com/">
+    <img src="https://img.shields.io/badge/code_style-standard-brightgreen.svg" alt="Standard Code Style"  style="max-width:100%;">
+  </a>
+  <a href="https://gitter.im/middyjs/Lobby">
+    <img src="https://badges.gitter.im/gitterHQ/gitter.svg" alt="Chat on Gitter"  style="max-width:100%;">
+  </a>
+</p>
+</div>
+
+This handler can route to requests to one of a nested hander based on `method` and `path` of an http event from API Gateway (REST or HTTP) or Elastic Load Balancer.
+
+## Install
+
+To install this middleware you can use NPM:
+
+```bash
+npm install --save @middy/http-router
+```
+
+## Options
+- `routes` (array[{method, path, handler}]) (required): Array of route objects.
+  - `method` (string) (required): One of `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS` and `ANY` that will match to any method passed in
+  - `path` (string) (required): AWS formatted path starting with `/`. Variable: `{id}`, Wildcard: `{proxy+}`
+  - `handler` (function) (required): Any `handler(event, context)` function
+  
+## Sample usage
+
+```javascript
+import middy from '@middy/core'
+import validatorMiddleware from '@middy/validator'
+
+const getHandler = middy((event, context) => {
+  return {
+    statusCode: 200,
+    body: '{...}'
+  }
+})
+  .use(validatorMiddleware({inputSchema: {...} }))
+
+const postHandler = middy((event, context) => {
+  return {
+    statusCode: 200,
+    body: '{...}'
+  }
+})
+  .use(validatorMiddleware({inputSchema: {...} }))
+
+handler = middy(httpRouterHandler([
+  {
+    method: 'GET',
+    path: '/user/{id}',
+    handler: getHandler
+  },
+  {
+    method: 'POST',
+    path: '/user',
+    handler: postHandler
+  }
+]))
+  .use(httpHeaderNormalizer())
+  
+
+module.exports = { handler }
+```
+
+
+## Middy documentation and examples
+
+For more documentation and examples, refers to the main [Middy monorepo on GitHub](https://github.com/middyjs/middy) or [Middy official website](https://middy.js.org).
+
+
+## Contributing
+
+Everyone is very welcome to contribute to this repository. Feel free to [raise issues](https://github.com/middyjs/middy/issues) or to [submit Pull Requests](https://github.com/middyjs/middy/pulls).
+
+
+## License
+
+Licensed under [MIT License](LICENSE). Copyright (c) 2017-2022 Luciano Mammino, will Farrell, and the [Middy team](https://github.com/middyjs/middy/graphs/contributors).
+
+<a href="https://app.fossa.io/projects/git%2Bgithub.com%2Fmiddyjs%2Fmiddy?ref=badge_large">
+  <img src="https://app.fossa.io/api/projects/git%2Bgithub.com%2Fmiddyjs%2Fmiddy.svg?type=large" alt="FOSSA Status"  style="max-width:100%;">
+</a>

--- a/packages/http-router/__tests__/index.js
+++ b/packages/http-router/__tests__/index.js
@@ -191,7 +191,7 @@ test('It should route to a v2 event', async (t) => {
 })
 
 // with middleware
-test('It should run middleware that are part of path hander', async (t) => {
+test('It should run middleware that are part of route handler', async (t) => {
   const event = {
     httpMethod: 'GET',
     path: '/'

--- a/packages/http-router/__tests__/index.js
+++ b/packages/http-router/__tests__/index.js
@@ -101,7 +101,6 @@ test('It should thrown 404 when route not found', async (t) => {
     t.is(e.message, 'Route does not exist')
     t.is(e.statusCode, 404)
   }
-
 })
 
 // route methods
@@ -176,7 +175,7 @@ test('It should route to a v2 event', async (t) => {
     requestContext: {
       http: {
         method: 'GET',
-        path:'/'
+        path: '/'
       }
     }
   }
@@ -190,7 +189,6 @@ test('It should route to a v2 event', async (t) => {
   const response = await handler(event)
   t.true(response)
 })
-
 
 // with middleware
 test('It should run middleware that are part of path hander', async (t) => {
@@ -230,4 +228,3 @@ test('It should middleware part of router', async (t) => {
   const response = await handler(event)
   t.true(response)
 })
-

--- a/packages/http-router/__tests__/index.js
+++ b/packages/http-router/__tests__/index.js
@@ -1,0 +1,233 @@
+const test = require('ava')
+const middy = require('../../core/index.js')
+const httpRouter = require('../index.js')
+
+// Types of routes
+test('It should route to a static route', async (t) => {
+  const event = {
+    httpMethod: 'GET',
+    path: '/'
+  }
+  const handler = httpRouter([
+    {
+      method: 'GET',
+      path: '/',
+      handler: () => true
+    }
+  ])
+  const response = await handler(event)
+  t.true(response)
+})
+
+test('It should route to a dynamic route with `{variable}`', async (t) => {
+  const event = {
+    httpMethod: 'GET',
+    path: '/user/1'
+  }
+  const handler = httpRouter([
+    {
+      method: 'GET',
+      path: '/user/{id}/',
+      handler: () => true
+    }
+  ])
+  const response = await handler(event)
+  t.true(response)
+})
+
+test('It should route to a dynamic route (/) with `{proxy+}`', async (t) => {
+  const event = {
+    httpMethod: 'GET',
+    path: '/any'
+  }
+  const handler = httpRouter([
+    {
+      method: 'GET',
+      path: '/{proxy+}',
+      handler: () => true
+    }
+  ])
+  const response = await handler(event)
+  t.true(response)
+})
+
+test('It should route to a dynamic route (/path) with `{proxy+}`', async (t) => {
+  const event = {
+    httpMethod: 'GET',
+    path: '/path'
+  }
+  const handler = httpRouter([
+    {
+      method: 'GET',
+      path: '/path/{proxy+}',
+      handler: () => true
+    }
+  ])
+  const response = await handler(event)
+  t.true(response)
+})
+
+test('It should route to a dynamic route (/path/to) with `{proxy+}`', async (t) => {
+  const event = {
+    httpMethod: 'GET',
+    path: '/path/to'
+  }
+  const handler = httpRouter([
+    {
+      method: 'GET',
+      path: '/path/{proxy+}',
+      handler: () => true
+    }
+  ])
+  const response = await handler(event)
+  t.true(response)
+})
+
+test('It should thrown 404 when route not found', async (t) => {
+  const event = {
+    httpMethod: 'GET',
+    path: '/notfound'
+  }
+  const handler = httpRouter([
+    {
+      method: 'GET',
+      path: '/',
+      handler: () => true
+    }
+  ])
+  try {
+    await handler(event)
+  } catch (e) {
+    t.is(e.message, 'Route does not exist')
+    t.is(e.statusCode, 404)
+  }
+
+})
+
+// route methods
+test('It should route to a static POST method', async (t) => {
+  const event = {
+    httpMethod: 'POST',
+    path: '/'
+  }
+  const handler = httpRouter([
+    {
+      method: 'POST',
+      path: '/',
+      handler: () => true
+    }
+  ])
+  const response = await handler(event)
+  t.true(response)
+})
+
+test('It should route to a static ANY method', async (t) => {
+  const event = {
+    httpMethod: 'POST',
+    path: '/'
+  }
+  const handler = httpRouter([
+    {
+      method: 'ANY',
+      path: '/',
+      handler: () => true
+    }
+  ])
+  const response = await handler(event)
+  t.true(response)
+})
+
+test('It should route to a dynamic POST method', async (t) => {
+  const event = {
+    httpMethod: 'POST',
+    path: '/user/1'
+  }
+  const handler = httpRouter([
+    {
+      method: 'POST',
+      path: '/user/{id}',
+      handler: () => true
+    }
+  ])
+  const response = await handler(event)
+  t.true(response)
+})
+
+test('It should route to a dynamic ANY method', async (t) => {
+  const event = {
+    httpMethod: 'GET',
+    path: '/user/1'
+  }
+  const handler = httpRouter([
+    {
+      method: 'ANY',
+      path: '/user/{id}',
+      handler: () => true
+    }
+  ])
+  const response = await handler(event)
+  t.true(response)
+})
+
+// event versions
+test('It should route to a v2 event', async (t) => {
+  const event = {
+    version: '2.0',
+    requestContext: {
+      http: {
+        method: 'GET',
+        path:'/'
+      }
+    }
+  }
+  const handler = httpRouter([
+    {
+      method: 'GET',
+      path: '/',
+      handler: () => true
+    }
+  ])
+  const response = await handler(event)
+  t.true(response)
+})
+
+
+// with middleware
+test('It should run middleware that are part of path hander', async (t) => {
+  const event = {
+    httpMethod: 'GET',
+    path: '/'
+  }
+  const handler = httpRouter([
+    {
+      method: 'GET',
+      path: '/',
+      handler: middy(() => false)
+        .after((request) => {
+          request.response = true
+        })
+    }
+  ])
+  const response = await handler(event)
+  t.true(response)
+})
+
+test('It should middleware part of router', async (t) => {
+  const event = {
+    httpMethod: 'GET',
+    path: '/'
+  }
+  const handler = middy(httpRouter([
+    {
+      method: 'GET',
+      path: '/',
+      handler: () => false
+    }
+  ]))
+    .after((request) => {
+      request.response = true
+    })
+  const response = await handler(event)
+  t.true(response)
+})
+

--- a/packages/http-router/index.d.ts
+++ b/packages/http-router/index.d.ts
@@ -1,4 +1,4 @@
-//import middy from '@middy/core'
+// import middy from '@middy/core'
 
 declare function httpRouterHandler (): any
 

--- a/packages/http-router/index.d.ts
+++ b/packages/http-router/index.d.ts
@@ -1,0 +1,5 @@
+//import middy from '@middy/core'
+
+declare function httpRouterHandler (): any
+
+export default httpRouterHandler

--- a/packages/http-router/index.js
+++ b/packages/http-router/index.js
@@ -7,6 +7,10 @@ const httpRouteHandler = (routes) => {
   for (const route of routes) {
     let { method, path, handler } = route
 
+    if (!methods.concat('ANY').includes(method)) {
+      throw new Error('method not allowed')
+    }
+
     // remove trailing slash, but not if it's the first one
     if (path.endsWith('/') && path !== '/') {
       path = path.substr(0, path.length - 1)
@@ -46,7 +50,7 @@ const httpRouteHandler = (routes) => {
   }
 }
 
-const regexpDynamicParameters = /\{.+\}/g
+const regexpDynamicParameters = /\/\{.+\}\//g
 const methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS']
 
 const attachStaticRoute = (method, path, handler, routesType) => {
@@ -59,7 +63,7 @@ const attachStaticRoute = (method, path, handler, routesType) => {
   if (!routesType[method]) {
     routesType[method] = {}
   }
-  routesType[method][path] = handler
+  routesType[method][path] = handler // This assignment may alter Object.prototype if a malicious '__proto__' string is injected from library input.
 }
 
 const attachDynamicRoute = (method, path, handler, routesType) => {
@@ -73,8 +77,8 @@ const attachDynamicRoute = (method, path, handler, routesType) => {
     routesType[method] = []
   }
   path = path
-    .replaceAll('{proxy+}', '?.*') // ? for previous `/` to make it optional
-    .replace(regexpDynamicParameters, '.+')
+    .replaceAll('/{proxy+}', '/?.*')
+    .replace(regexpDynamicParameters, '/.+/')
   path = new RegExp(`^${path}$`)
   routesType[method].push({ path, handler })
 }

--- a/packages/http-router/index.js
+++ b/packages/http-router/index.js
@@ -50,7 +50,7 @@ const httpRouteHandler = (routes) => {
   }
 }
 
-const regexpDynamicParameters = /\/\{.+\}\//g
+const regexpDynamicParameters = /\/\{.+\}/g
 const methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS']
 
 const attachStaticRoute = (method, path, handler, routesType) => {
@@ -78,7 +78,7 @@ const attachDynamicRoute = (method, path, handler, routesType) => {
   }
   path = path
     .replaceAll('/{proxy+}', '/?.*')
-    .replace(regexpDynamicParameters, '/.+/')
+    .replace(regexpDynamicParameters, '/.+')
   path = new RegExp(`^${path}$`)
   routesType[method].push({ path, handler })
 }

--- a/packages/http-router/index.js
+++ b/packages/http-router/index.js
@@ -4,10 +4,12 @@ const { createError } = require('@middy/util')
 const httpRouteHandler = (routes) => {
   const routesStatic = {}
   const routesDynamic = {}
+  const enumMethods = methods.concat('ANY')
   for (const route of routes) {
     let { method, path, handler } = route
 
-    if (!methods.concat('ANY').includes(method)) {
+    // Prevents `routesType[method][path] = handler` from flagging: This assignment may alter Object.prototype if a malicious '__proto__' string is injected from library input.
+    if (!enumMethods.includes(method)) {
       throw new Error('method not allowed')
     }
 
@@ -63,7 +65,7 @@ const attachStaticRoute = (method, path, handler, routesType) => {
   if (!routesType[method]) {
     routesType[method] = {}
   }
-  routesType[method][path] = handler // This assignment may alter Object.prototype if a malicious '__proto__' string is injected from library input.
+  routesType[method][path] = handler
 }
 
 const attachDynamicRoute = (method, path, handler, routesType) => {

--- a/packages/http-router/index.js
+++ b/packages/http-router/index.js
@@ -52,6 +52,7 @@ const httpRouteHandler = (routes) => {
   }
 }
 
+const regexpDynamicWildcards = /\/\{proxy\+\}/g
 const regexpDynamicParameters = /\/\{.+\}/g
 const methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS']
 
@@ -79,7 +80,7 @@ const attachDynamicRoute = (method, path, handler, routesType) => {
     routesType[method] = []
   }
   path = path
-    .replaceAll('/{proxy+}', '/?.*')
+    .replace(regexpDynamicWildcards, '/?.*') // TODO update ot replaceAll for v4
     .replace(regexpDynamicParameters, '/.+')
   path = new RegExp(`^${path}$`)
   routesType[method].push({ path, handler })

--- a/packages/http-router/index.js
+++ b/packages/http-router/index.js
@@ -1,0 +1,94 @@
+// import { createError } from '@middy/util'
+const { createError } = require('@middy/util')
+
+const httpRouteHandler = (routes) => {
+  const routesStatic = {}
+  const routesDynamic = {}
+  for (const route of routes) {
+    let { method, path, handler } = route
+
+    // remove trailing slash, but not if it's the first one
+    if (path.endsWith('/') && path !== '/') {
+      path = path.substr(0, path.length - 1)
+    }
+
+    // Static
+    if (path.indexOf('{') < 0) {
+      attachStaticRoute(method, path, handler, routesStatic)
+      continue
+    }
+
+    // Dynamic
+    attachDynamicRoute(method, path, handler, routesDynamic)
+  }
+
+  return (event, context) => {
+    const { method, path } = getVersionRoute[event.version ?? '1.0']?.(event)
+    if (!method) {
+      throw new Error('Unknown API Gateway Payload format')
+    }
+
+    // Static
+    const handler = routesStatic[method]?.[path]
+    if (handler !== undefined) {
+      return handler(event, context)
+    }
+
+    // Dynamic
+    for (const route of routesDynamic[method] ?? []) {
+      if (route.path.test(path)) {
+        return route.handler(event, context)
+      }
+    }
+
+    // Not Found
+    throw createError(404, 'Route does not exist')
+  }
+}
+
+const regexpDynamicParameters = /\{.+\}/g
+const methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS']
+
+const attachStaticRoute = (method, path, handler, routesType) => {
+  if (method === 'ANY') {
+    for (const method of methods) {
+      attachStaticRoute(method, path, handler, routesType)
+    }
+    return
+  }
+  if (!routesType[method]) {
+    routesType[method] = {}
+  }
+  routesType[method][path] = handler
+}
+
+const attachDynamicRoute = (method, path, handler, routesType) => {
+  if (method === 'ANY') {
+    for (const method of methods) {
+      attachDynamicRoute(method, path, handler, routesType)
+    }
+    return
+  }
+  if (!routesType[method]) {
+    routesType[method] = []
+  }
+  path = path
+    .replaceAll('{proxy+}', '?.*') // ? for previous `/` to make it optional
+    .replace(regexpDynamicParameters, '.+')
+  path = new RegExp(`^${path}$`)
+  routesType[method].push({ path, handler })
+}
+
+const getVersionRoute = {
+  '1.0': (event) => ({
+    method: event.httpMethod,
+    path: event.path
+  }),
+  '2.0': (event) => ({
+    method: event.requestContext.http.method,
+    path: event.requestContext.http.path
+  })
+}
+
+// export default httpRouteHandler
+module.exports = httpRouteHandler

--- a/packages/http-router/index.test-d.ts
+++ b/packages/http-router/index.test-d.ts
@@ -1,7 +1,6 @@
 import { expectType } from 'tsd'
-//import middy from '@middy/core'
-import httpRouterHandler from ".";
+// import middy from '@middy/core'
+import httpRouterHandler from '.'
 
-let middleware = httpRouterHandler()
+const middleware = httpRouterHandler()
 expectType<any>(middleware)
-

--- a/packages/http-router/index.test-d.ts
+++ b/packages/http-router/index.test-d.ts
@@ -1,0 +1,7 @@
+import { expectType } from 'tsd'
+//import middy from '@middy/core'
+import httpRouterHandler from ".";
+
+let middleware = httpRouterHandler()
+expectType<any>(middleware)
+

--- a/packages/http-router/package.json
+++ b/packages/http-router/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@middy/http-router",
+  "version": "2.5.4",
+  "description": "http event router for the middy framework",
+  "type": "commonjs",
+  "engines": {
+    "node": ">=14"
+  },
+  "engineStrict": true,
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "index.js",
+  "types": "index.d.ts",
+  "files": [
+    "index.d.ts"
+  ],
+  "scripts": {
+    "test": "npm run test:unit",
+    "test:unit": "ava"
+  },
+  "license": "MIT",
+  "keywords": [
+    "Lambda",
+    "Middleware",
+    "Serverless",
+    "Framework",
+    "AWS",
+    "AWS Lambda",
+    "Middy",
+    "HTTP",
+    "API",
+    "Urlencode",
+    "Body Parser"
+  ],
+  "author": {
+    "name": "Middy contributors",
+    "url": "https://github.com/middyjs/middy/graphs/contributors"
+  },
+  "repository": {
+    "type": "git",
+    "url": "github:middyjs/middy",
+    "directory": "packages/http-router"
+  },
+  "bugs": {
+    "url": "https://github.com/middyjs/middy/issues"
+  },
+  "homepage": "https://github.com/middyjs/middy#readme",
+  "dependencies": {
+    "@middy/util": "2.5.4"
+  },
+  "devDependencies": {
+    "@middy/core": "^2.5.4"
+  },
+  "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"
+}


### PR DESCRIPTION
## Supports
- All methods & `ANY`
- pathParameters (`/{id}`)
- wildcards (`/{proxy+}`)
- no 3rd party dependencies
- stupid fast, no seriously

```
# https://github.com/delvedor/router-benchmark
=======================
 find-my-way benchmark (used by fastify & restify)
=======================
short static: 15,692,685 ops/sec
static with same radix: 5,149,892 ops/sec
dynamic route: 2,255,178 ops/sec
mixed static dynamic: 2,821,514 ops/sec
long static: 6,370,850 ops/sec
wildcard: 3,677,858 ops/sec
all together: 642,840 ops/sec

==============================
 @middy/http-router benchmark
==============================
short static: 32,834,799 ops/sec
static with same radix: 37,876,469 ops/sec
dynamic route: 15,235,551 ops/sec
mixed static dynamic: 9,714,873 ops/sec
long static: 39,087,567 ops/sec
wildcard: 6,236,354 ops/sec
all together: 2,406,433 ops/sec
```

## TODO
- [ ] change name to `http-route-handler`?
- [ ] esm (after v3-alpha released)
- [ ] update to use `.handler()`? Will makes easier to understand what is going on

Closes: #596