### PR TITLE
merge existing event.pathParameters with the ones inferred from the dynamic route

### DIFF
--- a/packages/http-router/__tests__/index.js
+++ b/packages/http-router/__tests__/index.js
@@ -162,7 +162,7 @@ test('It should populate pathParameters to a dynamic route even if they already 
     httpMethod: 'GET',
     path: '/user/123',
     pathParameters: {
-      previous: '321',
+      previous: '321'
     }
   }
   const handler = httpRouter([

--- a/packages/http-router/__tests__/index.js
+++ b/packages/http-router/__tests__/index.js
@@ -157,6 +157,29 @@ test('It should route to a dynamic route (/path/to) with `{proxy+}`', async (t) 
   t.true(response)
 })
 
+test('It should populate pathParameters to a dynamic route even if they already exist in the event', async (t) => {
+  const event = {
+    httpMethod: 'GET',
+    path: '/user/123',
+    pathParameters: {
+      previous: '321',
+    }
+  }
+  const handler = httpRouter([
+    {
+      method: 'GET',
+      path: '/user/{id}',
+      handler: (event) => {
+        t.deepEqual(event.pathParameters, { id: '123', previous: '321' })
+        t.truthy(event.pathParameters.__proto__) // eslint-disable-line no-proto
+        return true
+      }
+    }
+  ])
+  const response = await handler(event, context)
+  t.true(response)
+})
+
 test('It should thrown 404 when route not found', async (t) => {
   const event = {
     httpMethod: 'GET',

--- a/packages/http-router/index.js
+++ b/packages/http-router/index.js
@@ -43,7 +43,10 @@ const httpRouteHandler = (routes) => {
     for (const route of routesDynamic[method] ?? []) {
       const match = path.match(route.path)
       if (match) {
-        event.pathParameters ??= { ...match.groups } // to prevent from being null prototype
+        event.pathParameters = {
+          ...match.groups,
+          ...event.pathParameters,
+        };
         return route.handler(event, context, abort)
       }
     }

--- a/packages/http-router/index.js
+++ b/packages/http-router/index.js
@@ -45,8 +45,8 @@ const httpRouteHandler = (routes) => {
       if (match) {
         event.pathParameters = {
           ...match.groups,
-          ...event.pathParameters,
-        };
+          ...event.pathParameters
+        }
         return route.handler(event, context, abort)
       }
     }


### PR DESCRIPTION
Previous code only wrote `pathParameters` in the event for a dynamic route when existing `pathParameters` property was undefined, this PR fixed that and merges both existing `pathParameters` and the inferred from the dynamic route