### PR TITLE
fix(http-json-body-parser): rawBody is missing

### DIFF
--- a/packages/http-json-body-parser/__tests__/index.js
+++ b/packages/http-json-body-parser/__tests__/index.js
@@ -203,3 +203,23 @@ test('It should handle invalid base64 JSON as an UnprocessableEntity', async (t)
     t.is(e.cause.message, 'Unexpected token m in JSON at position 0')
   }
 })
+
+test('It should retain the stringified source in rawBody', async (t) => {
+  const handler = middy((event) => {
+    return event // propagates the processed event as a response
+  })
+
+  handler.use(jsonBodyParser())
+
+  // invokes the handler
+  const event = {
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: '{ "foo" :   "bar"   }'
+  }
+
+  const processedEvent = await handler(event, defaultContext)
+
+  t.deepEqual(processedEvent.rawBody, '{ "foo" :   "bar"   }')
+})

--- a/packages/http-json-body-parser/index.js
+++ b/packages/http-json-body-parser/index.js
@@ -21,6 +21,7 @@ const httpJsonBodyParserMiddleware = (opts = {}) => {
         : body
 
       request.event.body = JSON.parse(data, reviver)
+      request.event.rawBody = body
     } catch (cause) {
       // UnprocessableEntity
       throw createError(422, 'Invalid or malformed JSON was provided', {


### PR DESCRIPTION
http-json-body-parser's `index.d.ts` says it sets `rawBody`:

https://github.com/middyjs/middy/blob/9fe167c060ce01456ebf3067a0ac653938e5e1c2/packages/http-json-body-parser/index.d.ts#L14

...which is in practice missing.  I doubt if this is intentional.