### PR TITLE
docs: fix handler typo

### DIFF
--- a/website/docs/intro/01-intro.md
+++ b/website/docs/intro/01-intro.md
@@ -29,7 +29,7 @@ import httpErrorHandler from '@middy/http-error-handler'
 import validator from '@middy/validator'
 
 // This is your common handler, in no way different than what you are used to doing every day in AWS Lambda
-const lambdaHander = async (event, context) => {
+const lambdaHandler = async (event, context) => {
  // we don't need to deserialize the body ourself as a middleware will be used to do that
  const { creditCardNumber, expiryMonth, expiryYear, cvc, nameOnCard, amount } = event.body
 
@@ -66,7 +66,7 @@ const handler = middy()
   .use(jsonBodyParser()) // parses the request body when it's a JSON and converts it to an object
   .use(validator({inputSchema})) // validates the input
   .use(httpErrorHandler()) // handles common http errors and returns proper responses
-  .handler(lambdaHander)
+  .handler(lambdaHandler)
 
 ```
 

--- a/website/docs/intro/02-getting-started.md
+++ b/website/docs/intro/02-getting-started.md
@@ -39,11 +39,11 @@ import middleware1 from 'sample-middleware1'
 import middleware2 from 'sample-middleware2'
 import middleware3 from 'sample-middleware3'
 
-const lambdaHander = (event, context) => {
+const lambdaHandler = (event, context) => {
   /* your business logic */
 }
 
-export const handler = middy(lambdaHander)
+export const handler = middy(lambdaHandler)
 
 handler
   .use(middleware1())
@@ -61,11 +61,11 @@ import middleware2 from "sample-middleware2"
 import middleware3 from "sample-middleware3"
 const middlewares = [middleware1(), middleware2(), middleware3()]
 
-const lambdaHander = (event, context) => {
+const lambdaHandler = (event, context) => {
   /* your business logic */
 };
 
-export const handler = middy(lambdaHander)
+export const handler = middy(lambdaHandler)
 
 handler.use(middlewares)
 

--- a/website/docs/intro/06-typescript.md
+++ b/website/docs/intro/06-typescript.md
@@ -11,7 +11,7 @@ Here's an example of how you might be using Middy with TypeScript for a Lambda r
 import middy from '@middy/core'
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda'
 
-async function lambdaHander (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+async function lambdaHandler (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
   // the returned response will be checked against the type `APIGatewayProxyResult`
   return {
     statusCode: 200,
@@ -19,7 +19,7 @@ async function lambdaHander (event: APIGatewayProxyEvent): Promise<APIGatewayPro
   }
 }
 
-let handler = middy(lambdaHander)
+let handler = middy(lambdaHandler)
 handler
   .use(someMiddleware)
   .use(someOtherMiddleware)

--- a/website/docs/middlewares/sqs-partial-batch-failure.md
+++ b/website/docs/middlewares/sqs-partial-batch-failure.md
@@ -29,7 +29,7 @@ NOTES:
 import middy from '@middy/core'
 import sqsBatch from '@middy/sqs-partial-batch-failure'
 
-const lambdaHander = (event, context) => {
+const lambdaHandler = (event, context) => {
   const recordPromises = event.Records.map(async (record, index) => { 
     /* Custom message processing logic */
     return record
@@ -37,6 +37,6 @@ const lambdaHander = (event, context) => {
   return Promise.allSettled(recordPromises)
 }
 
-export const handler = middy(lambdaHander)
+export const handler = middy(lambdaHandler)
   .use(sqsBatch())
 ```


### PR DESCRIPTION
Very minor typo: lambdaHander 👉 lambdaHand**l**er