### PR TITLE
Fix TS Error in httpRouterHandler

### DIFF
--- a/packages/http-router/index.d.ts
+++ b/packages/http-router/index.d.ts
@@ -13,6 +13,6 @@ export interface Route {
   handler: LambdaHandler<APIGatewayProxyEvent, APIGatewayProxyResult>
 }
 
-declare function httpRouterHandler (routes: Route[]): middy.MiddlewareObj
+declare function httpRouterHandler (routes: Route[]): middy.MiddyfiedHandler
 
 export default httpRouterHandler

--- a/packages/http-router/index.test-d.ts
+++ b/packages/http-router/index.test-d.ts
@@ -21,4 +21,4 @@ const middleware = httpRouterHandler([
     handler: lambdaHandler
   }
 ])
-expectType<middy.MiddlewareObj>(middleware)
+expectType<middy.MiddyfiedHandler>(middleware)


### PR DESCRIPTION
httpRouterHandler should return a MiddyfiedHandler to be type-checked correctly