### PR TITLE
feat(core): pass the `request` to the `timeoutEarlyResponse` handler

### DIFF
--- a/packages/core/__tests__/index.js
+++ b/packages/core/__tests__/index.js
@@ -771,3 +771,27 @@ test('Should not invoke timeoutEarlyResponse on error', async (t) => {
 
   t.false(timeoutCalled)
 })
+
+test('Should pass the request to the timeoutEarlyResponse handler', async (t) => {
+  const event = {}
+  const context = {
+    getRemainingTimeInMillis: () => 20
+  }
+
+  const plugin = {
+    timeoutEarlyInMillis: 10,
+    timeoutEarlyResponse: (request) => {
+      t.is(request.event, event)
+      t.is(request.context, context)
+      return 'timeout'
+    }
+  }
+
+  const handler = middy(async (event, context) => {
+    await setTimeout(30)
+  }, plugin)
+
+  const response = await handler(event, context)
+
+  t.is(response, 'timeout')
+})

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -16,7 +16,7 @@ interface PluginObject {
   afterMiddleware?: PluginHookWithMiddlewareName
   beforeHandler?: PluginHook
   timeoutEarlyInMillis?: number
-  timeoutEarlyResponse?: PluginHook
+  timeoutEarlyResponse?: PluginHookPromise
   afterHandler?: PluginHook
   requestEnd?: PluginHookPromise
 }

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -115,7 +115,7 @@ const runRequest = async (
             { signal: timeoutAbort.signal }
           ).then(() => {
             handlerAbort.abort()
-            return plugin.timeoutEarlyResponse()
+            return plugin.timeoutEarlyResponse(request)
           })
           : Promise.race([])
       ])

--- a/website/docs/writing-middlewares/05-timeouts.md
+++ b/website/docs/writing-middlewares/05-timeouts.md
@@ -12,12 +12,14 @@ const lambdaHandler = (event, context, {signal}) => {
   signal.onabort = () => {
     // cancel events
   }
-  // ... 
+  // ...
 }
 
 export const handler = middy(lambdaHandler, {
   timeoutEarlyInMillis: 50,
-  timeoutEarlyResponse: () => {
+  timeoutEarlyResponse: ({event, context}) => {
+    // You can also access the event and context of the current request
+
     return {
       statusCode: 408
     }


### PR DESCRIPTION
This PR adds the `request` as an argument to the `timeoutEarlyResponse()` function. This change is necessary to ensure that the function can access information about the current request, such as headers or query parameters, when handling a timeout.

By passing the request, it can now use this information to provide a more appropriate response to the client in the event of a timeout.

Additionally, this change should not cause any issues with existing code as it only adds the request as an additional parameter.