### PR TITLE
fix: add types for non-callback use case

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -39,8 +39,10 @@ export interface MiddlewareObj<TEvent = any, TResult = any, TErr = Error, TConte
 // The AWS provided Handler type uses void | Promise<TResult> so we have no choice but to follow and suppress the linter warning
 // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 type MiddyInputHandler<TEvent, TResult, TContext extends LambdaContext = LambdaContext> = (event: TEvent, context: TContext, callback: LambdaCallback<TResult>) => void | Promise<TResult>
+type MiddyInputPromiseHandler<TEvent, TResult, TContext extends LambdaContext = LambdaContext> = ( event: TEvent, context: TContext, ) => Promise<TResult>;
 
-export interface MiddyfiedHandler<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> extends MiddyInputHandler<TEvent, TResult, TContext> {
+export interface MiddyfiedHandler<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> extends MiddyInputHandler<TEvent, TResult, TContext>,
+MiddyInputPromiseHandler<TEvent, TResult, TContext> {
   use: UseFn<TEvent, TResult, TErr, TContext>
   applyMiddleware: AttachMiddlewareObj<TEvent, TResult, TErr, TContext>
   before: AttachMiddlewareFn<TEvent, TResult, TErr, TContext>


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes typescript error when not using the lambda callback pattern in a handler. Adds an extra type `MiddyInputPromiseHandler` for non-callback use case and adds that to the `MiddyfiedHandler` type. 

Does this close any currently open issues?
------------------------------------------
#738 


Where has this been tested?
---------------------------
**Node.js Versions:** 
- 14.18.2

**Middy Versions:**
- 2.5.4

**AWS SDK Versions:**
- node14x Lambda runtime AWS SDK version.

Todo list
---------

[x] Feature/Fix fully implemented
[ ] Added tests
[ ] Updated relevant documentation
[ ] Updated relevant examples
