### PR TITLE
fix: self-managed kafka event source name

### DIFF
--- a/packages/event-normalizer/__tests__/index.js
+++ b/packages/event-normalizer/__tests__/index.js
@@ -279,7 +279,7 @@ test('It should parse Apache Kafka event', async (t) => {
   const handler = middy((event) => event).use(eventNormalizer())
 
   const event = {
-    eventSource: 'aws:SelfManagedKafka',
+    eventSource: 'SelfManagedKafka',
     bootstrapServers:
       'b-2.demo-cluster-1.a1bcde.c1.kafka.us-east-1.amazonaws.com:9092,b-1.demo-cluster-1.a1bcde.c1.kafka.us-east-1.amazonaws.com:9092',
     records: {

--- a/packages/event-normalizer/index.js
+++ b/packages/event-normalizer/index.js
@@ -17,7 +17,7 @@ const eventNormalizerMiddleware = (opts = {}) => {
 }
 
 const parseEvent = (event) => {
-  // event.eventSource => aws:amq, aws:kafka, aws:SelfManagedKafka
+  // event.eventSource => aws:amq, aws:kafka, SelfManagedKafka
   // event.deliveryStreamArn => aws:lambda:events
   let eventSource = event.eventSource ?? event.deliveryStreamArn
 
@@ -100,7 +100,7 @@ const events = {
   'aws:s3:batch': (task) => {
     task.s3Key = normalizeS3Key(task.s3Key)
   },
-  'aws:SelfManagedKafka': (event) => {
+  SelfManagedKafka: (event) => {
     events['aws:kafka'](event)
   },
   'aws:sns': (record) => {


### PR DESCRIPTION
According to Lambda [documentation](https://docs.aws.amazon.com/lambda/latest/dg/with-kafka.html) event source name for self-managed Apache Kafka is `SelfManagedKafka` *not* `aws:SelfManagedKafka`.

I found this by enabling `@middy/event-normalizer` middleware for my project with this event source type and noticed that the event normalizer does not Base64 decode the record value. Made a fork with fixed event source name and now it works as expected.