### PR TITLE
Update 05-bundling.md recommendation on bundling the aws-sdk

### DIFF
--- a/website/docs/best-practices/05-bundling.md
+++ b/website/docs/best-practices/05-bundling.md
@@ -9,7 +9,8 @@ This page is a work in progress. If you want to help us to make this page better
 
 :::
 
-Lambda runtime already includes `aws-sdk` by default and as such you normally don't need to package it in your function.
+Always bundle the `aws-sdk` with your project eventhough the Lambda runtime already includes it by default. 
+This gives you full control of when to update the sdk to prevent unexpected errors from a bad sdk version, and allows you to ensure that you are running the latest version with the most up to date fixes and features.
 
 ## Compilers
 

--- a/website/docs/best-practices/05-bundling.md
+++ b/website/docs/best-practices/05-bundling.md
@@ -9,8 +9,8 @@ This page is a work in progress. If you want to help us to make this page better
 
 :::
 
-Always bundle the `aws-sdk` with your project eventhough the Lambda runtime already includes it by default. 
-This gives you full control of when to update the sdk to prevent unexpected errors from a bad sdk version, and allows you to ensure that you are running the latest version with the most up to date fixes and features.
+Always bundle the `@aws-sdk/*` with your project eventhough the Lambda runtime already includes it by default (Note: nodejs16.x does not have AWS SDK v3 included). 
+This gives you full control of when to update the SDK to prevent unexpected errors from a bad SDK version, allows you to ensure that you are running the latest version with the most up to date fixes and features, and has been shown to decrease cold start times.
 
 ## Compilers
 


### PR DESCRIPTION
AWS themselves [recommend ](https://docs.aws.amazon.com/lambda/latest/operatorguide/sdks-functions.html)that you always bundle the `aws-sdk` with your project.
Using the build-in sdk should be limited to quick tests and is not suitable for production use.