### PR TITLE
feat: self-composing UseFN

### DIFF
--- a/packages/cloudwatch-metrics/index.d.ts
+++ b/packages/cloudwatch-metrics/index.d.ts
@@ -1,6 +1,6 @@
 import middy from '@middy/core'
 import { MetricsLogger } from 'aws-embedded-metrics'
-import type { Context } from 'aws-lambda'
+import type { Context as LambdaContext } from 'aws-lambda'
 export { MetricsLogger } from 'aws-embedded-metrics'
 
 interface Options {
@@ -8,13 +8,12 @@ interface Options {
   dimensions?: Array<Record<string, string>>
 }
 
+export type Context = LambdaContext & {
+  metrics: MetricsLogger
+}
+
 declare function cloudwatchMetrics(
   options?: Options
-): middy.MiddlewareObj<
-  unknown,
-  any,
-  Error,
-  Context & { metrics: MetricsLogger }
->
+): middy.MiddlewareObj<unknown, any, Error, Context>
 
 export default cloudwatchMetrics

--- a/packages/cloudwatch-metrics/index.d.ts
+++ b/packages/cloudwatch-metrics/index.d.ts
@@ -1,4 +1,6 @@
 import middy from '@middy/core'
+import { MetricsLogger } from 'aws-embedded-metrics'
+import type { Context } from 'aws-lambda'
 export { MetricsLogger } from 'aws-embedded-metrics'
 
 interface Options {
@@ -6,6 +8,13 @@ interface Options {
   dimensions?: Array<Record<string, string>>
 }
 
-declare function cloudwatchMetrics (options?: Options): middy.MiddlewareObj
+declare function cloudwatchMetrics(
+  options?: Options
+): middy.MiddlewareObj<
+  unknown,
+  any,
+  Error,
+  Context & { metrics: MetricsLogger }
+>
 
 export default cloudwatchMetrics

--- a/packages/cloudwatch-metrics/index.d.ts
+++ b/packages/cloudwatch-metrics/index.d.ts
@@ -12,7 +12,7 @@ export type Context = LambdaContext & {
   metrics: MetricsLogger
 }
 
-declare function cloudwatchMetrics(
+declare function cloudwatchMetrics (
   options?: Options
 ): middy.MiddlewareObj<unknown, any, Error, Context>
 

--- a/packages/cloudwatch-metrics/index.test-d.ts
+++ b/packages/cloudwatch-metrics/index.test-d.ts
@@ -1,14 +1,19 @@
-import { expectType } from 'tsd'
 import middy from '@middy/core'
-import cloudwatchMetrics from '.'
+import { Context } from 'aws-lambda'
+import { expectType } from 'tsd'
+import cloudwatchMetrics, { MetricsLogger } from '.'
 
 // use with default options
 let middleware = cloudwatchMetrics()
-expectType<middy.MiddlewareObj>(middleware)
+expectType<
+  middy.MiddlewareObj<unknown, any, any, Context & { metrics: MetricsLogger }>
+>(middleware)
 
 // use with all options
 middleware = cloudwatchMetrics({
   namespace: 'myApp',
   dimensions: [{ Action: 'Buy' }]
 })
-expectType<middy.MiddlewareObj>(middleware)
+expectType<
+  middy.MiddlewareObj<unknown, any, any, Context & { metrics: MetricsLogger }>
+>(middleware)

--- a/packages/cloudwatch-metrics/index.test-d.ts
+++ b/packages/cloudwatch-metrics/index.test-d.ts
@@ -4,11 +4,11 @@ import cloudwatchMetrics, { Context } from '.'
 
 // use with default options
 let middleware = cloudwatchMetrics()
-expectType<middy.MiddlewareObj<unknown, any, any, Context>>(middleware)
+expectType<middy.MiddlewareObj<unknown, any, Error, Context>>(middleware)
 
 // use with all options
 middleware = cloudwatchMetrics({
   namespace: 'myApp',
   dimensions: [{ Action: 'Buy' }]
 })
-expectType<middy.MiddlewareObj<unknown, any, any, Context>>(middleware)
+expectType<middy.MiddlewareObj<unknown, any, Error, Context>>(middleware)

--- a/packages/cloudwatch-metrics/index.test-d.ts
+++ b/packages/cloudwatch-metrics/index.test-d.ts
@@ -1,19 +1,14 @@
 import middy from '@middy/core'
-import { Context } from 'aws-lambda'
 import { expectType } from 'tsd'
-import cloudwatchMetrics, { MetricsLogger } from '.'
+import cloudwatchMetrics, { Context } from '.'
 
 // use with default options
 let middleware = cloudwatchMetrics()
-expectType<
-  middy.MiddlewareObj<unknown, any, any, Context & { metrics: MetricsLogger }>
->(middleware)
+expectType<middy.MiddlewareObj<unknown, any, any, Context>>(middleware)
 
 // use with all options
 middleware = cloudwatchMetrics({
   namespace: 'myApp',
   dimensions: [{ Action: 'Buy' }]
 })
-expectType<
-  middy.MiddlewareObj<unknown, any, any, Context & { metrics: MetricsLogger }>
->(middleware)
+expectType<middy.MiddlewareObj<unknown, any, any, Context>>(middleware)

--- a/packages/cloudwatch-metrics/package-lock.json
+++ b/packages/cloudwatch-metrics/package-lock.json
@@ -12,7 +12,8 @@
         "aws-embedded-metrics": "3.0.0"
       },
       "devDependencies": {
-        "@middy/core": "3.1.1"
+        "@middy/core": "3.1.1",
+        "@types/aws-lambda": "^8.10.101"
       },
       "engines": {
         "node": ">=14"
@@ -31,6 +32,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.101",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
+      "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
+      "dev": true
     },
     "node_modules/aws-embedded-metrics": {
       "version": "3.0.0",
@@ -54,6 +61,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@middy/core/-/core-3.1.1.tgz",
       "integrity": "sha512-Og6Z1BrRWTYWDs9KF5Zb80JYv2fNwVpyMYAuG4+2fc0e8UORG4CAyccbc8SvRAReL9rLQY8pjp9WE4cdhDg3DQ==",
+      "dev": true
+    },
+    "@types/aws-lambda": {
+      "version": "8.10.101",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
+      "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
       "dev": true
     },
     "aws-embedded-metrics": {

--- a/packages/cloudwatch-metrics/package.json
+++ b/packages/cloudwatch-metrics/package.json
@@ -68,7 +68,8 @@
     "aws-embedded-metrics": "3.0.0"
   },
   "devDependencies": {
-    "@middy/core": "3.1.1"
+    "@middy/core": "3.1.1",
+    "@types/aws-lambda": "^8.10.101"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"
 }

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -8,6 +8,8 @@ declare type PluginHook = () => void
 declare type PluginHookWithMiddlewareName = (middlewareName: string) => void
 declare type PluginHookPromise = (request: Request) => Promise<unknown> | unknown
 
+declare type MiddlewareObjEvent<T extends MiddlewareObj<any>> = T extends MiddlewareObj<infer U> ? U : never;
+
 interface PluginObject {
   internal?: any
   beforePrefetch?: PluginHook
@@ -33,7 +35,7 @@ interface Request<TEvent = any, TResult = any, TErr = Error, TContext extends La
 
 declare type MiddlewareFn<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> = (request: Request<TEvent, TResult, TErr, TContext>) => any
 
-export interface MiddlewareObj<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> {
+export interface MiddlewareObj<TEvent = unknown, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> {
   before?: MiddlewareFn<TEvent, TResult, TErr, TContext>
   after?: MiddlewareFn<TEvent, TResult, TErr, TContext>
   onError?: MiddlewareFn<TEvent, TResult, TErr, TContext>
@@ -53,12 +55,12 @@ export interface MiddyfiedHandler<TEvent = any, TResult = any, TErr = Error, TCo
   handler: (handler: MiddlewareHandler<LambdaHandler<TEvent, TResult>, TContext>) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
 }
 
-declare type AttachMiddlewareFn<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> = (middleware: MiddlewareFn) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
+declare type AttachMiddlewareFn<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> = (middleware: MiddlewareFn<TEvent, TResult, TErr, TContext>) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
 
-declare type AttachMiddlewareObj<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> = (middleware: MiddlewareObj) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
+declare type AttachMiddlewareObj<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> = (middleware: MiddlewareObj<TEvent, TResult, TErr, TContext>) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
 
 declare type UseFn<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> =
-  (middlewares: MiddlewareObj<TEvent, TResult, TErr, TContext> | Array<MiddlewareObj<TEvent, TResult, TErr, TContext>>) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
+  <TMiddleware extends MiddlewareObj<any, any, Error, Context>>(middlewares: TMiddleware | Array<TMiddleware>) => MiddyfiedHandler<MiddlewareObjEvent<TMiddleware> & TEvent, TResult, TErr, TContext>;
 
 declare type MiddlewareHandler<THandler extends LambdaHandler<any, any>, TContext extends LambdaContext = LambdaContext> =
   THandler extends LambdaHandler<infer TEvent, infer TResult> // always true
@@ -70,7 +72,7 @@ declare type MiddlewareHandler<THandler extends LambdaHandler<any, any>, TContex
  * @param handler your original AWS Lambda function
  * @param plugin wraps around each middleware and handler to add custom lifecycle behaviours (e.g. to profile performance)
  */
-declare function middy<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> (handler?: MiddlewareHandler<LambdaHandler<TEvent, TResult>, TContext>, plugin?: PluginObject): MiddyfiedHandler<TEvent, TResult, TErr, TContext>
+declare function middy<TEvent = unknown, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> (handler?: MiddlewareHandler<LambdaHandler<TEvent, TResult>, TContext>, plugin?: PluginObject): MiddyfiedHandler<TEvent, TResult, TErr, TContext>
 
 declare namespace middy {
   export {

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -1,14 +1,12 @@
 import {
+  Callback as LambdaCallback,
   Context as LambdaContext,
-  Handler as LambdaHandler,
-  Callback as LambdaCallback
+  Handler as LambdaHandler
 } from 'aws-lambda'
 
 declare type PluginHook = () => void
 declare type PluginHookWithMiddlewareName = (middlewareName: string) => void
 declare type PluginHookPromise = (request: Request) => Promise<unknown> | unknown
-
-declare type MiddlewareObjEvent<T extends MiddlewareObj<any>> = T extends MiddlewareObj<infer U> ? U : never;
 
 interface PluginObject {
   internal?: any
@@ -35,7 +33,7 @@ interface Request<TEvent = any, TResult = any, TErr = Error, TContext extends La
 
 declare type MiddlewareFn<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> = (request: Request<TEvent, TResult, TErr, TContext>) => any
 
-export interface MiddlewareObj<TEvent = unknown, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> {
+export interface MiddlewareObj<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> {
   before?: MiddlewareFn<TEvent, TResult, TErr, TContext>
   after?: MiddlewareFn<TEvent, TResult, TErr, TContext>
   onError?: MiddlewareFn<TEvent, TResult, TErr, TContext>
@@ -55,12 +53,16 @@ export interface MiddyfiedHandler<TEvent = any, TResult = any, TErr = Error, TCo
   handler: (handler: MiddlewareHandler<LambdaHandler<TEvent, TResult>, TContext>) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
 }
 
-declare type AttachMiddlewareFn<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> = (middleware: MiddlewareFn<TEvent, TResult, TErr, TContext>) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
+declare type AttachMiddlewareFn<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> =
+  (middleware: MiddlewareFn<TEvent, TResult, TErr, TContext>) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
 
-declare type AttachMiddlewareObj<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> = (middleware: MiddlewareObj<TEvent, TResult, TErr, TContext>) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
+declare type AttachMiddlewareObj<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> = 
+  (middleware: MiddlewareObj<TEvent, TResult, TErr, TContext>) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
 
 declare type UseFn<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> =
-  <TMiddleware extends MiddlewareObj<any, any, Error, Context>>(middlewares: TMiddleware | Array<TMiddleware>) => MiddyfiedHandler<MiddlewareObjEvent<TMiddleware> & TEvent, TResult, TErr, TContext>;
+  <TMiddleware extends MiddlewareObj<any, any, Error, any>>(middlewares: TMiddleware | TMiddleware[]) => TMiddleware extends MiddlewareObj<infer TMiddlewareEvent, any, Error, infer TMiddlewareContext>
+    ? MiddyfiedHandler<TMiddlewareEvent & TEvent, TResult, TErr, TMiddlewareContext & TContext> // always true
+    : never
 
 declare type MiddlewareHandler<THandler extends LambdaHandler<any, any>, TContext extends LambdaContext = LambdaContext> =
   THandler extends LambdaHandler<infer TEvent, infer TResult> // always true
@@ -72,7 +74,8 @@ declare type MiddlewareHandler<THandler extends LambdaHandler<any, any>, TContex
  * @param handler your original AWS Lambda function
  * @param plugin wraps around each middleware and handler to add custom lifecycle behaviours (e.g. to profile performance)
  */
-declare function middy<TEvent = unknown, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> (handler?: MiddlewareHandler<LambdaHandler<TEvent, TResult>, TContext>, plugin?: PluginObject): MiddyfiedHandler<TEvent, TResult, TErr, TContext>
+declare function middy<TEvent = unknown, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> 
+  (handler?: MiddlewareHandler<LambdaHandler<TEvent, TResult>, TContext>, plugin?: PluginObject): MiddyfiedHandler<TEvent, TResult, TErr, TContext>
 
 declare namespace middy {
   export {

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -33,7 +33,7 @@ interface Request<TEvent = any, TResult = any, TErr = Error, TContext extends La
 
 declare type MiddlewareFn<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> = (request: Request<TEvent, TResult, TErr, TContext>) => any
 
-export interface MiddlewareObj<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> {
+export interface MiddlewareObj<TEvent = unknown, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> {
   before?: MiddlewareFn<TEvent, TResult, TErr, TContext>
   after?: MiddlewareFn<TEvent, TResult, TErr, TContext>
   onError?: MiddlewareFn<TEvent, TResult, TErr, TContext>

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -56,7 +56,7 @@ export interface MiddyfiedHandler<TEvent = any, TResult = any, TErr = Error, TCo
 declare type AttachMiddlewareFn<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> =
   (middleware: MiddlewareFn<TEvent, TResult, TErr, TContext>) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
 
-declare type AttachMiddlewareObj<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> = 
+declare type AttachMiddlewareObj<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> =
   (middleware: MiddlewareObj<TEvent, TResult, TErr, TContext>) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
 
 declare type UseFn<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> =
@@ -74,8 +74,7 @@ declare type MiddlewareHandler<THandler extends LambdaHandler<any, any>, TContex
  * @param handler your original AWS Lambda function
  * @param plugin wraps around each middleware and handler to add custom lifecycle behaviours (e.g. to profile performance)
  */
-declare function middy<TEvent = unknown, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> 
-  (handler?: MiddlewareHandler<LambdaHandler<TEvent, TResult>, TContext>, plugin?: PluginObject): MiddyfiedHandler<TEvent, TResult, TErr, TContext>
+declare function middy<TEvent = unknown, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> (handler?: MiddlewareHandler<LambdaHandler<TEvent, TResult>, TContext>, plugin?: PluginObject): MiddyfiedHandler<TEvent, TResult, TErr, TContext>
 
 declare namespace middy {
   export {

--- a/packages/http-content-negotiation/index.d.ts
+++ b/packages/http-content-negotiation/index.d.ts
@@ -12,6 +12,19 @@ interface Options {
   failOnMismatch?: boolean
 }
 
-declare function httpContentNegotiation (options?: Options): middy.MiddlewareObj
+export type Event = {
+  preferredCharsets: string[]
+  preferredCharset: string
+  preferredEncodings: string[]
+  preferredEncoding: string
+  preferredLanguages: string[]
+  preferredLanguage: string
+  preferredMediaTypes: string[]
+  preferredMediaType: string
+}
+
+declare function httpContentNegotiation(
+  options?: Options
+): middy.MiddlewareObj<Event>
 
 export default httpContentNegotiation

--- a/packages/http-content-negotiation/index.d.ts
+++ b/packages/http-content-negotiation/index.d.ts
@@ -12,7 +12,7 @@ interface Options {
   failOnMismatch?: boolean
 }
 
-export type Event = {
+export interface Event {
   preferredCharsets: string[]
   preferredCharset: string
   preferredEncodings: string[]
@@ -23,7 +23,7 @@ export type Event = {
   preferredMediaType: string
 }
 
-declare function httpContentNegotiation(
+declare function httpContentNegotiation (
   options?: Options
 ): middy.MiddlewareObj<Event>
 

--- a/packages/http-content-negotiation/index.test-d.ts
+++ b/packages/http-content-negotiation/index.test-d.ts
@@ -1,10 +1,10 @@
-import { expectType } from 'tsd'
 import middy from '@middy/core'
-import httpContentNegotiationMiddleware from '.'
+import { expectType } from 'tsd'
+import httpContentNegotiationMiddleware, { Event } from '.'
 
 // use with default options
 let middleware = httpContentNegotiationMiddleware()
-expectType<middy.MiddlewareObj>(middleware)
+expectType<middy.MiddlewareObj<Event>>(middleware)
 
 // use with all options
 middleware = httpContentNegotiationMiddleware({
@@ -18,4 +18,4 @@ middleware = httpContentNegotiationMiddleware({
   availableMediaTypes: ['application/xml', 'application/json'],
   failOnMismatch: true
 })
-expectType<middy.MiddlewareObj>(middleware)
+expectType<middy.MiddlewareObj<Event>>(middleware)

--- a/packages/http-event-normalizer/index.d.ts
+++ b/packages/http-event-normalizer/index.d.ts
@@ -1,5 +1,17 @@
 import middy from '@middy/core'
+import {
+  APIGatewayEvent,
+  APIGatewayProxyEventMultiValueQueryStringParameters,
+  APIGatewayProxyEventPathParameters,
+  APIGatewayProxyEventQueryStringParameters
+} from 'aws-lambda'
 
-declare function httpEventNormalizer (): middy.MiddlewareObj
+export type Event = APIGatewayEvent & {
+  multiValueQueryStringParameters: APIGatewayProxyEventMultiValueQueryStringParameters
+  pathParameters: APIGatewayProxyEventPathParameters
+  queryStringParameters: APIGatewayProxyEventQueryStringParameters
+}
+
+declare function httpEventNormalizer(): middy.MiddlewareObj<Event>
 
 export default httpEventNormalizer

--- a/packages/http-event-normalizer/index.d.ts
+++ b/packages/http-event-normalizer/index.d.ts
@@ -12,6 +12,6 @@ export type Event = APIGatewayEvent & {
   queryStringParameters: APIGatewayProxyEventQueryStringParameters
 }
 
-declare function httpEventNormalizer(): middy.MiddlewareObj<Event>
+declare function httpEventNormalizer (): middy.MiddlewareObj<Event>
 
 export default httpEventNormalizer

--- a/packages/http-event-normalizer/index.test-d.ts
+++ b/packages/http-event-normalizer/index.test-d.ts
@@ -1,11 +1,11 @@
-import { expectType } from 'tsd'
 import middy from '@middy/core'
-import httpEventNormalizer from '.'
+import { expectType } from 'tsd'
+import httpEventNormalizer, { Event } from '.'
 
 // use with default options
 let middleware = httpEventNormalizer()
-expectType<middy.MiddlewareObj>(middleware)
+expectType<middy.MiddlewareObj<Event>>(middleware)
 
 // use with all options
 middleware = httpEventNormalizer()
-expectType<middy.MiddlewareObj>(middleware)
+expectType<middy.MiddlewareObj<Event>>(middleware)

--- a/packages/http-event-normalizer/package-lock.json
+++ b/packages/http-event-normalizer/package-lock.json
@@ -9,7 +9,8 @@
       "version": "3.1.1",
       "license": "MIT",
       "devDependencies": {
-        "@middy/core": "3.1.1"
+        "@middy/core": "3.1.1",
+        "@types/aws-lambda": "^8.10.101"
       },
       "engines": {
         "node": ">=14"
@@ -23,6 +24,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.101",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
+      "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
+      "dev": true
     }
   },
   "dependencies": {
@@ -30,6 +37,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@middy/core/-/core-3.1.1.tgz",
       "integrity": "sha512-Og6Z1BrRWTYWDs9KF5Zb80JYv2fNwVpyMYAuG4+2fc0e8UORG4CAyccbc8SvRAReL9rLQY8pjp9WE4cdhDg3DQ==",
+      "dev": true
+    },
+    "@types/aws-lambda": {
+      "version": "8.10.101",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
+      "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
       "dev": true
     }
   }

--- a/packages/http-event-normalizer/package.json
+++ b/packages/http-event-normalizer/package.json
@@ -63,6 +63,7 @@
   "homepage": "https://middy.js.org",
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431",
   "devDependencies": {
-    "@middy/core": "3.1.1"
+    "@middy/core": "3.1.1",
+    "@types/aws-lambda": "^8.10.101"
   }
 }

--- a/packages/http-header-normalizer/index.d.ts
+++ b/packages/http-header-normalizer/index.d.ts
@@ -5,6 +5,12 @@ interface Options {
   canonical?: boolean
 }
 
-declare function httpHeaderNormalizer (options?: Options): middy.MiddlewareObj
+export type Event = {
+  rawHeaders: Record<string, string>
+}
+
+declare function httpHeaderNormalizer(
+  options?: Options
+): middy.MiddlewareObj<Event>
 
 export default httpHeaderNormalizer

--- a/packages/http-header-normalizer/index.d.ts
+++ b/packages/http-header-normalizer/index.d.ts
@@ -5,11 +5,11 @@ interface Options {
   canonical?: boolean
 }
 
-export type Event = {
+export interface Event {
   rawHeaders: Record<string, string>
 }
 
-declare function httpHeaderNormalizer(
+declare function httpHeaderNormalizer (
   options?: Options
 ): middy.MiddlewareObj<Event>
 

--- a/packages/http-header-normalizer/index.test-d.ts
+++ b/packages/http-header-normalizer/index.test-d.ts
@@ -1,14 +1,14 @@
-import { expectType } from 'tsd'
 import middy from '@middy/core'
-import httpHeaderNormalizer from '.'
+import { expectType } from 'tsd'
+import httpHeaderNormalizer, { Event } from '.'
 
 // use with default options
 let middleware = httpHeaderNormalizer()
-expectType<middy.MiddlewareObj>(middleware)
+expectType<middy.MiddlewareObj<Event>>(middleware)
 
 // use with all options
 middleware = httpHeaderNormalizer({
   normalizeHeaderKey: (key: string) => key.toLowerCase(),
   canonical: false
 })
-expectType<middy.MiddlewareObj>(middleware)
+expectType<middy.MiddlewareObj<Event>>(middleware)

--- a/packages/http-json-body-parser/index.d.ts
+++ b/packages/http-json-body-parser/index.d.ts
@@ -14,6 +14,6 @@ export type Event = Omit<APIGatewayEvent, 'body'> & {
   rawBody: string
 }
 
-declare function jsonBodyParser(options?: Options): middy.MiddlewareObj<Event>
+declare function jsonBodyParser (options?: Options): middy.MiddlewareObj<Event>
 
 export default jsonBodyParser

--- a/packages/http-json-body-parser/index.d.ts
+++ b/packages/http-json-body-parser/index.d.ts
@@ -11,6 +11,7 @@ export type Event = Omit<APIGatewayEvent, 'body'> & {
    * The body of the HTTP request.
    */
   body: JsonValue
+  rawBody: string
 }
 
 declare function jsonBodyParser(options?: Options): middy.MiddlewareObj<Event>

--- a/packages/http-json-body-parser/index.d.ts
+++ b/packages/http-json-body-parser/index.d.ts
@@ -1,9 +1,18 @@
 import middy from '@middy/core'
+import { APIGatewayEvent } from 'aws-lambda'
+import { JsonValue } from 'type-fest'
 
 interface Options {
   reviver?: (key: string, value: any) => any
 }
 
-declare function jsonBodyParser (options?: Options): middy.MiddlewareObj
+export type Event = Omit<APIGatewayEvent, 'body'> & {
+  /**
+   * The body of the HTTP request.
+   */
+  body: JsonValue
+}
+
+declare function jsonBodyParser(options?: Options): middy.MiddlewareObj<Event>
 
 export default jsonBodyParser

--- a/packages/http-json-body-parser/index.test-d.ts
+++ b/packages/http-json-body-parser/index.test-d.ts
@@ -1,13 +1,13 @@
-import { expectType } from 'tsd'
 import middy from '@middy/core'
-import jsonBodyParser from '.'
+import { expectType } from 'tsd'
+import jsonBodyParser, { Event } from '.'
 
 // use with default options
 let middleware = jsonBodyParser()
-expectType<middy.MiddlewareObj>(middleware)
+expectType<middy.MiddlewareObj<Event>>(middleware)
 
 // use with all options
 middleware = jsonBodyParser({
   reviver: (key: string, value: any) => Boolean(value)
 })
-expectType<middy.MiddlewareObj>(middleware)
+expectType<middy.MiddlewareObj<Event>>(middleware)

--- a/packages/http-json-body-parser/package-lock.json
+++ b/packages/http-json-body-parser/package-lock.json
@@ -12,7 +12,9 @@
         "@middy/util": "3.1.1"
       },
       "devDependencies": {
-        "@middy/core": "3.1.1"
+        "@middy/core": "3.1.1",
+        "@types/aws-lambda": "^8.10.101",
+        "type-fest": "^2.18.0"
       },
       "engines": {
         "node": ">=14"
@@ -34,6 +36,24 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.101",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
+      "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
+      "dev": true
+    },
+    "node_modules/type-fest": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
+      "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   },
   "dependencies": {
@@ -47,6 +67,18 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@middy/util/-/util-3.1.1.tgz",
       "integrity": "sha512-7RrfFwo/+fvVDMwJzCZugs14deI4r/9xk6Y02I8PD/3kxn5e1IKFJvnxcY32zmbIUs5eZJaSqOUSl+eehEn4qA=="
+    },
+    "@types/aws-lambda": {
+      "version": "8.10.101",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
+      "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
+      "dev": true
+    },
+    "type-fest": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
+      "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==",
+      "dev": true
     }
   }
 }

--- a/packages/http-json-body-parser/package.json
+++ b/packages/http-json-body-parser/package.json
@@ -67,7 +67,9 @@
     "@middy/util": "3.1.1"
   },
   "devDependencies": {
-    "@middy/core": "3.1.1"
+    "@middy/core": "3.1.1",
+    "@types/aws-lambda": "^8.10.101",
+    "type-fest": "^2.18.0"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"
 }

--- a/packages/http-multipart-body-parser/index.d.ts
+++ b/packages/http-multipart-body-parser/index.d.ts
@@ -25,7 +25,7 @@ export type Event = Omit<APIGatewayEvent, 'body'> & {
   body: JsonValue
 }
 
-declare function multipartBodyParser(
+declare function multipartBodyParser (
   options?: Options
 ): middy.MiddlewareObj<Event>
 

--- a/packages/http-multipart-body-parser/index.d.ts
+++ b/packages/http-multipart-body-parser/index.d.ts
@@ -1,4 +1,6 @@
 import middy from '@middy/core'
+import { APIGatewayEvent } from 'aws-lambda'
+import { JsonValue } from 'type-fest'
 
 interface Options {
   busboy?: {
@@ -19,6 +21,12 @@ interface Options {
   }
 }
 
-declare function multipartBodyParser (options?: Options): middy.MiddlewareObj
+export type Event = Omit<APIGatewayEvent, 'body'> & {
+  body: JsonValue
+}
+
+declare function multipartBodyParser(
+  options?: Options
+): middy.MiddlewareObj<Event>
 
 export default multipartBodyParser

--- a/packages/http-multipart-body-parser/index.test-d.ts
+++ b/packages/http-multipart-body-parser/index.test-d.ts
@@ -1,10 +1,10 @@
-import { expectType } from 'tsd'
 import middy from '@middy/core'
-import multipartBodyParser from '.'
+import { expectType } from 'tsd'
+import multipartBodyParser, { Event } from '.'
 
 // use with default options
 let middleware = multipartBodyParser()
-expectType<middy.MiddlewareObj>(middleware)
+expectType<middy.MiddlewareObj<Event>>(middleware)
 
 // use with all options
 middleware = multipartBodyParser({
@@ -25,4 +25,4 @@ middleware = multipartBodyParser({
     }
   }
 })
-expectType<middy.MiddlewareObj>(middleware)
+expectType<middy.MiddlewareObj<Event>>(middleware)

--- a/packages/http-multipart-body-parser/package-lock.json
+++ b/packages/http-multipart-body-parser/package-lock.json
@@ -13,7 +13,9 @@
         "busboy": "1.6.0"
       },
       "devDependencies": {
-        "@middy/core": "3.1.1"
+        "@middy/core": "3.1.1",
+        "@types/aws-lambda": "^8.10.101",
+        "type-fest": "^2.18.0"
       },
       "engines": {
         "node": ">=14"
@@ -36,6 +38,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.101",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
+      "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
+      "dev": true
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -54,6 +62,18 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/type-fest": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
+      "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   },
   "dependencies": {
@@ -68,6 +88,12 @@
       "resolved": "https://registry.npmjs.org/@middy/util/-/util-3.1.1.tgz",
       "integrity": "sha512-7RrfFwo/+fvVDMwJzCZugs14deI4r/9xk6Y02I8PD/3kxn5e1IKFJvnxcY32zmbIUs5eZJaSqOUSl+eehEn4qA=="
     },
+    "@types/aws-lambda": {
+      "version": "8.10.101",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
+      "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
+      "dev": true
+    },
     "busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -80,6 +106,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+    },
+    "type-fest": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
+      "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==",
+      "dev": true
     }
   }
 }

--- a/packages/http-multipart-body-parser/package.json
+++ b/packages/http-multipart-body-parser/package.json
@@ -66,7 +66,9 @@
     "busboy": "1.6.0"
   },
   "devDependencies": {
-    "@middy/core": "3.1.1"
+    "@middy/core": "3.1.1",
+    "@types/aws-lambda": "^8.10.101",
+    "type-fest": "^2.18.0"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"
 }

--- a/packages/http-urlencode-body-parser/index.d.ts
+++ b/packages/http-urlencode-body-parser/index.d.ts
@@ -6,6 +6,6 @@ export type Event = APIGatewayEvent & {
   body: JsonValue
 }
 
-declare function urlEncodeBodyParser(): middy.MiddlewareObj<Event>
+declare function urlEncodeBodyParser (): middy.MiddlewareObj<Event>
 
 export default urlEncodeBodyParser

--- a/packages/http-urlencode-body-parser/index.d.ts
+++ b/packages/http-urlencode-body-parser/index.d.ts
@@ -1,5 +1,11 @@
 import middy from '@middy/core'
+import { APIGatewayEvent } from 'aws-lambda'
+import { JsonValue } from 'type-fest'
 
-declare function urlEncodeBodyParser (): middy.MiddlewareObj
+export type Event = APIGatewayEvent & {
+  body: JsonValue
+}
+
+declare function urlEncodeBodyParser(): middy.MiddlewareObj<Event>
 
 export default urlEncodeBodyParser

--- a/packages/http-urlencode-body-parser/index.test-d.ts
+++ b/packages/http-urlencode-body-parser/index.test-d.ts
@@ -1,7 +1,7 @@
-import { expectType } from 'tsd'
 import middy from '@middy/core'
-import urlEncodeBodyParser from '.'
+import { expectType } from 'tsd'
+import urlEncodeBodyParser, { Event } from '.'
 
 // use with default options
 const middleware = urlEncodeBodyParser()
-expectType<middy.MiddlewareObj>(middleware)
+expectType<middy.MiddlewareObj<Event>>(middleware)

--- a/packages/http-urlencode-body-parser/package-lock.json
+++ b/packages/http-urlencode-body-parser/package-lock.json
@@ -12,7 +12,9 @@
         "qs": "6.11.0"
       },
       "devDependencies": {
-        "@middy/core": "3.1.1"
+        "@middy/core": "3.1.1",
+        "@types/aws-lambda": "^8.10.101",
+        "type-fest": "^2.18.0"
       },
       "engines": {
         "node": ">=14"
@@ -26,6 +28,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.101",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
+      "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
+      "dev": true
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -113,6 +121,18 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/type-fest": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
+      "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   },
   "dependencies": {
@@ -120,6 +140,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@middy/core/-/core-3.1.1.tgz",
       "integrity": "sha512-Og6Z1BrRWTYWDs9KF5Zb80JYv2fNwVpyMYAuG4+2fc0e8UORG4CAyccbc8SvRAReL9rLQY8pjp9WE4cdhDg3DQ==",
+      "dev": true
+    },
+    "@types/aws-lambda": {
+      "version": "8.10.101",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
+      "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
       "dev": true
     },
     "call-bind": {
@@ -181,6 +207,12 @@
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
       }
+    },
+    "type-fest": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
+      "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==",
+      "dev": true
     }
   }
 }

--- a/packages/http-urlencode-body-parser/package.json
+++ b/packages/http-urlencode-body-parser/package.json
@@ -66,7 +66,9 @@
     "qs": "6.11.0"
   },
   "devDependencies": {
-    "@middy/core": "3.1.1"
+    "@middy/core": "3.1.1",
+    "@types/aws-lambda": "^8.10.101",
+    "type-fest": "^2.18.0"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"
 }

--- a/packages/http-urlencode-path-parser/index.d.ts
+++ b/packages/http-urlencode-path-parser/index.d.ts
@@ -1,5 +1,11 @@
 import middy from '@middy/core'
+import { APIGatewayEvent } from 'aws-lambda'
+import { JsonValue } from 'type-fest'
 
-declare function urlEncodePathParser (): middy.MiddlewareObj
+export type Event = APIGatewayEvent & {
+  body: JsonValue
+}
+
+declare function urlEncodePathParser(): middy.MiddlewareObj<Event>
 
 export default urlEncodePathParser

--- a/packages/http-urlencode-path-parser/index.d.ts
+++ b/packages/http-urlencode-path-parser/index.d.ts
@@ -6,6 +6,6 @@ export type Event = APIGatewayEvent & {
   body: JsonValue
 }
 
-declare function urlEncodePathParser(): middy.MiddlewareObj<Event>
+declare function urlEncodePathParser (): middy.MiddlewareObj<Event>
 
 export default urlEncodePathParser

--- a/packages/http-urlencode-path-parser/index.test-d.ts
+++ b/packages/http-urlencode-path-parser/index.test-d.ts
@@ -1,7 +1,7 @@
-import { expectType } from 'tsd'
 import middy from '@middy/core'
-import urlEncodePathParser from '.'
+import { expectType } from 'tsd'
+import urlEncodePathParser, { Event } from '.'
 
 // use with default options
 const middleware = urlEncodePathParser()
-expectType<middy.MiddlewareObj>(middleware)
+expectType<middy.MiddlewareObj<Event>>(middleware)

--- a/packages/http-urlencode-path-parser/package-lock.json
+++ b/packages/http-urlencode-path-parser/package-lock.json
@@ -9,7 +9,9 @@
       "version": "3.1.1",
       "license": "MIT",
       "devDependencies": {
-        "@middy/core": "3.1.1"
+        "@middy/core": "3.1.1",
+        "@types/aws-lambda": "^8.10.101",
+        "type-fest": "^2.18.0"
       },
       "engines": {
         "node": ">=14"
@@ -23,6 +25,24 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.101",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
+      "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
+      "dev": true
+    },
+    "node_modules/type-fest": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
+      "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   },
   "dependencies": {
@@ -30,6 +50,18 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@middy/core/-/core-3.1.1.tgz",
       "integrity": "sha512-Og6Z1BrRWTYWDs9KF5Zb80JYv2fNwVpyMYAuG4+2fc0e8UORG4CAyccbc8SvRAReL9rLQY8pjp9WE4cdhDg3DQ==",
+      "dev": true
+    },
+    "@types/aws-lambda": {
+      "version": "8.10.101",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
+      "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
+      "dev": true
+    },
+    "type-fest": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
+      "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==",
       "dev": true
     }
   }

--- a/packages/http-urlencode-path-parser/package.json
+++ b/packages/http-urlencode-path-parser/package.json
@@ -63,7 +63,9 @@
   },
   "homepage": "https://middy.js.org",
   "devDependencies": {
-    "@middy/core": "3.1.1"
+    "@middy/core": "3.1.1",
+    "@types/aws-lambda": "^8.10.101",
+    "type-fest": "^2.18.0"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"
 }

--- a/packages/s3-object-response/index.d.ts
+++ b/packages/s3-object-response/index.d.ts
@@ -26,6 +26,6 @@ export type Context<TOptions extends Options | undefined> = LambdaContext & {
 
 declare function s3ObjectResponse<TOptions extends Options | undefined> (
   options?: TOptions
-): middy.MiddlewareObj<unknown, any, any, Context<TOptions>>
+): middy.MiddlewareObj<unknown, any, Error, Context<TOptions>>
 
 export default s3ObjectResponse

--- a/packages/s3-object-response/index.d.ts
+++ b/packages/s3-object-response/index.d.ts
@@ -1,13 +1,31 @@
-import S3 from 'aws-sdk/clients/s3'
 import middy from '@middy/core'
 import { Options as MiddyOptions } from '@middy/util'
+import { Context } from 'aws-lambda'
+import S3 from 'aws-sdk/clients/s3'
+import { ClientRequest } from 'http'
 
 interface Options<S = S3>
-  extends Pick<MiddyOptions<S, S3.Types.ClientConfiguration>,
-  'AwsClient' | 'awsClientOptions' | 'awsClientAssumeRole' | 'awsClientCapture' | 'disablePrefetch'> {
+  extends Pick<
+    MiddyOptions<S, S3.Types.ClientConfiguration>,
+    | 'AwsClient'
+    | 'awsClientOptions'
+    | 'awsClientAssumeRole'
+    | 'awsClientCapture'
+    | 'disablePrefetch'
+  > {
   bodyType?: 'stream' | 'promise'
 }
 
-declare function s3ObjectResponse (options?: Options): middy.MiddlewareObj
+export type S3ObjectContext<TOptions extends Options | undefined> = Context & {
+  s3Object: TOptions extends { bodyType: 'stream' }
+    ? ClientRequest
+    : TOptions extends { bodyType: 'promise' }
+    ? Promise<any>
+    : void
+}
+
+declare function s3ObjectResponse<TOptions extends Options | undefined>(
+  options?: TOptions
+): middy.MiddlewareObj<unknown, any, any, S3ObjectContext<TOptions>>
 
 export default s3ObjectResponse

--- a/packages/s3-object-response/index.d.ts
+++ b/packages/s3-object-response/index.d.ts
@@ -6,12 +6,12 @@ import { ClientRequest } from 'http'
 
 interface Options<S = S3>
   extends Pick<
-    MiddyOptions<S, S3.Types.ClientConfiguration>,
-    | 'AwsClient'
-    | 'awsClientOptions'
-    | 'awsClientAssumeRole'
-    | 'awsClientCapture'
-    | 'disablePrefetch'
+  MiddyOptions<S, S3.Types.ClientConfiguration>,
+  | 'AwsClient'
+  | 'awsClientOptions'
+  | 'awsClientAssumeRole'
+  | 'awsClientCapture'
+  | 'disablePrefetch'
   > {
   bodyType?: 'stream' | 'promise'
 }
@@ -20,11 +20,11 @@ export type Context<TOptions extends Options | undefined> = LambdaContext & {
   s3Object: TOptions extends { bodyType: 'stream' }
     ? ClientRequest
     : TOptions extends { bodyType: 'promise' }
-    ? Promise<any>
-    : void
+      ? Promise<any>
+      : never
 }
 
-declare function s3ObjectResponse<TOptions extends Options | undefined>(
+declare function s3ObjectResponse<TOptions extends Options | undefined> (
   options?: TOptions
 ): middy.MiddlewareObj<unknown, any, any, Context<TOptions>>
 

--- a/packages/s3-object-response/index.d.ts
+++ b/packages/s3-object-response/index.d.ts
@@ -1,6 +1,6 @@
 import middy from '@middy/core'
 import { Options as MiddyOptions } from '@middy/util'
-import { Context } from 'aws-lambda'
+import { Context as LambdaContext } from 'aws-lambda'
 import S3 from 'aws-sdk/clients/s3'
 import { ClientRequest } from 'http'
 
@@ -16,7 +16,7 @@ interface Options<S = S3>
   bodyType?: 'stream' | 'promise'
 }
 
-export type S3ObjectContext<TOptions extends Options | undefined> = Context & {
+export type Context<TOptions extends Options | undefined> = LambdaContext & {
   s3Object: TOptions extends { bodyType: 'stream' }
     ? ClientRequest
     : TOptions extends { bodyType: 'promise' }
@@ -26,6 +26,6 @@ export type S3ObjectContext<TOptions extends Options | undefined> = Context & {
 
 declare function s3ObjectResponse<TOptions extends Options | undefined>(
   options?: TOptions
-): middy.MiddlewareObj<unknown, any, any, S3ObjectContext<TOptions>>
+): middy.MiddlewareObj<unknown, any, any, Context<TOptions>>
 
 export default s3ObjectResponse

--- a/packages/s3-object-response/index.test-d.ts
+++ b/packages/s3-object-response/index.test-d.ts
@@ -6,7 +6,7 @@ import s3ObjectResponse, { Context } from '.'
 
 // use with default options
 let middleware = s3ObjectResponse()
-expectType<middy.MiddlewareObj<unknown, any, any, Context<undefined>>>(
+expectType<middy.MiddlewareObj<unknown, any, Error, Context<undefined>>>(
   middleware
 )
 
@@ -16,6 +16,6 @@ middleware = s3ObjectResponse({
   awsClientCapture: captureAWSClient,
   disablePrefetch: true
 })
-expectType<middy.MiddlewareObj<unknown, any, any, Context<undefined>>>(
+expectType<middy.MiddlewareObj<unknown, any, Error, Context<undefined>>>(
   middleware
 )

--- a/packages/s3-object-response/index.test-d.ts
+++ b/packages/s3-object-response/index.test-d.ts
@@ -1,12 +1,14 @@
-import { expectType } from 'tsd'
 import middy from '@middy/core'
 import S3 from 'aws-sdk/clients/s3'
 import { captureAWSClient } from 'aws-xray-sdk'
-import s3ObjectResponse from '.'
+import { expectType } from 'tsd'
+import s3ObjectResponse, { S3ObjectContext } from '.'
 
 // use with default options
 let middleware = s3ObjectResponse()
-expectType<middy.MiddlewareObj>(middleware)
+expectType<middy.MiddlewareObj<unknown, any, any, S3ObjectContext<undefined>>>(
+  middleware
+)
 
 // use with all options
 middleware = s3ObjectResponse({
@@ -14,4 +16,6 @@ middleware = s3ObjectResponse({
   awsClientCapture: captureAWSClient,
   disablePrefetch: true
 })
-expectType<middy.MiddlewareObj>(middleware)
+expectType<middy.MiddlewareObj<unknown, any, any, S3ObjectContext<undefined>>>(
+  middleware
+)

--- a/packages/s3-object-response/index.test-d.ts
+++ b/packages/s3-object-response/index.test-d.ts
@@ -2,11 +2,11 @@ import middy from '@middy/core'
 import S3 from 'aws-sdk/clients/s3'
 import { captureAWSClient } from 'aws-xray-sdk'
 import { expectType } from 'tsd'
-import s3ObjectResponse, { S3ObjectContext } from '.'
+import s3ObjectResponse, { Context } from '.'
 
 // use with default options
 let middleware = s3ObjectResponse()
-expectType<middy.MiddlewareObj<unknown, any, any, S3ObjectContext<undefined>>>(
+expectType<middy.MiddlewareObj<unknown, any, any, Context<undefined>>>(
   middleware
 )
 
@@ -16,6 +16,6 @@ middleware = s3ObjectResponse({
   awsClientCapture: captureAWSClient,
   disablePrefetch: true
 })
-expectType<middy.MiddlewareObj<unknown, any, any, S3ObjectContext<undefined>>>(
+expectType<middy.MiddlewareObj<unknown, any, any, Context<undefined>>>(
   middleware
 )

--- a/packages/s3-object-response/package-lock.json
+++ b/packages/s3-object-response/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@middy/core": "3.1.1",
+        "@types/aws-lambda": "^8.10.101",
         "aws-sdk": "^2.939.0",
         "aws-xray-sdk": "^3.3.3"
       },
@@ -54,6 +55,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.101",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
+      "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
+      "dev": true
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
@@ -122,9 +129,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.6.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
-      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==",
+      "version": "18.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
+      "integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==",
       "dev": true
     },
     "node_modules/@types/pg": {
@@ -1174,6 +1181,12 @@
       "resolved": "https://registry.npmjs.org/@middy/util/-/util-3.1.1.tgz",
       "integrity": "sha512-7RrfFwo/+fvVDMwJzCZugs14deI4r/9xk6Y02I8PD/3kxn5e1IKFJvnxcY32zmbIUs5eZJaSqOUSl+eehEn4qA=="
     },
+    "@types/aws-lambda": {
+      "version": "8.10.101",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
+      "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
+      "dev": true
+    },
     "@types/body-parser": {
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
@@ -1241,9 +1254,9 @@
       }
     },
     "@types/node": {
-      "version": "18.6.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
-      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==",
+      "version": "18.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
+      "integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==",
       "dev": true
     },
     "@types/pg": {

--- a/packages/s3-object-response/package.json
+++ b/packages/s3-object-response/package.json
@@ -66,6 +66,7 @@
   },
   "devDependencies": {
     "@middy/core": "3.1.1",
+    "@types/aws-lambda": "^8.10.101",
     "aws-sdk": "^2.939.0",
     "aws-xray-sdk": "^3.3.3"
   },

--- a/packages/secrets-manager/index.d.ts
+++ b/packages/secrets-manager/index.d.ts
@@ -1,9 +1,19 @@
-import SecretsManager from 'aws-sdk/clients/secretsmanager'
 import middy from '@middy/core'
 import { Options as MiddyOptions } from '@middy/util'
+import { Context as LambdaContext } from 'aws-lambda'
+import SecretsManager from 'aws-sdk/clients/secretsmanager'
 
-interface Options<SM = SecretsManager> extends MiddyOptions<SM, SecretsManager.Types.ClientConfiguration> {}
+interface Options<SM = SecretsManager>
+  extends MiddyOptions<SM, SecretsManager.Types.ClientConfiguration> {}
 
-declare function secretsManager (options?: Options): middy.MiddlewareObj
+export type Context<TOptions extends Options | undefined> = TOptions extends {
+  setToContext: true
+}
+  ? LambdaContext & Record<keyof TOptions['fetchData'], any>
+  : LambdaContext
+
+declare function secretsManager<TOptions extends Options | undefined>(
+  options?: TOptions
+): middy.MiddlewareObj<unknown, any, any, Context<TOptions>>
 
 export default secretsManager

--- a/packages/secrets-manager/index.d.ts
+++ b/packages/secrets-manager/index.d.ts
@@ -12,7 +12,7 @@ export type Context<TOptions extends Options | undefined> = TOptions extends {
   ? LambdaContext & Record<keyof TOptions['fetchData'], any>
   : LambdaContext
 
-declare function secretsManager<TOptions extends Options | undefined>(
+declare function secretsManager<TOptions extends Options | undefined> (
   options?: TOptions
 ): middy.MiddlewareObj<unknown, any, any, Context<TOptions>>
 

--- a/packages/secrets-manager/index.d.ts
+++ b/packages/secrets-manager/index.d.ts
@@ -14,6 +14,6 @@ export type Context<TOptions extends Options | undefined> = TOptions extends {
 
 declare function secretsManager<TOptions extends Options | undefined> (
   options?: TOptions
-): middy.MiddlewareObj<unknown, any, any, Context<TOptions>>
+): middy.MiddlewareObj<unknown, any, Error, Context<TOptions>>
 
 export default secretsManager

--- a/packages/secrets-manager/index.test-d.ts
+++ b/packages/secrets-manager/index.test-d.ts
@@ -5,7 +5,7 @@ import { expectType } from 'tsd'
 import rdsSigner, { Context } from '.'
 
 // use with default options
-expectType<middy.MiddlewareObj<unknown, any, any, Context<undefined>>>(
+expectType<middy.MiddlewareObj<unknown, any, Error, Context<undefined>>>(
   rdsSigner()
 )
 
@@ -24,6 +24,6 @@ const options = {
 }
 
 // use with all options
-expectType<middy.MiddlewareObj<unknown, any, any, Context<typeof options>>>(
+expectType<middy.MiddlewareObj<unknown, any, Error, Context<typeof options>>>(
   rdsSigner(options)
 )

--- a/packages/secrets-manager/index.test-d.ts
+++ b/packages/secrets-manager/index.test-d.ts
@@ -1,15 +1,15 @@
-import { expectType } from 'tsd'
 import middy from '@middy/core'
 import SecretsManager from 'aws-sdk/clients/secretsmanager'
 import { captureAWSClient } from 'aws-xray-sdk'
-import rdsSigner from '.'
+import { expectType } from 'tsd'
+import rdsSigner, { Context } from '.'
 
 // use with default options
-let middleware = rdsSigner()
-expectType<middy.MiddlewareObj>(middleware)
+expectType<middy.MiddlewareObj<unknown, any, any, Context<undefined>>>(
+  rdsSigner()
+)
 
-// use with all options
-middleware = rdsSigner({
+const options = {
   AwsClient: SecretsManager,
   awsClientOptions: {
     secretAccessKey: 'abc'
@@ -21,5 +21,9 @@ middleware = rdsSigner({
   cacheKey: 'some-key',
   cacheExpiry: 60 * 60 * 5,
   setToContext: true
-})
-expectType<middy.MiddlewareObj>(middleware)
+}
+
+// use with all options
+expectType<middy.MiddlewareObj<unknown, any, any, Context<typeof options>>>(
+  rdsSigner(options)
+)

--- a/packages/secrets-manager/package-lock.json
+++ b/packages/secrets-manager/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@middy/core": "3.1.1",
+        "@types/aws-lambda": "^8.10.101",
         "aws-sdk": "^2.939.0",
         "aws-xray-sdk": "^3.3.3"
       },
@@ -54,6 +55,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.101",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
+      "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
+      "dev": true
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
@@ -122,9 +129,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.6.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
-      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==",
+      "version": "18.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
+      "integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==",
       "dev": true
     },
     "node_modules/@types/pg": {
@@ -1174,6 +1181,12 @@
       "resolved": "https://registry.npmjs.org/@middy/util/-/util-3.1.1.tgz",
       "integrity": "sha512-7RrfFwo/+fvVDMwJzCZugs14deI4r/9xk6Y02I8PD/3kxn5e1IKFJvnxcY32zmbIUs5eZJaSqOUSl+eehEn4qA=="
     },
+    "@types/aws-lambda": {
+      "version": "8.10.101",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
+      "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
+      "dev": true
+    },
     "@types/body-parser": {
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
@@ -1241,9 +1254,9 @@
       }
     },
     "@types/node": {
-      "version": "18.6.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
-      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==",
+      "version": "18.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
+      "integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==",
       "dev": true
     },
     "@types/pg": {

--- a/packages/secrets-manager/package.json
+++ b/packages/secrets-manager/package.json
@@ -64,6 +64,7 @@
   },
   "devDependencies": {
     "@middy/core": "3.1.1",
+    "@types/aws-lambda": "^8.10.101",
     "aws-sdk": "^2.939.0",
     "aws-xray-sdk": "^3.3.3"
   },

--- a/packages/service-discovery/index.d.ts
+++ b/packages/service-discovery/index.d.ts
@@ -7,15 +7,15 @@ import ServiceDiscovery, {
 
 interface Options<S = ServiceDiscovery>
   extends Pick<
-    MiddyOptions<S, ServiceDiscovery.Types.ClientConfiguration>,
-    | 'AwsClient'
-    | 'awsClientOptions'
-    | 'awsClientCapture'
-    | 'fetchData'
-    | 'disablePrefetch'
-    | 'cacheKey'
-    | 'cacheExpiry'
-    | 'setToContext'
+  MiddyOptions<S, ServiceDiscovery.Types.ClientConfiguration>,
+  | 'AwsClient'
+  | 'awsClientOptions'
+  | 'awsClientCapture'
+  | 'fetchData'
+  | 'disablePrefetch'
+  | 'cacheKey'
+  | 'cacheExpiry'
+  | 'setToContext'
   > {}
 
 export type Context<TOptions extends Options | undefined> = TOptions extends {
@@ -24,7 +24,7 @@ export type Context<TOptions extends Options | undefined> = TOptions extends {
   ? LambdaContext & Record<keyof TOptions['fetchData'], HttpInstanceSummaryList>
   : LambdaContext
 
-declare function serviceDiscovery<TOptions extends Options | undefined>(
+declare function serviceDiscovery<TOptions extends Options | undefined> (
   options?: TOptions
 ): middy.MiddlewareObj<unknown, any, Error, Context<TOptions>>
 

--- a/packages/service-discovery/index.d.ts
+++ b/packages/service-discovery/index.d.ts
@@ -1,13 +1,31 @@
-import ServiceDiscovery from 'aws-sdk/clients/servicediscovery'
 import middy from '@middy/core'
 import { Options as MiddyOptions } from '@middy/util'
+import { Context as LambdaContext } from 'aws-lambda'
+import ServiceDiscovery, {
+  HttpInstanceSummaryList
+} from 'aws-sdk/clients/servicediscovery'
 
 interface Options<S = ServiceDiscovery>
-  extends Pick<MiddyOptions<S, ServiceDiscovery.Types.ClientConfiguration>,
-  'AwsClient' | 'awsClientOptions' | 'awsClientCapture' |
-  'fetchData' | 'disablePrefetch' | 'cacheKey' | 'cacheExpiry' | 'setToContext'> {
-}
+  extends Pick<
+    MiddyOptions<S, ServiceDiscovery.Types.ClientConfiguration>,
+    | 'AwsClient'
+    | 'awsClientOptions'
+    | 'awsClientCapture'
+    | 'fetchData'
+    | 'disablePrefetch'
+    | 'cacheKey'
+    | 'cacheExpiry'
+    | 'setToContext'
+  > {}
 
-declare function serviceDiscovery (options?: Options): middy.MiddlewareObj
+export type Context<TOptions extends Options | undefined> = TOptions extends {
+  setToContext: true
+}
+  ? LambdaContext & Record<keyof TOptions['fetchData'], HttpInstanceSummaryList>
+  : LambdaContext
+
+declare function serviceDiscovery<TOptions extends Options | undefined>(
+  options?: TOptions
+): middy.MiddlewareObj<unknown, any, Error, Context<TOptions>>
 
 export default serviceDiscovery

--- a/packages/service-discovery/index.test-d.ts
+++ b/packages/service-discovery/index.test-d.ts
@@ -1,18 +1,21 @@
-import { expectType } from 'tsd'
 import middy from '@middy/core'
 import ServiceDiscovery from 'aws-sdk/clients/servicediscovery'
 import { captureAWSClient } from 'aws-xray-sdk'
-import serviceDiscovery from '.'
+import { expectType } from 'tsd'
+import serviceDiscovery, { Context } from '.'
 
 // use with default options
-let middleware = serviceDiscovery()
-expectType<middy.MiddlewareObj>(middleware)
+expectType<middy.MiddlewareObj<unknown, any, Error, Context<undefined>>>(
+  serviceDiscovery()
+)
 
 // use with all options
-middleware = serviceDiscovery({
+const options = {
   AwsClient: ServiceDiscovery,
   awsClientOptions: {},
   awsClientCapture: captureAWSClient,
   disablePrefetch: true
-})
-expectType<middy.MiddlewareObj>(middleware)
+}
+expectType<middy.MiddlewareObj<unknown, any, Error, Context<typeof options>>>(
+  serviceDiscovery()
+)

--- a/packages/service-discovery/package-lock.json
+++ b/packages/service-discovery/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@middy/core": "3.1.1",
+        "@types/aws-lambda": "^8.10.101",
         "aws-sdk": "^2.939.0",
         "aws-xray-sdk": "^3.3.3"
       },
@@ -54,6 +55,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.101",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
+      "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
+      "dev": true
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
@@ -122,9 +129,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.6.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
-      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==",
+      "version": "18.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
+      "integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==",
       "dev": true
     },
     "node_modules/@types/pg": {
@@ -1174,6 +1181,12 @@
       "resolved": "https://registry.npmjs.org/@middy/util/-/util-3.1.1.tgz",
       "integrity": "sha512-7RrfFwo/+fvVDMwJzCZugs14deI4r/9xk6Y02I8PD/3kxn5e1IKFJvnxcY32zmbIUs5eZJaSqOUSl+eehEn4qA=="
     },
+    "@types/aws-lambda": {
+      "version": "8.10.101",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
+      "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
+      "dev": true
+    },
     "@types/body-parser": {
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
@@ -1241,9 +1254,9 @@
       }
     },
     "@types/node": {
-      "version": "18.6.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
-      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==",
+      "version": "18.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
+      "integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==",
       "dev": true
     },
     "@types/pg": {

--- a/packages/service-discovery/package.json
+++ b/packages/service-discovery/package.json
@@ -65,6 +65,7 @@
   },
   "devDependencies": {
     "@middy/core": "3.1.1",
+    "@types/aws-lambda": "^8.10.101",
     "aws-sdk": "^2.939.0",
     "aws-xray-sdk": "^3.3.3"
   },

--- a/packages/ssm/index.d.ts
+++ b/packages/ssm/index.d.ts
@@ -15,11 +15,11 @@ export type Context<TOptions extends Options | undefined> = TOptions extends {
   setToContext: true
 }
   ? LambdaContext &
-      Record<Basename<ExtractPaths<keyof TOptions['fetchData']>>, JsonValue> &
-      Record<ExtractSingles<keyof TOptions['fetchData']>, JsonValue>
+  Record<Basename<ExtractPaths<keyof TOptions['fetchData']>>, JsonValue> &
+  Record<ExtractSingles<keyof TOptions['fetchData']>, JsonValue>
   : LambdaContext
 
-declare function ssm<TOptions extends Options>(
+declare function ssm<TOptions extends Options> (
   options?: TOptions
 ): middy.MiddlewareObj<unknown, any, any, Context<TOptions>>
 

--- a/packages/ssm/index.d.ts
+++ b/packages/ssm/index.d.ts
@@ -7,8 +7,11 @@ import { JsonValue } from 'type-fest'
 interface Options<S = SSM>
   extends MiddyOptions<S, SSM.Types.ClientConfiguration> {}
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 type Basename<T> = T extends `${infer _P}/${infer _S}` ? Basename<_S> : T
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 type ExtractPaths<T> = T extends `${infer _P}/${infer _S}` ? T : never
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 type ExtractSingles<T> = T extends `${infer _P}/${infer _S}` ? never : T
 
 export type Context<TOptions extends Options | undefined> = TOptions extends {
@@ -21,6 +24,6 @@ export type Context<TOptions extends Options | undefined> = TOptions extends {
 
 declare function ssm<TOptions extends Options> (
   options?: TOptions
-): middy.MiddlewareObj<unknown, any, any, Context<TOptions>>
+): middy.MiddlewareObj<unknown, any, Error, Context<TOptions>>
 
 export default ssm

--- a/packages/ssm/index.d.ts
+++ b/packages/ssm/index.d.ts
@@ -1,9 +1,26 @@
-import SSM from 'aws-sdk/clients/ssm'
-import { Options as MiddyOptions } from '@middy/util'
 import middy from '@middy/core'
+import { Options as MiddyOptions } from '@middy/util'
+import { Context as LambdaContext } from 'aws-lambda'
+import SSM from 'aws-sdk/clients/ssm'
+import { JsonValue } from 'type-fest'
 
-interface Options<S = SSM> extends MiddyOptions<S, SSM.Types.ClientConfiguration> {}
+interface Options<S = SSM>
+  extends MiddyOptions<S, SSM.Types.ClientConfiguration> {}
 
-declare function ssm (options?: Options): middy.MiddlewareObj
+type Basename<T> = T extends `${infer _P}/${infer _S}` ? Basename<_S> : T
+type ExtractPaths<T> = T extends `${infer _P}/${infer _S}` ? T : never
+type ExtractSingles<T> = T extends `${infer _P}/${infer _S}` ? never : T
+
+export type Context<TOptions extends Options | undefined> = TOptions extends {
+  setToContext: true
+}
+  ? LambdaContext &
+      Record<Basename<ExtractPaths<keyof TOptions['fetchData']>>, JsonValue> &
+      Record<ExtractSingles<keyof TOptions['fetchData']>, JsonValue>
+  : LambdaContext
+
+declare function ssm<TOptions extends Options>(
+  options?: TOptions
+): middy.MiddlewareObj<unknown, any, any, Context<TOptions>>
 
 export default ssm

--- a/packages/ssm/index.d.ts
+++ b/packages/ssm/index.d.ts
@@ -8,18 +8,17 @@ interface Options<S = SSM>
   extends MiddyOptions<S, SSM.Types.ClientConfiguration> {}
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-type Basename<T> = T extends `${infer _P}/${infer _S}` ? Basename<_S> : T
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type ExtractPaths<T> = T extends `${infer _P}/${infer _S}` ? T : never
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type ExtractSingles<T> = T extends `${infer _P}/${infer _S}` ? never : T
+type ExtractSingles<T> = T extends `/${infer _}` ? never : T
 
 export type Context<TOptions extends Options | undefined> = TOptions extends {
   setToContext: true
 }
   ? LambdaContext &
-  Record<Basename<ExtractPaths<keyof TOptions['fetchData']>>, JsonValue> &
-  Record<ExtractSingles<keyof TOptions['fetchData']>, JsonValue>
+  Record<ExtractSingles<keyof TOptions['fetchData']>, JsonValue> &
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  (keyof TOptions['fetchData'] extends `${infer _P}/${infer _S}`
+    ? Record<string, JsonValue>
+    : unknown)
   : LambdaContext
 
 declare function ssm<TOptions extends Options> (

--- a/packages/ssm/index.test-d.ts
+++ b/packages/ssm/index.test-d.ts
@@ -1,15 +1,14 @@
-import { expectType } from 'tsd'
 import middy from '@middy/core'
 import SSM from 'aws-sdk/clients/ssm'
 import { captureAWSClient } from 'aws-xray-sdk'
-import ssm from '.'
+import { expectType } from 'tsd'
+import ssm, { Context } from '.'
 
 // use with default options
-let middleware = ssm()
-expectType<middy.MiddlewareObj>(middleware)
+expectType<middy.MiddlewareObj<unknown, any, Error, Context<undefined>>>(ssm())
 
 // use with all options
-middleware = ssm({
+const options = {
   AwsClient: SSM,
   awsClientOptions: {
     secretAccessKey: 'abc'
@@ -17,5 +16,7 @@ middleware = ssm({
   awsClientAssumeRole: 'some-role',
   awsClientCapture: captureAWSClient,
   disablePrefetch: true
-})
-expectType<middy.MiddlewareObj>(middleware)
+}
+expectType<middy.MiddlewareObj<unknown, any, Error, Context<typeof options>>>(
+  ssm(options)
+)

--- a/packages/ssm/package-lock.json
+++ b/packages/ssm/package-lock.json
@@ -13,8 +13,10 @@
       },
       "devDependencies": {
         "@middy/core": "3.1.1",
+        "@types/aws-lambda": "^8.10.101",
         "aws-sdk": "^2.939.0",
-        "aws-xray-sdk": "^3.3.3"
+        "aws-xray-sdk": "^3.3.3",
+        "type-fest": "^2.18.0"
       },
       "engines": {
         "node": ">=14"
@@ -54,6 +56,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.101",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
+      "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
+      "dev": true
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
@@ -122,9 +130,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.6.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
-      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==",
+      "version": "18.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
+      "integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==",
       "dev": true
     },
     "node_modules/@types/pg": {
@@ -1037,6 +1045,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/type-fest": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
+      "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -1174,6 +1194,12 @@
       "resolved": "https://registry.npmjs.org/@middy/util/-/util-3.1.1.tgz",
       "integrity": "sha512-7RrfFwo/+fvVDMwJzCZugs14deI4r/9xk6Y02I8PD/3kxn5e1IKFJvnxcY32zmbIUs5eZJaSqOUSl+eehEn4qA=="
     },
+    "@types/aws-lambda": {
+      "version": "8.10.101",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
+      "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
+      "dev": true
+    },
     "@types/body-parser": {
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
@@ -1241,9 +1267,9 @@
       }
     },
     "@types/node": {
-      "version": "18.6.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
-      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==",
+      "version": "18.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
+      "integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==",
       "dev": true
     },
     "@types/pg": {
@@ -1892,6 +1918,12 @@
         "define-properties": "^1.1.4",
         "es-abstract": "^1.19.5"
       }
+    },
+    "type-fest": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
+      "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/packages/ssm/package.json
+++ b/packages/ssm/package.json
@@ -66,8 +66,10 @@
   },
   "devDependencies": {
     "@middy/core": "3.1.1",
+    "@types/aws-lambda": "^8.10.101",
     "aws-sdk": "^2.939.0",
-    "aws-xray-sdk": "^3.3.3"
+    "aws-xray-sdk": "^3.3.3",
+    "type-fest": "^2.18.0"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"
 }

--- a/packages/sts/index.d.ts
+++ b/packages/sts/index.d.ts
@@ -30,6 +30,8 @@ export type Context<TOptions extends Options | undefined> = TOptions extends {
   >
   : LambdaContext
 
-declare function sts (options?: Options): middy.MiddlewareObj
+declare function sts<TOptions extends Options> (
+  options?: TOptions
+): middy.MiddlewareObj<unknown, any, Error, Context<TOptions>>
 
 export default sts

--- a/packages/sts/index.d.ts
+++ b/packages/sts/index.d.ts
@@ -5,31 +5,31 @@ import STS from 'aws-sdk/clients/sts'
 
 interface Options<S = STS>
   extends Pick<
-    MiddyOptions<S, STS.Types.ClientConfiguration>,
-    | 'AwsClient'
-    | 'awsClientOptions'
-    | 'awsClientCapture'
-    | 'fetchData'
-    | 'disablePrefetch'
-    | 'cacheKey'
-    | 'cacheExpiry'
-    | 'setToContext'
+  MiddyOptions<S, STS.Types.ClientConfiguration>,
+  | 'AwsClient'
+  | 'awsClientOptions'
+  | 'awsClientCapture'
+  | 'fetchData'
+  | 'disablePrefetch'
+  | 'cacheKey'
+  | 'cacheExpiry'
+  | 'setToContext'
   > {}
 
 export type Context<TOptions extends Options | undefined> = TOptions extends {
   setToContext: true
 }
   ? LambdaContext &
-      Record<
-        keyof TOptions['fetchData'],
-        {
-          accessKeyId: STS.accessKeyIdType
-          secretAccessKey: STS.accessKeySecretType
-          sessionToken: STS.tokenType
-        }
-      >
+  Record<
+  keyof TOptions['fetchData'],
+  {
+    accessKeyId: STS.accessKeyIdType
+    secretAccessKey: STS.accessKeySecretType
+    sessionToken: STS.tokenType
+  }
+  >
   : LambdaContext
 
-declare function sts(options?: Options): middy.MiddlewareObj
+declare function sts (options?: Options): middy.MiddlewareObj
 
 export default sts

--- a/packages/sts/index.d.ts
+++ b/packages/sts/index.d.ts
@@ -1,13 +1,35 @@
-import STS from 'aws-sdk/clients/sts'
 import middy from '@middy/core'
 import { Options as MiddyOptions } from '@middy/util'
+import { Context as LambdaContext } from 'aws-lambda'
+import STS from 'aws-sdk/clients/sts'
 
 interface Options<S = STS>
-  extends Pick<MiddyOptions<S, STS.Types.ClientConfiguration>,
-  'AwsClient' | 'awsClientOptions' | 'awsClientCapture' |
-  'fetchData' | 'disablePrefetch' | 'cacheKey' | 'cacheExpiry' | 'setToContext'> {
-}
+  extends Pick<
+    MiddyOptions<S, STS.Types.ClientConfiguration>,
+    | 'AwsClient'
+    | 'awsClientOptions'
+    | 'awsClientCapture'
+    | 'fetchData'
+    | 'disablePrefetch'
+    | 'cacheKey'
+    | 'cacheExpiry'
+    | 'setToContext'
+  > {}
 
-declare function sts (options?: Options): middy.MiddlewareObj
+export type Context<TOptions extends Options | undefined> = TOptions extends {
+  setToContext: true
+}
+  ? LambdaContext &
+      Record<
+        keyof TOptions['fetchData'],
+        {
+          accessKeyId: STS.accessKeyIdType
+          secretAccessKey: STS.accessKeySecretType
+          sessionToken: STS.tokenType
+        }
+      >
+  : LambdaContext
+
+declare function sts(options?: Options): middy.MiddlewareObj
 
 export default sts

--- a/packages/sts/index.test-d.ts
+++ b/packages/sts/index.test-d.ts
@@ -1,20 +1,21 @@
-import { expectType } from 'tsd'
 import middy from '@middy/core'
 import STS from 'aws-sdk/clients/sts'
 import { captureAWSClient } from 'aws-xray-sdk'
-import sts from '.'
+import { expectType } from 'tsd'
+import sts, { Context } from '.'
 
 // use with default options
-let middleware = sts()
-expectType<middy.MiddlewareObj>(middleware)
+expectType<middy.MiddlewareObj<unknown, any, Error, Context<undefined>>>(sts())
 
 // use with all options
-middleware = sts({
+const options = {
   AwsClient: STS,
   awsClientOptions: {
     secretAccessKey: 'abc'
   },
   awsClientCapture: captureAWSClient,
   disablePrefetch: true
-})
-expectType<middy.MiddlewareObj>(middleware)
+}
+expectType<middy.MiddlewareObj<unknown, any, Error, Context<typeof options>>>(
+  sts(options)
+)

--- a/packages/sts/package-lock.json
+++ b/packages/sts/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@middy/core": "3.1.1",
+        "@types/aws-lambda": "^8.10.101",
         "aws-sdk": "^2.939.0",
         "aws-xray-sdk": "^3.3.3"
       },
@@ -54,6 +55,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.101",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
+      "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
+      "dev": true
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
@@ -122,9 +129,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.6.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
-      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==",
+      "version": "18.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
+      "integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==",
       "dev": true
     },
     "node_modules/@types/pg": {
@@ -1174,6 +1181,12 @@
       "resolved": "https://registry.npmjs.org/@middy/util/-/util-3.1.1.tgz",
       "integrity": "sha512-7RrfFwo/+fvVDMwJzCZugs14deI4r/9xk6Y02I8PD/3kxn5e1IKFJvnxcY32zmbIUs5eZJaSqOUSl+eehEn4qA=="
     },
+    "@types/aws-lambda": {
+      "version": "8.10.101",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
+      "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
+      "dev": true
+    },
     "@types/body-parser": {
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
@@ -1241,9 +1254,9 @@
       }
     },
     "@types/node": {
-      "version": "18.6.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
-      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==",
+      "version": "18.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
+      "integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==",
       "dev": true
     },
     "@types/pg": {

--- a/packages/sts/package.json
+++ b/packages/sts/package.json
@@ -66,6 +66,7 @@
   },
   "devDependencies": {
     "@middy/core": "3.1.1",
+    "@types/aws-lambda": "^8.10.101",
     "aws-sdk": "^2.939.0",
     "aws-xray-sdk": "^3.3.3"
   },

--- a/packages/ws-json-body-parser/index.d.ts
+++ b/packages/ws-json-body-parser/index.d.ts
@@ -1,9 +1,15 @@
 import middy from '@middy/core'
+import { APIGatewayProxyWebsocketEventV2 } from 'aws-lambda'
+import { JsonValue } from 'type-fest'
 
 interface Options {
   reviver?: (key: string, value: any) => any
 }
 
-declare function jsonBodyParser (options?: Options): middy.MiddlewareObj
+export type Event = Omit<APIGatewayProxyWebsocketEventV2, 'body'> & {
+  body: JsonValue
+}
+
+declare function jsonBodyParser(options?: Options): middy.MiddlewareObj<Event>
 
 export default jsonBodyParser

--- a/packages/ws-json-body-parser/index.d.ts
+++ b/packages/ws-json-body-parser/index.d.ts
@@ -10,6 +10,6 @@ export type Event = Omit<APIGatewayProxyWebsocketEventV2, 'body'> & {
   body: JsonValue
 }
 
-declare function jsonBodyParser(options?: Options): middy.MiddlewareObj<Event>
+declare function jsonBodyParser (options?: Options): middy.MiddlewareObj<Event>
 
 export default jsonBodyParser

--- a/packages/ws-json-body-parser/index.test-d.ts
+++ b/packages/ws-json-body-parser/index.test-d.ts
@@ -1,13 +1,12 @@
-import { expectType } from 'tsd'
 import middy from '@middy/core'
-import jsonBodyParser from '.'
+import { expectType } from 'tsd'
+import jsonBodyParser, { Event } from '.'
 
 // use with default options
-let middleware = jsonBodyParser()
-expectType<middy.MiddlewareObj>(middleware)
+expectType<middy.MiddlewareObj<Event>>(jsonBodyParser())
 
 // use with all options
-middleware = jsonBodyParser({
+const options = {
   reviver: (key: string, value: any) => Boolean(value)
-})
-expectType<middy.MiddlewareObj>(middleware)
+}
+expectType<middy.MiddlewareObj<Event>>(jsonBodyParser(options))

--- a/packages/ws-json-body-parser/package-lock.json
+++ b/packages/ws-json-body-parser/package-lock.json
@@ -12,7 +12,9 @@
         "@middy/util": "3.1.1"
       },
       "devDependencies": {
-        "@middy/core": "3.1.1"
+        "@middy/core": "3.1.1",
+        "@types/aws-lambda": "^8.10.101",
+        "type-fest": "^2.18.0"
       },
       "engines": {
         "node": ">=14"
@@ -34,6 +36,24 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.101",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
+      "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
+      "dev": true
+    },
+    "node_modules/type-fest": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
+      "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   },
   "dependencies": {
@@ -47,6 +67,18 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@middy/util/-/util-3.1.1.tgz",
       "integrity": "sha512-7RrfFwo/+fvVDMwJzCZugs14deI4r/9xk6Y02I8PD/3kxn5e1IKFJvnxcY32zmbIUs5eZJaSqOUSl+eehEn4qA=="
+    },
+    "@types/aws-lambda": {
+      "version": "8.10.101",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.101.tgz",
+      "integrity": "sha512-84geGyVc0H9P9aGbcg/vkDh5akJq0bEf3tizHNR2d1gcm0wsp9IZ/SW6rPxvgjJFi3OeVxDc8WTKCAjoZbogzg==",
+      "dev": true
+    },
+    "type-fest": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
+      "integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==",
+      "dev": true
     }
   }
 }

--- a/packages/ws-json-body-parser/package.json
+++ b/packages/ws-json-body-parser/package.json
@@ -67,7 +67,9 @@
     "@middy/util": "3.1.1"
   },
   "devDependencies": {
-    "@middy/core": "3.1.1"
+    "@middy/core": "3.1.1",
+    "@types/aws-lambda": "^8.10.101",
+    "type-fest": "^2.18.0"
   },
   "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"
 }


### PR DESCRIPTION
In respond to https://github.com/middyjs/middy/issues/769#issuecomment-1196279277, this is the first attempt to make the event object self- and auto- composing through the chain of `.use()`.

Intended usage:
```ts
import type middy from "@middy/core";
import type { Context } from "aws-lambda";

const middyFoo = (): middy.MiddlewareObj<{ evtFoo: string }, any, Error, Context & { ctxFoo: string }> => ({
  before: ({ context, event }) => {
    context.ctxFoo = "foo";
    event.evtFoo = "foo";
  },
});

const middyBar = (): middy.MiddlewareObj<{ evtBar: string }, any, Error, Context & { ctxBar: string }> => ({
  before: ({ context, event }) => {
    context.ctxBar = "bar";
    event.evtBar = "bar";
  },
});


export const handler = middy()
  .use(middyFoo())
  .use(middyBar())
  .before(({ context: { ctxFoo, ctxBar }, event: { evtFoo, evtBar } }) => {
    // context and event inherits new properties from the .use() above
  })
  .handler(({ evtFoo, evtBar }, { ctxFoo, ctxBar }) => {
    // context and event inherits new properties from the .use() above
  });
```