### PR TITLE
fix(http-response-serializer): add type for full-response serializers

### DIFF
--- a/packages/http-response-serializer/index.d.ts
+++ b/packages/http-response-serializer/index.d.ts
@@ -2,7 +2,7 @@ import middy from '@middy/core'
 
 interface SerializerHandler {
   regex: RegExp
-  serializer: (response: any) => string
+  serializer: (response: any) => string | { body: any, [key: string]: any }
 }
 
 interface Options {


### PR DESCRIPTION
The type was inferred from this test: https://github.com/middyjs/middy/blob/8ec3224e773ff6938ab446ad6335091b2a99a3c2/packages/http-response-serializer/__tests__/index.js#L257