### PR TITLE
SSM module / Fix object like values failing to set into the env

### DIFF
--- a/packages/ssm/README.md
+++ b/packages/ssm/README.md
@@ -35,7 +35,6 @@ The Middleware makes a single API request to fetch all the parameters defined by
 
 For each parameter defined by name, you also provide the name under which its value should be added to `process.env` or `context`. For each path, you instead provide a prefix, and by default the value import each parameter returned from that path will be added to `process.env` or `context` with a name equal to what's left of the parameter's full name _after_ the defined path, with the prefix prepended. If the prefix is an empty string, nothing is prepended. You can override this behaviour by providing your own mapping function with the `getParamNameFromPath` config option.
 
-
 ## Install
 
 To install this middleware you can use NPM:
@@ -43,7 +42,6 @@ To install this middleware you can use NPM:
 ```bash
 npm install --save @middy/ssm
 ```
-
 
 ## Options
 
@@ -55,14 +53,16 @@ npm install --save @middy/ssm
 - `disablePrefetch` (boolean) (default `false`): On cold start requests will trigger early if they can. Setting `awsClientAssumeRole` disables prefetch.
 - `cacheKey` (string) (default `ssm`): Cache key for the fetched data responses. Must be unique across all middleware.
 - `cacheExpiry` (number) (default `-1`): How long fetch data responses should be cached for. `-1`: cache forever, `0`: never cache, `n`: cache for n ms.
-- `setToEnv` (boolean) (default `false`): Store role tokens to `process.env`. **Storing secrets in `process.env` is considered security bad practice**
+- `setToEnv` (boolean) (default `false`): Store role tokens to `process.env`. **Storing secrets in `process.env` is considered security bad practice**. Parsing object like values are not working correctly
 - `setToContext` (boolean) (default `false`): Store role tokens to `request.context`.
 
 NOTES:
