### PR TITLE
Abort the handler timeout when the handler succeeds or fail

### DIFF
--- a/packages/core/__tests__/index.js
+++ b/packages/core/__tests__/index.js
@@ -743,3 +743,27 @@ test('Should not invoke timeoutEarlyResponse on success', async (t) => {
 
   t.false(timeoutCalled)
 })
+
+test('Should not invoke timeoutEarlyResponse on error', async (t) => {
+  let timeoutCalled = false
+  const plugin = {
+    timeoutEarlyInMillis: 50,
+    timeoutEarlyResponse: () => {
+      timeoutCalled = true
+    }
+  }
+  const context = {
+    getRemainingTimeInMillis: () => 100
+  }
+  const error = new Error('Oops!')
+  const handler = middy(async (event, context, { signal }) => {
+    throw error
+  }, plugin)
+
+  const response = await handler(event, context).catch((err) => err)
+  t.is(response, error)
+
+  await setTimeout(100)
+
+  t.false(timeoutCalled)
+})

--- a/packages/core/__tests__/index.js
+++ b/packages/core/__tests__/index.js
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises'
 import test from 'ava'
 import sinon from 'sinon'
 import middy from '../index.js'
@@ -718,4 +719,27 @@ test('Should abort timeout', async (t) => {
 
   const response = await handler(event, context)
   t.true(response)
+})
+
+test('Should not invoke timeoutEarlyResponse on success', async (t) => {
+  let timeoutCalled = false
+  const plugin = {
+    timeoutEarlyInMillis: 50,
+    timeoutEarlyResponse: () => {
+      timeoutCalled = true
+    }
+  }
+  const context = {
+    getRemainingTimeInMillis: () => 100
+  }
+  const handler = middy(async (event, context, { signal }) => {
+    return true
+  }, plugin)
+
+  const response = await handler(event, context)
+  t.true(response)
+
+  await setTimeout(200)
+
+  t.false(timeoutCalled)
 })

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -110,6 +110,7 @@ const runRequest = async (
           ? setTimeout(
             request.context.getRemainingTimeInMillis() -
                 plugin.timeoutEarlyInMillis,
+            undefined,
             { signal: timeoutAbort.signal }
           ).then(() => {
             handlerAbort.abort()


### PR DESCRIPTION
This pull request addresses an issue where the handler timeout is not being correctly aborted when the handler either succeeds or fails.

This leads to the lambda handler and the timeout handler being both called instead of just one of them. This is a problem if the timeout handler produces side effects (for example, logging)


Let me know if you have any questions or concerns, regards!