### PR TITLE
Inaccurate return type for middy

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -69,7 +69,7 @@ declare type MiddlewareHandler<THandler extends LambdaHandler<any, any>, TContex
  * @param handler your original AWS Lambda function
  * @param plugin wraps around each middleware and handler to add custom lifecycle behaviours (e.g. to profile performance)
  */
-declare function middy<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> (handler?: MiddlewareHandler<LambdaHandler<TEvent, TResult>, TContext>, plugin?: PluginObject): MiddyfiedHandler<TEvent, TResult, TErr, TContext>
+declare function middy<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> (handler?: MiddlewareHandler<LambdaHandler<TEvent, TResult>, TContext>, plugin?: PluginObject): MiddyfiedHandler<any, TResult, TErr, any>
 
 declare namespace middy {
   export {


### PR DESCRIPTION
Even though we can set custom event and context types for our handler, AWS will still send (potentially) different data at runtime and we can't guarantee what they'll send.

Meaning that we cannot assume that the returned handler still accepts the custom event and context that we've given to the original `handler`.

```ts
import { Handler } from 'aws-lambda';

const handler: Handler<{ x: 5 }> = ({ x }) => ({ statusCode: 200, body: String(x + 1) })

const middlewarizedHandler = middy(handler);
//    ^^^^^^^^^^^^^^^^^^^^ this handler
// it can't expect an event that has a property x 
// and that that property has a value of 5
```

Right now the type of `middlewarizedHandler` would be `middy.MiddyfiedHandler<{ x: 5 }, any, Error, Context>` but it should probably be something like `middy.MiddyfiedHandler<any, any, Error, Context>`.

AWS can invoke the `middlewarizedHandler` without `x` but the types won't let that happen at dev time. 

```ts
middlewarizedHandler({}, {}, () => {});
// Argument of type '{}' is not assignable to parameter of type '{ x: 5; }'.
//  Property 'x' is missing in type '{}' but required in type '{ x: 5; }'.(2345)
//  input.tsx(4, 26): 'x' is declared here.
```

[Here's a quick TS playground to demonstrate the issue
](https://www.typescriptlang.org/play?ssl=9&ssc=1&pln=9&pc=39#code/JYWwDg9gTgLgBCYATJBPOAzKERwOQACiKqA9AMbQCmeA3AFCiSxwDecAEgIYB2SANlShwAvpmy48XAO4BnALT8uIAEZIudevUo9Z8ABa8BQgFycjgqAB52ADzMBWUQD44AXjhdZqHuTgAKO1EASndXQLg9LhgAV1kAYQgkKjMAJgAGdIAaOBUk1DMAZRgoYB4Ac39bOABqOABGUJFgrR09BGRjaS5SgC8qJG4+S3cOkn9DYaFghlJSOAW4AD0V1bX19bh6ObgYfWBZTBjfGGAIHjhyXjx4KlswKnJ4XjgqADcqHng96LhDQ64cDA2AesHQ1SMu0M32hQJBQhg6H+njgby4-BiVDgEAwcAc9GIXR6wH6gwsQkCIhyrCpAVCblcNOCQA)