### PR TITLE
enablePreflightReply feature added

### DIFF
--- a/packages/http-cors/index.d.ts
+++ b/packages/http-cors/index.d.ts
@@ -3,6 +3,7 @@ import middy from '@middy/core'
 export interface Options {
   getOrigin?: (incomingOrigin: string, options: Options) => string
   credentials?: boolean | string
+  enablePreflightReply: true,
   headers?: string
   methods?: string
   origin?: string

--- a/packages/http-cors/index.js
+++ b/packages/http-cors/index.js
@@ -18,6 +18,7 @@ const getOrigin = (incomingOrigin, options = {}) => {
 const defaults = {
   getOrigin,
   credentials: undefined,
+  enablePreflightReply: true,
   headers: undefined,
   methods: undefined,
   origin: '*',
@@ -32,6 +33,14 @@ const defaults = {
 
 const httpCorsMiddleware = (opts = {}) => {
   const options = { ...defaults, ...opts }
+
+  const httpCorsMiddlewareBefore = async (request) => {
+    if (options.enablePreflightReply) {
+      if (request.event.httpMethod === "OPTIONS") {
+        return true;
+      }
+    }
+  }
 
   const httpCorsMiddlewareAfter = async (request) => {
     normalizeHttpResponse(request)

--- a/packages/http-cors/index.js
+++ b/packages/http-cors/index.js
@@ -1,154 +1,121 @@
-import { normalizeHttpResponse } from '@middy/util'
+import {normalizeHttpResponse} from '@middy/util';
 
 const getOrigin = (incomingOrigin, options = {}) => {
   if (options.origins.length > 0) {
     if (incomingOrigin && options.origins.includes(incomingOrigin)) {
-      return incomingOrigin
+      return incomingOrigin;
     } else {
-      return options.origins[0]
+      return options.origins[0];
     }
   } else {
     if (incomingOrigin && options.credentials && options.origin === '*') {
-      return incomingOrigin
+      return incomingOrigin;
     }
-    return options.origin
+    return options.origin;
+  }
+};
+
+const modifyHeaders = (headers, options, request) => {
+  const existingHeaders = Object.keys(headers);
+  if (existingHeaders.includes('Access-Control-Allow-Credentials')) {
+    options.credentials = headers['Access-Control-Allow-Credentials'] === 'true';
+  }
+  if (options.credentials) {
+    headers['Access-Control-Allow-Credentials'] = String(options.credentials);
+  }
+  if (options.headers && !existingHeaders.includes('Access-Control-Allow-Headers')) {
+    headers['Access-Control-Allow-Headers'] = options.headers;
+  }
+  if (options.methods && !existingHeaders.includes('Access-Control-Allow-Methods')) {
+    headers['Access-Control-Allow-Methods'] = options.methods;
+  }
+  if (!existingHeaders.includes('Access-Control-Allow-Origin')) {
+    const eventHeaders = request.event.headers ?? {};
+    const incomingOrigin = eventHeaders.Origin ?? eventHeaders.origin;
+    headers['Access-Control-Allow-Origin'] = options.getOrigin(incomingOrigin, options);
+  }
+  let vary = options.vary;
+  if (headers['Access-Control-Allow-Origin'] !== '*' && !vary) {
+    vary = 'Origin';
+  }
+  if (vary && !existingHeaders.includes('Vary')) {
+    headers.Vary = vary;
+  }
+  if (options.exposeHeaders && !existingHeaders.includes('Access-Control-Expose-Headers')) {
+    headers['Access-Control-Expose-Headers'] = options.exposeHeaders;
+  }
+  if (options.maxAge && !existingHeaders.includes('Access-Control-Max-Age')) {
+    headers['Access-Control-Max-Age'] = String(options.maxAge);
+  }
+  if (options.requestHeaders && !existingHeaders.includes('Access-Control-Request-Headers')) {
+    headers['Access-Control-Request-Headers'] = options.requestHeaders;
+  }
+  if (options.requestMethods && !existingHeaders.includes('Access-Control-Request-Methods')) {
+    headers['Access-Control-Request-Methods'] = options.requestMethods;
+  }
+  const httpMethod = getVersionHttpMethod[request.event.version ?? '1.0']?.(request.event);
+  if (!httpMethod) {
+    throw new Error('[http-cors] Unknown http event format');
+  }
+  if (httpMethod === 'OPTIONS' && options.cacheControl && !existingHeaders.includes('Cache-Control')) {
+    headers['Cache-Control'] = options.cacheControl;
   }
 }
 
 const defaults = {
   getOrigin,
   credentials: undefined,
-  enablePreflightReply: true,
   headers: undefined,
   methods: undefined,
   origin: '*',
   origins: [],
+  enablePreflightReply: true,
   exposeHeaders: undefined,
   maxAge: undefined,
   requestHeaders: undefined,
   requestMethods: undefined,
   cacheControl: undefined,
   vary: undefined
-}
-
+};
 const httpCorsMiddleware = (opts = {}) => {
-  const options = { ...defaults, ...opts }
-
+  const options = {
+    ...defaults,
+    ...opts
+  };
   const httpCorsMiddlewareBefore = async (request) => {
     if (options.enablePreflightReply) {
       if (request.event.httpMethod === "OPTIONS") {
-        return true;
+        const {headers} = request.event;
+        normalizeHttpResponse(request);
+        modifyHeaders(headers, options, request);
+        request.response.headers = headers;
+        request.response.statusCode = 204
       }
     }
   }
 
   const httpCorsMiddlewareAfter = async (request) => {
-    normalizeHttpResponse(request)
-
-    const { headers } = request.response
-    const existingHeaders = Object.keys(headers)
-
-    // Check if already setup the header Access-Control-Allow-Credentials
-    if (existingHeaders.includes('Access-Control-Allow-Credentials')) {
-      options.credentials =
-        headers['Access-Control-Allow-Credentials'] === 'true'
-    }
-    if (options.credentials) {
-      headers['Access-Control-Allow-Credentials'] = String(options.credentials) // boolean
-    }
-
-    // Check if already setup Access-Control-Allow-Headers
-    if (
-      options.headers &&
-      !existingHeaders.includes('Access-Control-Allow-Headers')
-    ) {
-      headers['Access-Control-Allow-Headers'] = options.headers
-    }
-
-    // Check if already setup Access-Control-Allow-Methods
-    if (
-      options.methods &&
-      !existingHeaders.includes('Access-Control-Allow-Methods')
-    ) {
-      headers['Access-Control-Allow-Methods'] = options.methods
-    }
-
-    // Check if already setup the header Access-Control-Allow-Origin
-    if (!existingHeaders.includes('Access-Control-Allow-Origin')) {
-      const eventHeaders = request.event.headers ?? {}
-      const incomingOrigin = eventHeaders.Origin ?? eventHeaders.origin
-      headers['Access-Control-Allow-Origin'] = options.getOrigin(
-        incomingOrigin,
-        options
-      )
-    }
-
-    let vary = options.vary
-    if (headers['Access-Control-Allow-Origin'] !== '*' && !vary) {
-      vary = 'Origin'
-    }
-    if (vary && !existingHeaders.includes('Vary')) {
-      headers.Vary = vary
-    }
-
-    // Check if already setup Access-Control-Expose-Headers
-    if (
-      options.exposeHeaders &&
-      !existingHeaders.includes('Access-Control-Expose-Headers')
-    ) {
-      headers['Access-Control-Expose-Headers'] = options.exposeHeaders
-    }
-
-    if (options.maxAge && !existingHeaders.includes('Access-Control-Max-Age')) {
-      headers['Access-Control-Max-Age'] = String(options.maxAge) // number
-    }
-
-    // Check if already setup Access-Control-Request-Headers
-    if (
-      options.requestHeaders &&
-      !existingHeaders.includes('Access-Control-Request-Headers')
-    ) {
-      headers['Access-Control-Request-Headers'] = options.requestHeaders
-    }
-
-    // Check if already setup Access-Control-Request-Methods
-    if (
-      options.requestMethods &&
-      !existingHeaders.includes('Access-Control-Request-Methods')
-    ) {
-      headers['Access-Control-Request-Methods'] = options.requestMethods
-    }
-
-    const httpMethod = getVersionHttpMethod[request.event.version ?? '1.0']?.(
-      request.event
-    )
-    if (!httpMethod) {
-      throw new Error('[http-cors] Unknown http event format')
-    }
-    if (
-      httpMethod === 'OPTIONS' &&
-      options.cacheControl &&
-      !existingHeaders.includes('Cache-Control')
-    ) {
-      headers['Cache-Control'] = options.cacheControl
-    }
-
-    request.response.headers = headers
-  }
+    normalizeHttpResponse(request);
+    const {headers} = request.response;
+    modifyHeaders(headers, options, request);
+    request.response.headers = headers;
+  };
   const httpCorsMiddlewareOnError = async (request) => {
-    if (request.response === undefined) return
-    return httpCorsMiddlewareAfter(request)
-  }
+    if (request.response === undefined) return;
+    return httpCorsMiddlewareAfter(request);
+  };
   return {
     before: httpCorsMiddlewareBefore,
     after: httpCorsMiddlewareAfter,
     onError: httpCorsMiddlewareOnError
-  }
-}
-
+  };
+};
 const getVersionHttpMethod = {
   '1.0': (event) => event.httpMethod,
   '2.0': (event) => event.requestContext.http.method
-}
+};
 
