### PR TITLE
fix(http-error-handler): type error in 'logger' option

### DIFF
--- a/packages/http-error-handler/index.d.ts
+++ b/packages/http-error-handler/index.d.ts
@@ -1,7 +1,7 @@
 import middy from '@middy/core'
 
 interface Options {
-  logger?: (error: any) => void
+  logger?: ((error: any) => void) | boolean
   fallbackMessage?: string
 }
 


### PR DESCRIPTION
Fix error `Type 'boolean' is not assignable to type '(error: any) => void'.`

According to [readme](https://github.com/middyjs/middy/tree/main/packages/http-error-handler#options), "You can pass `false`" to the `logger` option