### PR TITLE
Improve typings for security-headers middleware

### DIFF
--- a/packages/http-security-headers/index.d.ts
+++ b/packages/http-security-headers/index.d.ts
@@ -30,6 +30,10 @@ interface Options {
   }
 }
 
-declare function httpSecurityHeaders (options?: Options): middy.MiddlewareObj
+type WithFalseValues<T> = { [K in keyof T]: T[K] | false }
+
+declare function httpSecurityHeaders(
+  options?: WithFalseValues<Options>
+): middy.MiddlewareObj
 
 export default httpSecurityHeaders

--- a/packages/http-security-headers/index.d.ts
+++ b/packages/http-security-headers/index.d.ts
@@ -28,6 +28,28 @@ interface Options {
   xssProtection?: {
     reportUri?: string
   }
+  contentSecurityPolicy?: Record<string, string>
+  crossOriginEmbedderPolicy?: {
+    policy?: string
+  }
+  crossOriginOpenerPolicy?: {
+    policy?: string
+  }
+  crossOriginResourcePolicy?: {
+    policy?: string
+  }
+  permissionsPolicy?: Record<string, string>
+  permittedCrossDomainPolicies?: {
+    policy?: string
+  }
+  reportTo?: {
+    maxAge?: number
+    default?: string
+    includeSubdomains?: boolean
+    csp?: string
+    staple?: string
+    xss?: string
+  }
 }
 
 type WithFalseValues<T> = { [K in keyof T]: T[K] | false }

--- a/packages/http-security-headers/index.test-d.ts
+++ b/packages/http-security-headers/index.test-d.ts
@@ -37,3 +37,18 @@ middleware = httpSecurityHeaders({
   }
 })
 expectType<middy.MiddlewareObj>(middleware)
+
+// allow false options
+middleware = httpSecurityHeaders({
+  dnsPrefetchControl: false,
+  frameOptions: false,
+  poweredBy: false,
+  strictTransportSecurity: false,
+  downloadOptions: false,
+  contentTypeOptions: false,
+  originAgentCluster: false,
+  referrerPolicy: false,
+  xssProtection: false
+})
+
+expectType<middy.MiddlewareObj>(middleware)

--- a/packages/http-security-headers/index.test-d.ts
+++ b/packages/http-security-headers/index.test-d.ts
@@ -34,6 +34,33 @@ middleware = httpSecurityHeaders({
   },
   xssProtection: {
     reportUri: 'xss'
+  },
+  contentSecurityPolicy: {
+    'default-src': "'none'",
+    sandbox: ''
+  },
+  crossOriginEmbedderPolicy: {
+    policy: 'require-corp'
+  },
+  crossOriginOpenerPolicy: {
+    policy: 'same-origin'
+  },
+  crossOriginResourcePolicy: {
+    policy: 'same-origin'
+  },
+  permissionsPolicy: {
+    'ambient-light-sensor': ''
+  },
+  permittedCrossDomainPolicies: {
+    policy: 'none'
+  },
+  reportTo: {
+    maxAge: 365 * 24 * 60 * 60,
+    default: '',
+    includeSubdomains: true,
+    csp: '',
+    staple: '',
+    xss: ''
   }
 })
 expectType<middy.MiddlewareObj>(middleware)


### PR DESCRIPTION
Hi! 

I started recently using security-headers with typescript and noticed that type definitions don't quite match the javascript implementation. Here are some fixes that allow typescript usage without using `// @ts-ignore`. 

Basically this allows typescript users to pass in false to skip setting header and adds some recently added headers. 