### PR TITLE
Use aws-sdk submodule

### DIFF
--- a/packages/rds-signer/index.d.ts
+++ b/packages/rds-signer/index.d.ts
@@ -1,4 +1,4 @@
-import { RDS } from 'aws-sdk'
+import RDS from 'aws-sdk/clients/rds'
 import middy from '@middy/core'
 import { Options as MiddyOptions } from '@middy/util'
 

--- a/packages/rds-signer/index.test-d.ts
+++ b/packages/rds-signer/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd'
 import middy from '@middy/core'
-import { RDS } from 'aws-sdk'
+import RDS from 'aws-sdk/clients/rds'
 import { captureAWSClient } from 'aws-xray-sdk'
 import rdsSigner from '.'
 

--- a/packages/s3-object-response/index.d.ts
+++ b/packages/s3-object-response/index.d.ts
@@ -1,4 +1,4 @@
-import { S3 } from 'aws-sdk'
+import S3 from 'aws-sdk/clients/s3'
 import middy from '@middy/core'
 import { Options as MiddyOptions } from '@middy/util'
 

--- a/packages/s3-object-response/index.test-d.ts
+++ b/packages/s3-object-response/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd'
 import middy from '@middy/core'
-import { S3 } from 'aws-sdk'
+import S3 from 'aws-sdk/clients/s3'
 import { captureAWSClient } from 'aws-xray-sdk'
 import s3ObjectResponse from '.'
 

--- a/packages/secrets-manager/index.d.ts
+++ b/packages/secrets-manager/index.d.ts
@@ -1,4 +1,4 @@
-import { SecretsManager } from 'aws-sdk'
+import SecretsManager from 'aws-sdk/clients/secretsmanager'
 import middy from '@middy/core'
 import { Options as MiddyOptions } from '@middy/util'
 

--- a/packages/secrets-manager/index.test-d.ts
+++ b/packages/secrets-manager/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd'
 import middy from '@middy/core'
-import { SecretsManager } from 'aws-sdk'
+import SecretsManager from 'aws-sdk/clients/secretsmanager'
 import { captureAWSClient } from 'aws-xray-sdk'
 import rdsSigner from '.'
 

--- a/packages/service-discovery/index.d.ts
+++ b/packages/service-discovery/index.d.ts
@@ -1,4 +1,4 @@
-import { ServiceDiscovery } from 'aws-sdk'
+import ServiceDiscovery from 'aws-sdk/clients/servicediscovery'
 import middy from '@middy/core'
 import { Options as MiddyOptions } from '@middy/util'
 

--- a/packages/service-discovery/index.test-d.ts
+++ b/packages/service-discovery/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd'
 import middy from '@middy/core'
-import { ServiceDiscovery } from 'aws-sdk'
+import ServiceDiscovery from 'aws-sdk/clients/servicediscovery'
 import { captureAWSClient } from 'aws-xray-sdk'
 import serviceDiscovery from '.'
 

--- a/packages/sqs-partial-batch-failure/index.d.ts
+++ b/packages/sqs-partial-batch-failure/index.d.ts
@@ -1,5 +1,5 @@
 import middy from '@middy/core'
-import SQS from 'aws-sdk/clients/SQS'
+import SQS from 'aws-sdk/clients/sqs'
 import { Options as MiddyOptions } from '@middy/util'
 
 interface Options<S = SQS> extends Pick<MiddyOptions<S, SQS.Types.ClientConfiguration>,

--- a/packages/sqs-partial-batch-failure/index.d.ts
+++ b/packages/sqs-partial-batch-failure/index.d.ts
@@ -1,5 +1,5 @@
 import middy from '@middy/core'
-import { SQS } from 'aws-sdk'
+import SQS from 'aws-sdk/clients/SQS'
 import { Options as MiddyOptions } from '@middy/util'
 
 interface Options<S = SQS> extends Pick<MiddyOptions<S, SQS.Types.ClientConfiguration>,

--- a/packages/sqs-partial-batch-failure/index.test-d.ts
+++ b/packages/sqs-partial-batch-failure/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd'
 import middy from '@middy/core'
-import { SQS } from 'aws-sdk'
+import SQS from 'aws-sdk/clients/sqs'
 import { captureAWSClient } from 'aws-xray-sdk'
 import sqsPartialBatchFailure from '.'
 

--- a/packages/ssm/index.d.ts
+++ b/packages/ssm/index.d.ts
@@ -1,4 +1,4 @@
-import { SSM } from 'aws-sdk'
+import SSM from 'aws-sdk/clients/ssm'
 import { Options as MiddyOptions } from '@middy/util'
 import middy from '@middy/core'
 

--- a/packages/ssm/index.test-d.ts
+++ b/packages/ssm/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd'
 import middy from '@middy/core'
-import { SSM } from 'aws-sdk'
+import SSM from 'aws-sdk/clients/ssm'
 import { captureAWSClient } from 'aws-xray-sdk'
 import ssm from '.'
 

--- a/packages/sts/index.d.ts
+++ b/packages/sts/index.d.ts
@@ -1,4 +1,4 @@
-import { STS } from 'aws-sdk'
+import STS from 'aws-sdk/clients/sts'
 import middy from '@middy/core'
 import { Options as MiddyOptions } from '@middy/util'
 

--- a/packages/sts/index.test-d.ts
+++ b/packages/sts/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd'
 import middy from '@middy/core'
-import { STS } from 'aws-sdk'
+import STS from 'aws-sdk/clients/sts'
 import { captureAWSClient } from 'aws-xray-sdk'
 import sts from '.'
 

--- a/packages/util/index.test-d.ts
+++ b/packages/util/index.test-d.ts
@@ -1,6 +1,6 @@
 import middy from '@middy/core'
 import { expectType } from 'tsd'
-import { SSM } from 'aws-sdk'
+import SSM from 'aws-sdk/clients/ssm'
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda'
 import * as util from '.'
 

--- a/packages/ws-response/index.d.ts
+++ b/packages/ws-response/index.d.ts
@@ -1,4 +1,4 @@
-import { ApiGatewayManagementApi } from 'aws-sdk'
+import ApiGatewayManagementApi from 'aws-sdk/clients/apigatewaymanagementapi'
 import middy from '@middy/core'
 import { Options as MiddyOptions } from '@middy/util'
 

--- a/packages/ws-response/index.test-d.ts
+++ b/packages/ws-response/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd'
 import middy from '@middy/core'
-import { ApiGatewayManagementApi } from 'aws-sdk'
+import ApiGatewayManagementApi from 'aws-sdk/clients/apigatewaymanagementapi'
 import { captureAWSClient } from 'aws-xray-sdk'
 import wsResponse from '.'
 


### PR DESCRIPTION
In order to reduce check-types we should import the submodule directly.
This method is already in use for the main `js` files, but not for the `.d.ts` files - so we pay the price when typechecking our code.

- importing the whole aws-sdk takes 3.5 seconds of typechecking time.
You can see 2.5 seconds in the picture below, but there is added segment of binding operations that takes another ~second
![Screen Shot 2022-06-23 at 12 37 32](https://user-images.githubusercontent.com/10139826/175269051-1b2e5631-9ae9-43d9-851d-e4ac32c5c6f3.png)
