### PR TITLE
Feature: http-router - Expose Method as a string-enum.

### DIFF
--- a/packages/http-router/index.d.ts
+++ b/packages/http-router/index.d.ts
@@ -7,14 +7,15 @@ import {
   Handler as LambdaHandler
 } from 'aws-lambda'
 
-export type Method =
-  | 'GET'
-  | 'POST'
-  | 'PUT'
-  | 'PATCH'
-  | 'DELETE'
-  | 'OPTIONS'
-  | 'ANY'
+export enum Method {
+  Get = 'GET',
+  Post = 'POST',
+  Put = 'PUT',
+  Patch = 'PATCH',
+  Delete = 'DELETE',
+  Options = 'OPTIONS',
+  Any = 'ANY'
+}
 
 export interface Route<TEvent> {
   method: Method

--- a/packages/http-router/index.test-d.ts
+++ b/packages/http-router/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd'
 import middy from '@middy/core'
-import httpRouterHandler, { Method } from '.';
+import httpRouterHandler, { Method } from '.'
 import {
   APIGatewayProxyEvent,
   APIGatewayProxyResult,

--- a/packages/http-router/index.test-d.ts
+++ b/packages/http-router/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd'
 import middy from '@middy/core'
-import httpRouterHandler from '.'
+import httpRouterHandler, { Method } from '.';
 import {
   APIGatewayProxyEvent,
   APIGatewayProxyResult,
@@ -16,7 +16,7 @@ const lambdaHandler: LambdaHandler<APIGatewayProxyEvent, APIGatewayProxyResult> 
 
 const middleware = httpRouterHandler([
   {
-    method: 'GET',
+    method: Method.Get,
     path: '/',
     handler: lambdaHandler
   }


### PR DESCRIPTION
Addresses [this comment](https://github.com/middyjs/middy/issues/895#issuecomment-1344252536) in #895.

Exposes the `Method` type as a String Enum instead of a union string.
Note that this is a breaking TS change as per the linked comment.