-export default httpCorsMiddleware
+export default httpCorsMiddleware;
+
+
+//# sourceMappingURL=index.js.map

--- a/packages/http-cors/index.js
+++ b/packages/http-cors/index.js
@@ -140,6 +140,7 @@ const httpCorsMiddleware = (opts = {}) => {
     return httpCorsMiddlewareAfter(request)
   }
   return {
+    before: httpCorsMiddlewareBefore,
     after: httpCorsMiddlewareAfter,
     onError: httpCorsMiddlewareOnError
   }

--- a/packages/http-cors/index.test-d.ts
+++ b/packages/http-cors/index.test-d.ts
@@ -9,6 +9,7 @@ expectType<middy.MiddlewareObj>(middleware)
 // use with all options
 middleware = httpCors({
   credentials: true, // Access-Control-Allow-Credentials
+  enablePreflightReply: true, // answer preflight requests accordingly
   headers: 'X-Custom-Header, Upgrade-Insecure-Requests', // 'Access-Control-Allow-Headers',
   methods: 'POST, GET, OPTIONS', // 'Access-Control-Allow-Methods'
   origin: 'foo.bar.com',

--- a/packages/http-cors/package-lock.json
+++ b/packages/http-cors/package-lock.json
@@ -19,18 +19,18 @@
       }
     },
     "node_modules/@middy/core": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-4.0.8.tgz",
