### PR TITLE
Export the Request interface

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -21,7 +21,7 @@ interface PluginObject {
   requestEnd?: PluginHookPromise
 }
 
-interface Request<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> {
+export interface Request<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> {
   event: TEvent
   context: TContext
   response: TResult | null


### PR DESCRIPTION
**Issue:** https://github.com/middyjs/middy/issues/933

## Changes

Exports the [Request](https://github.com/middyjs/middy/blob/main/packages/core/index.d.ts#L24) interface so that consumers can assign the type to the argument in the middleware functions.

```ts
const middlewareObj = {
    before: (request: Request) => {
      ...
    }
}
```