### PR TITLE
fix(type): add `handler` in the `MiddyfiedHandler`

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -50,6 +50,7 @@ export interface MiddyfiedHandler<TEvent = any, TResult = any, TErr = Error, TCo
   before: AttachMiddlewareFn<TEvent, TResult, TErr, TContext>
   after: AttachMiddlewareFn<TEvent, TResult, TErr, TContext>
   onError: AttachMiddlewareFn<TEvent, TResult, TErr, TContext>
+  handler: (handler: MiddlewareHandler<LambdaHandler<TEvent, TResult>, TContext>) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
 }
 
 declare type AttachMiddlewareFn<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> = (middleware: MiddlewareFn) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>


### PR DESCRIPTION
In the middy 3, we proposed the `.handler` function but not mentioned in the type for `TypeScript`. This change is adding to that.