### PR TITLE
add missing `optional chaining operators`

### DIFF
--- a/packages/http-response-serializer/index.js
+++ b/packages/http-response-serializer/index.js
@@ -21,7 +21,7 @@ const httpResponseSerializerMiddleware = (opts = {}) => {
       types = [request.event.requiredContentType]
     } else {
       const acceptHeader =
-        request.event.headers.Accept ?? request.event.headers.accept
+        request.event.headers?.Accept ?? request.event.headers?.accept
       types = [
         ...((acceptHeader && Accept.mediaTypes(acceptHeader)) ?? []),
         request.event.preferredContentType,


### PR DESCRIPTION
I get the error below when I invoke lambda functions without headers defined.

```haskell
ERROR	TypeError: Cannot read properties of undefined (reading 'accept')
job-crawler-container-dfe899e[0]     at null.httpResponseSerializerMiddlewareAfter (/node_modules/.pnpm/@middy+http-response-serializer@3.1.0/node_modules/@middy/http-response-serializer/index.js:21:89)
```

The error goes away when _optional chaining operators_ are added. Beware that _nullish coalescing operators_ are not a replacement of the _optional chaining operators_ and can be used together, as shown by MDN: 

* [Relationship with the optional chaining operator (?.)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator#relationship_with_the_optional_chaining_operator)