### PR TITLE
fixed typo in documentation

### DIFF
--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -161,12 +161,12 @@ Version 2.x of Middy no longer supports Node.js versions 10.x. You are highly en
 which support ES6 modules by default (`export`), optional chaining (`?.`) and nullish coalescing operator (`??`) natively.
 
 ## Core
-- In handler `callback(err, reponse)` have been removed for `async/await` support
+- In handler `callback(err, response)` have been removed for `async/await` support
   - `return response` to trigger `after` middleware stack  
   - `throw new Error(...)` to trigger `onError` middleware stack
 - In middleware `next(err)` has been removed for `async/await` support
   - `throw new Error(...)` to trigger `onError` middleware stack
-  - `return reponse` to **short circuit** any middleware stack and respond. v1.x currently throws an error when something is returned
+  - `return response` to **short circuit** any middleware stack and respond. v1.x currently throws an error when something is returned
 
 ## Middleware
 ### cache

--- a/packages/http-error-handler/README.md
+++ b/packages/http-error-handler/README.md
@@ -41,7 +41,7 @@ for them (using the message and the status code provided by the error object). A
 We recommend generating these HTTP errors with the npm module [`http-errors`](https://npm.im/http-errors). When manually catching and setting errors with `statusCode >= 500` setting `{expose: true}` 
 is needed for them to be handled.
 
-This middleware should be set as the last error handler unless you also want to register the `http-reponse-serializer`. If so, this middleware should come second-last and the `http-response-serializer` should come last.
+This middleware should be set as the last error handler unless you also want to register the `http-response-serializer`. If so, this middleware should come second-last and the `http-response-serializer` should come last.
 
 
 ## Install

--- a/packages/http-response-serializer/package.json
+++ b/packages/http-response-serializer/package.json
@@ -51,7 +51,7 @@
   "repository": {
     "type": "git",
     "url": "github:middyjs/middy",
-    "directory": "packages/http-reponse-serializer"
+    "directory": "packages/http-response-serializer"
   },
   "bugs": {
     "url": "https://github.com/middyjs/middy/issues"

--- a/website/docs/middlewares/http-error-handler.md
+++ b/website/docs/middlewares/http-error-handler.md
@@ -7,7 +7,7 @@ for them (using the message and the status code provided by the error object). A
 We recommend generating these HTTP errors with the npm module [`http-errors`](https://npm.im/http-errors). When manually catching and setting errors with `statusCode >= 500` setting `{expose: true}` 
 is needed for them to be handled.
 
-This middleware should be set as the last error handler unless you also want to register the `http-reponse-serializer`. If so, this middleware should come second-last and the `http-response-serializer` should come last.
+This middleware should be set as the last error handler unless you also want to register the `http-response-serializer`. If so, this middleware should come second-last and the `http-response-serializer` should come last.
 
 
 ## Install

--- a/website/docs/upgrade/1-2.md
+++ b/website/docs/upgrade/1-2.md
@@ -7,12 +7,12 @@ Version 2.x of Middy no longer supports Node.js versions 10.x. You are highly en
 which support ES6 modules by default (`export`), optional chaining (`?.`) and nullish coalescing operator (`??`) natively.
 
 ## Core
-- In handler `callback(err, reponse)` have been removed for `async/await` support
+- In handler `callback(err, response)` have been removed for `async/await` support
   - `return response` to trigger `after` middleware stack
   - `throw new Error(...)` to trigger `onError` middleware stack
 - In middleware `next(err)` has been removed for `async/await` support
   - `throw new Error(...)` to trigger `onError` middleware stack
-  - `return reponse` to **short circuit** any middleware stack and respond. v1.x currently throws an error when something is returned
+  - `return response` to **short circuit** any middleware stack and respond. v1.x currently throws an error when something is returned
 
 ## Middleware
 ### cache


### PR DESCRIPTION
updated occurrences of "reponse" to "response"