### PR TITLE
make event.pathParameter a full object

### DIFF
--- a/packages/http-router/__tests__/index.js
+++ b/packages/http-router/__tests__/index.js
@@ -156,6 +156,22 @@ test('It should route to a dynamic route (/path/to) with `{proxy+}`', async (t) 
   t.true(response)
 })
 
+test('It should add pathParameters with object prototype', async (t) => {
+  const event = {
+    httpMethod: 'GET',
+    path: '/path/to'
+  }
+  const handler = httpRouter([
+    {
+      method: 'GET',
+      path: '/path/{proxy+}',
+      handler: () => true
+    }
+  ])
+  await handler(event, context)
+  t.truthy(event.pathParameters.__proto__)
+})
+
 test('It should thrown 404 when route not found', async (t) => {
   const event = {
     httpMethod: 'GET',

--- a/packages/http-router/index.js
+++ b/packages/http-router/index.js
@@ -43,7 +43,7 @@ const httpRouteHandler = (routes) => {
     for (const route of routesDynamic[method] ?? []) {
       const match = path.match(route.path)
       if (match) {
-        event.pathParameters ??= match.groups
+        event.pathParameters ??= {...match.groups}
         return route.handler(event, context, abort)
       }
     }

--- a/packages/http-router/index.js
+++ b/packages/http-router/index.js
@@ -43,7 +43,7 @@ const httpRouteHandler = (routes) => {
     for (const route of routesDynamic[method] ?? []) {
       const match = path.match(route.path)
       if (match) {
-        event.pathParameters ??= {...match.groups}
+        event.pathParameters ??= { ...match.groups }
         return route.handler(event, context, abort)
       }
     }


### PR DESCRIPTION
when creating pathParameters in a dynamic route, the resulting object is a `null prototype` object which causes problems for libraries that try to inspect pathParameters using prototype methods

this patch creates pathParameters as a "full fledged" object