### PR TITLE
Fix: possible to omit paths on already stringified object from request/response

### DIFF
--- a/packages/input-output-logger/__tests__/index.js
+++ b/packages/input-output-logger/__tests__/index.js
@@ -56,6 +56,36 @@ test('It should omit paths', async (t) => {
 
   t.deepEqual(response, { message: 'hello world', bar: 'bi' })
 })
+
+test('It should omit paths and not stringify twice an existed stringify object', async (t) => {
+  const logger = sinon.spy()
+
+  const handler = middy((event, context) => {
+    return {
+      message: 'hello world',
+      bar: JSON.stringify({ fuu: 'bur', duu: 'bir' })
+    }
+  })
+
+  handler.use(
+    inputOutputLogger({ logger, omitPaths: ['event.foo', 'response.bar.fuu'] })
+  )
+
+  const response = await handler({ foo: 'bar', fuu: 'baz' })
+  t.log(logger)
+  t.true(logger.calledWith({ event: { fuu: 'baz' } }))
+  t.true(
+    logger.calledWith({
+      response: { message: 'hello world', bar: { duu: 'bir' } }
+    })
+  )
+
+  t.deepEqual(response, {
+    message: 'hello world',
+    bar: JSON.stringify({ fuu: 'bur', duu: 'bir' })
+  })
+})
+
 test('It should skip paths that do not exist', async (t) => {
   const logger = sinon.spy()
 

--- a/packages/input-output-logger/index.js
+++ b/packages/input-output-logger/index.js
@@ -1,4 +1,3 @@
-
 const defaults = {
   logger: (data) => console.log(JSON.stringify(data, null, 2)),
   awsContext: false,
@@ -16,7 +15,10 @@ const inputOutputLoggerMiddleware = (opts = {}) => {
     if (awsContext) {
       message.context = pick(request.context, awsContextKeys)
     }
-    const redactedMessage = omit(JSON.parse(JSON.stringify(message)), omitPaths) // Full clone to prevent nested mutations
+    const redactedMessage = omit(
+      JSON.parse(JSON.stringify(message, replaceStringifyObjectValue)),
+      omitPaths
+    ) // Full clone to prevent nested mutations
     logger(redactedMessage)
   }
 
@@ -74,6 +76,15 @@ const deleteKey = (obj, key) => {
     delete obj[rootKey]
   }
   return obj
+}
+
+const replaceStringifyObjectValue = (key, value) => {
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value)
+    } catch (e) {}
+  }
+  return value
 }
 
 module.exports = inputOutputLoggerMiddleware

--- a/packages/input-output-logger/index.js
+++ b/packages/input-output-logger/index.js
@@ -1,3 +1,5 @@
+const { jsonSafeParse } = require('@middy/util')
+
 const defaults = {
   logger: (data) => console.log(JSON.stringify(data, null, 2)),
   awsContext: false,
@@ -16,7 +18,9 @@ const inputOutputLoggerMiddleware = (opts = {}) => {
       message.context = pick(request.context, awsContextKeys)
     }
     const redactedMessage = omit(
-      JSON.parse(JSON.stringify(message, replaceStringifyObjectValue)),
+      JSON.parse(
+        JSON.stringify(message, (key, value) => jsonSafeParse(value))
+      ),
       omitPaths
     ) // Full clone to prevent nested mutations
     logger(redactedMessage)
@@ -76,15 +80,6 @@ const deleteKey = (obj, key) => {
     delete obj[rootKey]
   }
   return obj
-}
-
-const replaceStringifyObjectValue = (key, value) => {
-  if (typeof value === 'string') {
-    try {
-      return JSON.parse(value)
-    } catch (e) {}
-  }
-  return value
 }
 
 module.exports = inputOutputLoggerMiddleware

--- a/packages/input-output-logger/package-lock.json
+++ b/packages/input-output-logger/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@middy/input-output-logger",
       "version": "2.5.4",
       "license": "MIT",
+      "dependencies": {
+        "@middy/util": "^2.5.4"
+      },
       "devDependencies": {
         "@middy/core": "^2.5.4",
         "@types/node": "^17.0.0"
@@ -25,6 +28,14 @@
         "node": ">=12"
       }
     },
+    "node_modules/@middy/util": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@middy/util/-/util-2.5.4.tgz",
+      "integrity": "sha512-/715LFKuz3EAao+e+4eWjO0fpJbtFjXAAA6nVcShnFKaU/s+P5qqRD9X8+iU+R1q7uFidd4eWnDhmpqJ43ZY8A==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@types/node": {
       "version": "17.0.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
@@ -38,6 +49,11 @@
       "resolved": "https://registry.npmjs.org/@middy/core/-/core-2.5.4.tgz",
       "integrity": "sha512-WQFUFhCG0P2rmNDBX8x5RiREfSUnMhq77QyrwIZg2/gLUhuOZa8TPFFKzIFBz+blvw9Ep41LRrWdV/gzYwMuww==",
       "dev": true
+    },
+    "@middy/util": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@middy/util/-/util-2.5.4.tgz",
+      "integrity": "sha512-/715LFKuz3EAao+e+4eWjO0fpJbtFjXAAA6nVcShnFKaU/s+P5qqRD9X8+iU+R1q7uFidd4eWnDhmpqJ43ZY8A=="
     },
     "@types/node": {
       "version": "17.0.8",

--- a/packages/input-output-logger/package.json
+++ b/packages/input-output-logger/package.json
@@ -49,5 +49,8 @@
     "@middy/core": "^2.5.4",
     "@types/node": "^17.0.0"
   },
-  "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"
+  "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431",
+  "dependencies": {
+    "@middy/util": "^2.5.4"
+  }
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
The fix allows parsing objects previously stringify in the response object onto `omitPaths` option input/output middleware. 
For this, a new function named `replaceStringifyObjectValue` was created, which try to parse a value if it is a string. This function is called in the replacer option of JSON.Stringify() just before building a logger message

Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, etc?
-------------------------------------
The problem was spotted when we wanted to omit the values body of an HTTP endpoint but there already stringified so it is not possible to omit them. 
Please look at the added test, It is normally quite understandable, thanks!

Any other comments?
-------------------
No

Where has this been tested?
---------------------------
**Node.js Versions:** v14.17.6

**Middy Versions:** v2.5.2

**AWS SDK Versions:** v2.897.0

Todo list
---------

[✅] Feature/Fix fully implemented
[✅] Added tests
[❌] Updated relevant documentation
[❌] Updated relevant examples
