### PR TITLE
Allow handler setup to define additional properties on event

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -50,7 +50,7 @@ export interface MiddyfiedHandler<TEvent = any, TResult = any, TErr = Error, TCo
   before: AttachMiddlewareFn<TEvent, TResult, TErr, TContext>
   after: AttachMiddlewareFn<TEvent, TResult, TErr, TContext>
   onError: AttachMiddlewareFn<TEvent, TResult, TErr, TContext>
-  handler: (handler: MiddlewareHandler<LambdaHandler<TEvent, TResult>, TContext>) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
+  handler: <TAdditional>(handler: MiddlewareHandler<LambdaHandler<TEvent & TAdditional, TResult>, TContext>) => MiddyfiedHandler<TEvent, TResult, TErr, TContext>
 }
 
 declare type AttachMiddlewareFn<TEvent = any, TResult = any, TErr = Error, TContext extends LambdaContext = LambdaContext> =


### PR DESCRIPTION
Useful if middleware adds properties to the event.

e.g.
A `authMiddleware` that adds `userId` from a JWT token to the event.

`handler<{userId: string}>(event => event.userId)` <-- userId will not complain in TS.