### PR TITLE
fix: Add missing fields to Option typescript type

### DIFF
--- a/packages/input-output-logger/index.d.ts
+++ b/packages/input-output-logger/index.d.ts
@@ -4,6 +4,8 @@ interface Options {
   logger?: (message: any) => void
   awsContext?: boolean
   omitPaths?: string[]
+  mask?: string
+  replacer?: (this: any, key: string, value: any) => any | (number | string)[]
 }
 
 declare function inputOutputLogger (options?: Options): middy.MiddlewareObj


### PR DESCRIPTION
The fields `mask` and `replacer` are missing in the `Option` interface. I have added the missing fields to provide typescript type information.