+
 - Lambda is required to have IAM permission for `ssm:GetParameters` and/or `ssm:GetParametersByPath` depending on what you're requesting.
 - `SSM` has [throughput limitations](https://docs.aws.amazon.com/general/latest/gr/ssm.html). Switching to Advanced Parameter type or increasing `maxRetries` and `retryDelayOptions.base` in `awsClientOptions` may be required.
 - `setToEnv` and `setToContext` are included for legacy support and should be avoided for performance and security reasons. See main documentation for best practices.
 - `setToEnv` can only assign secrets of type string
+- `shouldParseValues` default to true.
 
 ## Sample usage
 
@@ -76,14 +76,16 @@ const handler = middy((event, context) => {
 
 let globalDefaults = {}
 handler
-  .use(ssm({
-    fetchData: {
-      accessToken: '/dev/service_name/access_token',  // single value
-      dbParams: '/dev/service_name/database/',        // object of values, key for each path
-      defaults: '/dev/defaults'
-    },
-    setToContext: true
-  }))
+  .use(
+    ssm({
+      fetchData: {
+        accessToken: '/dev/service_name/access_token', // single value
+        dbParams: '/dev/service_name/database/', // object of values, key for each path
+        defaults: '/dev/defaults'
+      },
+      setToContext: true
+    })
+  )
   .before((request) => {
     globalDefaults = request.context.defaults.global
   })
@@ -91,7 +93,7 @@ handler
 
 ```javascript
 import middy from '@middy/core'
-import {getInternal} from '@middy/util'
+import { getInternal } from '@middy/util'
 import ssm from '@middy/ssm'
 
 const handler = middy((event, context) => {
@@ -100,37 +102,41 @@ const handler = middy((event, context) => {
 
 let globalDefaults = {}
 handler
-  .use(ssm({
-    fetchData: {
-      defaults: '/dev/defaults'
-    },
-    cacheKey: 'ssm-defaults'
-  }))
-  .use(ssm({
-    fetchData: {
-      accessToken: '/dev/service_name/access_token',  // single value
-      dbParams: '/dev/service_name/database/',        // object of values, key for each path
-    },
-    cacheExpiry: 15*60*1000,
-    cacheKey: 'ssm-secrets'
-  }))
+  .use(
+    ssm({
+      fetchData: {
+        defaults: '/dev/defaults'
+      },
+      cacheKey: 'ssm-defaults'
+    })
+  )
+  .use(
+    ssm({
+      fetchData: {
+        accessToken: '/dev/service_name/access_token', // single value
+        dbParams: '/dev/service_name/database/' // object of values, key for each path
+      },
+      cacheExpiry: 15 * 60 * 1000,
+      cacheKey: 'ssm-secrets'
+    })
+  )
   // ... other middleware that fetch
   .before(async (request) => {
-    const data = await getInternal(['accessToken','dbParams','defaults'], request)
+    const data = await getInternal(
+      ['accessToken', 'dbParams', 'defaults'],
+      request
+    )
     Object.assign(request.context, data)
   })
 ```
-
 
 ## Middy documentation and examples
 
 For more documentation and examples, refers to the main [Middy monorepo on GitHub](https://github.com/middyjs/middy) or [Middy official website](https://middy.js.org).
 
-
 ## Contributing
 
 Everyone is very welcome to contribute to this repository. Feel free to [raise issues](https://github.com/middyjs/middy/issues) or to [submit Pull Requests](https://github.com/middyjs/middy/pulls).
-
 
 ## License
 

--- a/packages/ssm/__tests__/index.js
+++ b/packages/ssm/__tests__/index.js
@@ -216,7 +216,7 @@ test.serial('It should set SSM param value to process.env', async (t) => {
 
 test.serial('It should set SSM param object-like value to process.env', async (t) => {
   mockService(SSM, {
-    Parameters: [{ Name: '/dev/service_name/key_name', Value: '{"a": 1}' }]
+    Parameters: [{ Name: '/dev/service_name/object-key', Value: '{"a": 1}' }]
   })
 
   const handler = middy(() => { })
@@ -230,7 +230,7 @@ test.serial('It should set SSM param object-like value to process.env', async (t
       ssm({
         AwsClient: SSM,
         fetchData: {
-          objectLikeKey: '/dev/service_name/key_name'
+          objectLikeKey: '/dev/service_name/object-key'
         },
         setToEnv: true
       })

--- a/packages/ssm/__tests__/index.js
+++ b/packages/ssm/__tests__/index.js
@@ -232,7 +232,8 @@ test.serial('It should set SSM param object-like value to process.env', async (t
         fetchData: {
           objectLikeKey: '/dev/service_name/object-key'
         },
-        setToEnv: true
+        setToEnv: true,
+        shouldParseValues: false
       })
     )
     .before(middleware)

--- a/packages/ssm/__tests__/index.js
+++ b/packages/ssm/__tests__/index.js
@@ -214,6 +214,32 @@ test.serial('It should set SSM param value to process.env', async (t) => {
   await handler()
 })
 
+test.serial('It should set SSM param object-like value to process.env', async (t) => {
+  mockService(SSM, {
+    Parameters: [{ Name: '/dev/service_name/key_name', Value: '{"a": 1}' }]
+  })
+
+  const handler = middy(() => {})
+
+  const middleware = async () => {
+    t.is(process.env.objectLikeKey, 'key-value')
+  }
+
+  handler
+    .use(
+      ssm({
+        AwsClient: SSM,
+        fetchData: {
+          objectLikeKey: '/dev/service_name/key_name'
+        },
+        setToEnv: true
+      })
+    )
+    .before(middleware)
+
+  await handler()
+})
+
 test.serial(
   'It should set SSM param value to internal storage when request > 10 params',
   async (t) => {

--- a/packages/ssm/__tests__/index.js
+++ b/packages/ssm/__tests__/index.js
@@ -41,7 +41,7 @@ test.serial('It should set SSM param value to internal storage', async (t) => {
     Parameters: [{ Name: '/dev/service_name/key_name', Value: 'key-value' }]
   })
 
-  const handler = middy(() => {})
+  const handler = middy(() => { })
 
   const middleware = async (request) => {
     const values = await getInternal(true, request)
@@ -70,7 +70,7 @@ test.serial('It should set SSM param path to internal storage', async (t) => {
     ]
   })
 
-  const handler = middy(() => {})
+  const handler = middy(() => { })
 
   const middleware = async (request) => {
     const values = await getInternal(true, request)
@@ -107,7 +107,7 @@ test.serial(
       }
     )
 
-    const handler = middy(() => {})
+    const handler = middy(() => { })
 
     const middleware = async (request) => {
       const values = await getInternal(true, request)
@@ -139,7 +139,7 @@ test.serial(
       Parameters: [{ Name: '/dev/service_name/key_name', Value: 'key-value' }]
     })
 
-    const handler = middy(() => {})
+    const handler = middy(() => { })
 
     const middleware = async (request) => {
       const values = await getInternal(true, request)
@@ -167,7 +167,7 @@ test.serial('It should set SSM param value to context', async (t) => {
     Parameters: [{ Name: '/dev/service_name/key_name', Value: 'key-value' }]
   })
 
-  const handler = middy(() => {})
+  const handler = middy(() => { })
 
   const middleware = async (request) => {
     t.is(request.context.key, 'key-value')
@@ -193,7 +193,7 @@ test.serial('It should set SSM param value to process.env', async (t) => {
     Parameters: [{ Name: '/dev/service_name/key_name', Value: 'key-value' }]
   })
 
-  const handler = middy(() => {})
+  const handler = middy(() => { })
 
   const middleware = async () => {
     t.is(process.env.key, 'key-value')
@@ -219,10 +219,10 @@ test.serial('It should set SSM param object-like value to process.env', async (t
     Parameters: [{ Name: '/dev/service_name/key_name', Value: '{"a": 1}' }]
   })
 
-  const handler = middy(() => {})
+  const handler = middy(() => { })
 
   const middleware = async () => {
-    t.is(process.env.objectLikeKey, 'key-value')
+    t.is(process.env.objectLikeKey, '{"a": 1}')
   }
 
   handler
@@ -275,7 +275,7 @@ test.serial(
       }
     )
 
-    const handler = middy(() => {})
+    const handler = middy(() => { })
 
     const middleware = async (request) => {
       const values = await getInternal(true, request)
@@ -318,7 +318,7 @@ test.serial(
       Parameters: [{ Name: '/dev/service_name/key_name', Value: 'key-value' }]
     })
 
-    const handler = middy(() => {})
+    const handler = middy(() => { })
 
     const middleware = async (request) => {
       const values = await getInternal(true, request)
@@ -351,7 +351,7 @@ test.serial(
       Parameters: [{ Name: '/dev/service_name/key_name', Value: 'key-value' }]
     })
 
-    const handler = middy(() => {})
+    const handler = middy(() => { })
 
     const middleware = async (request) => {
       const values = await getInternal(true, request)
@@ -390,7 +390,7 @@ test.serial(
       }
     )
 
-    const handler = middy(() => {})
+    const handler = middy(() => { })
 
     const middleware = async (request) => {
       const values = await getInternal(true, request)
@@ -422,7 +422,7 @@ test('It should throw error if InvalidParameters returned', async (t) => {
     Parameters: [{ Name: '/dev/service_name/key_name', Value: 'key-value' }]
   })
 
-  const handler = middy(() => {})
+  const handler = middy(() => { })
 
   handler.use(
     ssm({

--- a/packages/ssm/index.js
+++ b/packages/ssm/index.js
@@ -23,7 +23,8 @@ const defaults = {
   cacheKey: 'ssm',
   cacheExpiry: -1,
   setToEnv: false,
-  setToContext: false
+  setToContext: false,
+  shouldParseValues: true
 }
 
 const ssmMiddleware = (opts = {}) => {
@@ -141,6 +142,9 @@ const ssmMiddleware = (opts = {}) => {
   }
 
   const parseValue = (param) => {
+    if (!options.shouldParseValues) {
+      return param.Value
+    }
     if (param.Type === 'StringList') {
       return param.Value.split(',')
     }


### PR DESCRIPTION
Hey! Would like to add option to not parse value ;)

What does this implement/fix? Explain your changes.
---------------------------------------------------
An object like values are added to the environment as the string "[object Object]"
This solution is to add more options for the default behavior with the usage of the safeJsonParse.
The default behavior will not change

Does this close any currently open issues?
------------------------------------------
Nope


Any relevant logs, error output, etc?
-------------------------------------
Test should cover it
-------------------



[ x ] Feature/Fix fully implemented
[ x ] Added tests
[ x ] Updated relevant documentation
[ x ] Updated relevant examples