-      "integrity": "sha512-7KzPkM4Ax4H5Wr9KFn6WfBcYlxX9rcXN8J9zoiG4EF2rxCtXlZrTo81dZVamBGLmUGaCUeHRpBA7w/Wv/WIHqA==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-4.0.9.tgz",
+      "integrity": "sha512-DZjkBhBJD82UmkFgOebtlluiYpHSYGYVShNvfLUMI8u2pqKu4t00C0oPtYCVsIhU2gyhSdFP4THMD58jn01SIA==",
       "dev": true,
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@middy/util": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@middy/util/-/util-4.0.8.tgz",
-      "integrity": "sha512-2Pv5jZ0b1Pa3UZOspFrh4/d+9DXdRpOJ9XR2bmgFVtUFt+NLIsmDK6LwKurkDRWy5wcb2NHXuqDOcBNhuFCCGw==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@middy/util/-/util-4.0.9.tgz",
+      "integrity": "sha512-p3db9lvzZp+jIYle5hvgBXig5nMoTPTa1Q5ZlZhoFe6uyMkf3IvMhnSaSrHbo+1sOYyyXcVEly4gqMFr2zHf/Q==",
       "engines": {
         "node": ">=16"
       }

--- a/website/docs/middlewares/http-cors.md
+++ b/website/docs/middlewares/http-cors.md
@@ -19,6 +19,7 @@ npm install --save @middy/http-cors
 ## Options
 
  - `credentials` (bool) (optional): if true, sets `Access-Control-Allow-Credentials` (default `false`)
+ - `enablePreflightReply` (bool) (optional): if true, replies automatically to cors preflight requests (default `true`)
  - `headers` (string) (optional): value to put in `Access-Control-Allow-Headers` (default: `false`)
  - `methods` (string) (optional): value to put in `Access-Control-Allow-Methods` (default: `false`)
  - `getOrigin` (function(incomingOrigin:string, options)) (optional): take full control of the generating the returned origin. Defaults to using the origin or origins option.


### PR DESCRIPTION
This feature (default -> true) handles all OPTION requests from a cors enabled browser automatically. Since a lot of people have problems understanding cors, i made it default to true. Only problem which might arise is if somebody really wants to handle other OPTION requests in their function. 

I have not found a way to distinguish a cors OPTION requests from potential business code based OPTION requests which are very rare anyway. Happy to discuss this scenario as well. 

Tell me what you think. Its a first try. Of course its tested in a real project of mine already. 