### PR TITLE
docs: replace typo `default` in sample with `defaultContentType`

### DIFF
--- a/packages/http-response-serializer/README.md
+++ b/packages/http-response-serializer/README.md
@@ -68,7 +68,7 @@ The middleware is configured by defining some `serializers`.
       serializer: ({ body }) => body
     }
   ],
-  default: 'application/json'
+  defaultContentType: 'application/json'
 }
 ```
 


### PR DESCRIPTION
There's a typo in the sample usage that trips up first time users of the `@middy/http-response-serializer`  so updated the top example to be consistent with the others.