### PR TITLE
fix: export route and method for middy http router

### DIFF
--- a/packages/http-router/index.d.ts
+++ b/packages/http-router/index.d.ts
@@ -5,9 +5,9 @@ import {
   Handler as LambdaHandler
 } from 'aws-lambda'
 
-type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'ANY'
+export type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'ANY'
 
-interface Route {
+export interface Route {
   method: Method
   path: string
   handler: LambdaHandler<APIGatewayProxyEvent, APIGatewayProxyResult>


### PR DESCRIPTION
Struggled to type the `ROUTES` array mainatined in a configuration file that gets imported for the httpRouter