### PR TITLE
Add transpile.d.ts to npm package

### DIFF
--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -40,7 +40,8 @@
     "index.cjs",
     "index.d.ts",
     "transpile.js",
-    "transpile.cjs"
+    "transpile.cjs",
+    "transpile.d.ts"
   ],
   "scripts": {
     "test": "npm run test:unit",


### PR DESCRIPTION
I think the typescript typings are missing for the new transpile.js.

Haven't published an npm package in a while but I think this is how you make sure it gets included?