### PR TITLE
[docs][@middy/validator] Add missing type "object"

### DIFF
--- a/website/docs/middlewares/validator.md
+++ b/website/docs/middlewares/validator.md
@@ -57,6 +57,7 @@ const handler = middy((event, context) => {
 })
 
 const schema = {
+  type: "object",
   required: ['body', 'foo'],
   properties: {
     // this will pass validation
@@ -94,6 +95,7 @@ const handler = middy((event, context) => {
 })
 
 const responseSchema = {
+  type: "object",
   required: ['body', 'statusCode'],
   properties: {
     body: {


### PR DESCRIPTION
ajv requires the schema to specify its type when running in strict mode.
The examples in the docs do not have that, and thus they fail with the following error:

```haskell
Error: strict mode: missing type "object" for keyword "required" at "#" (strictTypes)
    at checkStrictMode (~/node_modules/.pnpm/ajv@8.11.0/node_modules/ajv/dist/compile/util.js:174:15)
    at strictTypesError (~/node_modules/.pnpm/ajv@8.11.0/node_modules/ajv/dist/compile/validate/index.js:275:32)
    at checkKeywordTypes (~/node_modules/.pnpm/ajv@8.11.0/node_modules/ajv/dist/compile/validate/index.js:261:17)
    at checkStrictTypes (~/node_modules/.pnpm/ajv@8.11.0/node_modules/ajv/dist/compile/validate/index.js:233:5)
    at schemaKeywords (~/node_modules/.pnpm/ajv@8.11.0/node_modules/ajv/dist/compile/validate/index.js:189:9)
    at typeAndKeywords (~/node_modules/.pnpm/ajv@8.11.0/node_modules/ajv/dist/compile/validate/index.js:128:5)
    at ~/node_modules/.pnpm/ajv@8.11.0/node_modules/ajv/dist/compile/validate/index.js:70:9
    at CodeGen.code (~/node_modules/.pnpm/ajv@8.11.0/node_modules/ajv/dist/compile/codegen/index.js:439:13)
    at ~/node_modules/.pnpm/ajv@8.11.0/node_modules/ajv/dist/compile/validate/index.js:37:166
    at CodeGen.code (~/node_modules/.pnpm/ajv@8.11.0/node_modules/ajv/dist/compile/codegen/index.js:439:13)
```