### PR TITLE
Replace deprecated validator option

### DIFF
--- a/website/docs/middlewares/validator.md
+++ b/website/docs/middlewares/validator.md
@@ -87,7 +87,7 @@ const schema = {
 
 handler.use(
   validator({
-    inputSchema: transpileSchema(schema)
+    eventSchema: transpileSchema(schema)
   })
 )
 


### PR DESCRIPTION
This pull request replaces the `inputSchema` option that is deprecated according to the [4.x upgrade guide](https://middy.js.org/docs/upgrade/3-4/#validator). It has also been removed from the TypeScript definitions in https://github.com/middyjs/middy/commit/2a9154ff056ab06f871f2f1ca34393f99df3d0d3.