### PR TITLE
:memo: middy wrapped handler syntax error

### DIFF
--- a/website/docs/intro/06-typescript.md
+++ b/website/docs/intro/06-typescript.md
@@ -20,7 +20,6 @@ async function lambdaHandler (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 }
 
 let handler = middy(lambdaHandler)
-handler
   .use(someMiddleware)
   .use(someOtherMiddleware)
 


### PR DESCRIPTION
Remove 'handler' word incorrectly placed within code sample.