### PR TITLE
Update http-response-serializer default option to defaultContentType

### DIFF
--- a/website/docs/middlewares/http-response-serializer.md
+++ b/website/docs/middlewares/http-response-serializer.md
@@ -98,7 +98,7 @@ handler
         serializer: ({ body }) => body
       }
     ],
-    default: 'application/json'
+    defaultContentType: 'application/json'
   }))
 
 const event = {


### PR DESCRIPTION
In the new version of http-response-serializer middleware  the `default` option is renamed to `defaultContentType`