### PR TITLE
Change GitHub link in documentation from docusaurus to middy

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -102,7 +102,7 @@ const config = {
             items: [
               {
                 label: 'GitHub',
-                href: 'https://github.com/facebook/docusaurus'
+                href: 'https://github.com/middyjs/middy'
               },
               {
                 label: 'Stack Overflow',


### PR DESCRIPTION
The GitHub link in the footer wasn't changed and still pointed to the docusaurus repository instead of the middy repository.