### PR TITLE
Fix CommonJS export in version 3.2.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Transpile for Node.js ${{ matrix.node-version }}
         run: |
           ./node_modules/.bin/lerna exec --bail --concurrency 2 -- ../../node_modules/.bin/swc --config-file ../../swc.cjs.config.json --source-maps false index.js --out-file index.cjs
-          ./node_modules/.bin/lerna exec --bail --concurrency 2 -- sed -i.bak 's/exports.default/module.exports/g' index.cjs # Fix CommonJS default import
+          ./node_modules/.bin/lerna exec --bail --concurrency 2 -- sed -i.bak 's/exports, "default"/module, "exports"/g' index.cjs # Fix CommonJS default import
           ./node_modules/.bin/lerna exec --bail --concurrency 2 -- ../../node_modules/.bin/swc --config-file ../../swc.esm.config.json --source-maps false index.js --out-file index.js
 
       #- name: Pre-Release


### PR DESCRIPTION
This pull request fixes the CommonJS export in version 3.2.1 due to a change in https://github.com/swc-project/swc/releases/tag/v1.2.206 (https://github.com/swc-project/swc/issues/5204)

Version 3.2.1:
```
Object.defineProperty(module, "exports", {
    enumerable: true,
    get: ()=>_default
});
```

Version 3.2.0:
```
module.exports = _default;
```