### PR TITLE
fix: `content-type skips response serialization` for real

### DIFF
--- a/packages/http-response-serializer/__tests__/index.js
+++ b/packages/http-response-serializer/__tests__/index.js
@@ -40,7 +40,9 @@ for (const [key] of [['Content-Type'], ['content-type']]) {
         [key]: 'text/plain'
       }
     })
-    const handler = middy((event, context) => handlerResponse)
+    const handler = middy((event, context) =>
+      Object.assign({}, handlerResponse)
+    )
 
     handler.use(httpResponseSerializer(standardConfiguration))
 
@@ -49,7 +51,7 @@ for (const [key] of [['Content-Type'], ['content-type']]) {
     }
     const response = await handler(event, context)
 
-    t.is(response, handlerResponse)
+    t.deepEqual(response, handlerResponse)
   })
 }
 

--- a/packages/http-response-serializer/index.js
+++ b/packages/http-response-serializer/index.js
@@ -11,8 +11,13 @@ const httpResponseSerializerMiddleware = (opts = {}) => {
   const httpResponseSerializerMiddlewareAfter = async (request) => {
     normalizeHttpResponse(request)
 
-    // skip serialization when Content-Type is already set
-    if (request.response.headers['Content-Type']) return
+    // skip serialization when Content-Type or content-type is already set
+    if (
+      request.response.headers['Content-Type'] ??
+      request.response.headers['content-type']
+    ) {
+      return
+    }
 
     // find accept value(s)
     let types


### PR DESCRIPTION
**What does this implement/fix? Explain your changes.**

Per https://github.com/middyjs/middy/issues/978#issuecomment-1371189007.

Yeah, this wasn't exactly working for the `Content-Type skips response serialization` case either.

**Does this close any currently open issues?**

Closes #978 

**Any relevant logs, error output, etc?**

See #978.

**Environment:**

 - Node.js: 16
 - Middy: 3.6.2
 - AWS SDK: 2.1246.0

**Any other comments?**

N/A.

**Todo List:**

- [x] Feature/Fix fully implemented
- [x] Added tests
  - [x] Unit tests
  - [ ] Benchmark tests (if applicable)
- [ ] Updated relevant documentation
- [ ] Updated relevant examples
