### PR TITLE
fix: import DynamoDB from straight from aws-sdk

### DIFF
--- a/packages/event-normalizer/README.md
+++ b/packages/event-normalizer/README.md
@@ -118,6 +118,34 @@ const lambdaHandler = (event, context) => {
 const handler = middy(lambdaHandler).use(eventNormalizer())
 ```
 
+## AWS SDK
+
+This middleware depends on `aws-sdk` package. Lambda runtime already includes `aws-sdk` by default and as such you normally don't need to package it in your function. If you are using Webpack and Serverless Framework to package your code you'd want to add `aws-sdk` to Webpack `externals` and to `forceExclude` of Serverless Framework Webpack configuration.
+
+1. Tell Webpack not to bundle `aws-sdk` into the output (e.g. handler.js):
+```
+# webpack.config.js
+
+var nodeExternals = require("webpack-node-externals");
+
+module.exports = {
+  externals: ["aws-sdk"],
+};
+```
+
+2. Tell Serverless Framework not to include `aws-sdk` located in `node_modules` (because it was not bundled by Webpack):
+```
+# serverless.yml
+
+custom:
+  webpack: # for webpack
+    includeModules:
+      forceExclude:
+        - aws-sdk
+  esbuild: # for esbuild
+    exclude: ["aws-sdk"]
+```
+
 ## Middy documentation and examples
 
 For more documentation and examples, refers to the main [Middy monorepo on GitHub](https://github.com/middyjs/middy) or [Middy official website](https://middy.js.org).

--- a/packages/event-normalizer/index.js
+++ b/packages/event-normalizer/index.js
@@ -1,7 +1,6 @@
-import DynamoDB from 'aws-sdk/clients/dynamodb.js' // v2
+import { DynamoDB } from 'aws-sdk' // v2
 // import { unmarshall } from '@aws-sdk/util-dynamodb' // v3
 import { jsonSafeParse } from '@middy/util'
-const { unmarshall } = DynamoDB.Converter
 
 const eventNormalizerMiddleware = () => {
   const eventNormalizerMiddlewareBefore = async (request) => {
@@ -68,9 +67,9 @@ const events = {
     event.ruleParameters = jsonSafeParse(event.ruleParameters)
   },
   'aws:dynamodb': (record) => {
-    record.dynamodb.Keys = unmarshall(record.dynamodb.Keys)
-    record.dynamodb.OldImage = unmarshall(record.dynamodb.OldImage)
-    record.dynamodb.NewImage = unmarshall(record.dynamodb.NewImage)
+    record.dynamodb.Keys = DynamoDB.Converter.unmarshall(record.dynamodb.Keys)
+    record.dynamodb.OldImage = DynamoDB.Converter.unmarshall(record.dynamodb.OldImage)
+    record.dynamodb.NewImage = DynamoDB.Converter.unmarshall(record.dynamodb.NewImage)
   },
   'aws:kafka': (event) => {
     for (const record in event.records) {


### PR DESCRIPTION
Before this change if you had Webpack configured to not bundle `aws-sdk` via `externals` setting it would still bundle it because the import was done via `aws-sdk/clients/dynamodb.js` instead of `aws-sdk`. This is very unexpected behavior for most setups and would require someone figuring out why `aws-sdk` is getting bundled to spend many hours debugging.