### PR TITLE
Minor fixes in utility types

### DIFF
--- a/packages/util/index.d.ts
+++ b/packages/util/index.d.ts
@@ -22,7 +22,7 @@ type HttpError = Error & {
 
 declare function createPrefetchClient<Client, ClientOptions> (options: Options<Client, ClientOptions>): Client
 
-declare function createClient<Client, ClientOptions> (options: Options<Client, ClientOptions>, request: middy.Request): Client
+declare function createClient<Client, ClientOptions> (options: Options<Client, ClientOptions>, request: middy.Request): Promise<Client>
 
 declare function canPrefetch<Client, ClientOptions> (options: Options<Client, ClientOptions>): boolean
 
@@ -30,7 +30,7 @@ declare function getInternal (variables: any, request: middy.Request): Promise<a
 
 declare function sanitizeKey (key: string): string
 
-declare function processCache<Client, ClientOptions> (options: Options<Client, ClientOptions>, fetch: (request: middy.Request) => any, request: middy.Request): { value: any, expiry: number }
+declare function processCache<Client, ClientOptions> (options: Options<Client, ClientOptions>, fetch: (request: middy.Request) => any, request?: middy.Request): { value: any, expiry: number }
 
 declare function getCache (keys: string): any
 

--- a/packages/util/index.test-d.ts
+++ b/packages/util/index.test-d.ts
@@ -83,7 +83,7 @@ const prefetchClient = util.createPrefetchClient<SSM, {}>({ AwsClient: SSM })
 expectType<SSM>(prefetchClient)
 
 const client = util.createClient<SSM, {}>({ AwsClient: SSM }, sampleRequest)
-expectType<SSM>(client)
+expectType<Promise<SSM>>(client)
 
 const canPrefetch = util.canPrefetch<SSM, {}>({ AwsClient: SSM })
 expectType<boolean>(canPrefetch)


### PR DESCRIPTION
- Changed the return type of `createClient` to be a Promise.
- Made `request` an optional argument in `processCache` to work for scenarios like prefetching where there is no request.