### PR TITLE
Fix setDimensions function arg and update docs

### DIFF
--- a/packages/cloudwatch-metrics/__tests__/index.js
+++ b/packages/cloudwatch-metrics/__tests__/index.js
@@ -75,7 +75,7 @@ test.serial(
 )
 
 test.serial(
-  'It should call metrics.setDimensions when option passed',
+  'It should call metrics.setDimensions when option passed using plain object',
   async (t) => {
     const handler = middy(() => {})
 
@@ -99,6 +99,44 @@ test.serial(
             Agent: 'CloudWatchAgent',
             Version: 2
           }
+        })
+      )
+      .before(middleware)
+
+    const context = { ...defaultContext }
+    await handler(event, context)
+  }
+)
+
+test.serial(
+  'It should call metrics.setDimensions when option passed using an array of objects',
+  async (t) => {
+    const handler = middy(() => {})
+
+    const middleware = () => {
+      t.true(
+        metricsLoggerMock.setDimensions.calledWith([
+          {
+            Runtime: 'NodeJS',
+            Platform: 'ECS',
+            Agent: 'CloudWatchAgent',
+            Version: 2
+          }
+        ])
+      )
+    }
+
+    handler
+      .use(
+        metrics({
+          dimensions: [
+            {
+              Runtime: 'NodeJS',
+              Platform: 'ECS',
+              Agent: 'CloudWatchAgent',
+              Version: 2
+            }
+          ]
         })
       )
       .before(middleware)

--- a/packages/cloudwatch-metrics/__tests__/index.js
+++ b/packages/cloudwatch-metrics/__tests__/index.js
@@ -93,14 +93,12 @@ test.serial(
     handler
       .use(
         metrics({
-          dimensions: [
-            {
-              Runtime: 'NodeJS',
-              Platform: 'ECS',
-              Agent: 'CloudWatchAgent',
-              Version: 2
-            }
-          ]
+          dimensions: {
+            Runtime: 'NodeJS',
+            Platform: 'ECS',
+            Agent: 'CloudWatchAgent',
+            Version: 2
+          }
         })
       )
       .before(middleware)

--- a/packages/cloudwatch-metrics/index.js
+++ b/packages/cloudwatch-metrics/index.js
@@ -12,7 +12,7 @@ const cloudwatchMetricsMiddleware = (opts = {}) => {
       metrics.setNamespace(namespace)
     }
 
-    // If not set, keeps defaults as defined here https://github.com/awslabs/aws-embedded-metrics-node/#configuration 
+    // If not set, keeps defaults as defined here https://github.com/awslabs/aws-embedded-metrics-node/#configuration
     if (dimensions) {
       metrics.setDimensions(dimensions)
     }

--- a/packages/cloudwatch-metrics/index.js
+++ b/packages/cloudwatch-metrics/index.js
@@ -12,9 +12,9 @@ const cloudwatchMetricsMiddleware = (opts = {}) => {
       metrics.setNamespace(namespace)
     }
 
-    // If not set, defaults to ServiceName, ServiceType and LogGroupName
+    // If not set, keeps defaults as defined here https://github.com/awslabs/aws-embedded-metrics-node/#configuration 
     if (dimensions) {
-      metrics.setDimensions(...dimensions)
+      metrics.setDimensions(dimensions)
     }
     Object.assign(request.context, { metrics })
   }

--- a/packages/http-cors/index.d.ts
+++ b/packages/http-cors/index.d.ts
@@ -15,6 +15,6 @@ export interface Options {
   cacheControl?: string
 }
 
-declare function httpCors(options?: Options): middy.MiddlewareObj
+declare function httpCors (options?: Options): middy.MiddlewareObj
 
 export default httpCors

--- a/website/docs/middlewares/cloudwatch-metrics.md
+++ b/website/docs/middlewares/cloudwatch-metrics.md
@@ -19,15 +19,7 @@ npm install --save @middy/cloudwatch-metrics
 ## Options
 
 - `namespace` (`string`) (optional): Defaults to `aws-embedded-metrics`. Sets the CloudWatch [namespace](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Namespace) that extracted metrics should be published to.
-- `dimensions` (`Record<String, String>[]`) (optional): Defaults to
-  ```json
-  [
-    { "ServiceName": "myLambdaFunctionName" },
-    { "ServiceType": "AWS::Lambda::Function" },
-    { "LogGroupName": "logGroupNameUsedByMyLambda" }
-  ]
-  ```
-  Explicitly override all dimensions. This will remove the default dimensions. You can provide an empty array to record all metrics without dimensions.
+- `dimensions` (`Record<String, String> | Record<String, String>[]`) (optional): Explicitly overrides all dimensions. This will remove the default dimensions. You can provide an empty array to record all metrics without dimensions. For dimensions defaults and configuration see the [aws-embedded-metrics docs](https://github.com/awslabs/aws-embedded-metrics-node/tree/v4.1.0#configuration).
 
 ## Sample usage
 


### PR DESCRIPTION
Fixes https://github.com/middyjs/middy/issues/998

[`aws-embedded-metrics` `setDimensions` function signature](https://github.com/awslabs/aws-embedded-metrics-node#metriclogger) is `Record<String, String> | Record<String, String>[]` whereas the `cloudwatch-metrics` middleware was expecting `Record<String, String>[]` and passing the dimensions args through via the spread operator, which if an empty array was passed (as per middy docs) would result in an undefined error.

This should be a backwards-compatible bug fix as the original middy `Record<String, String>[]` is a valid parameter for `setDimensions` even without the spread operator.

I've also updated the docs to reflect this change and removed the explicitly mentioned defaults as I couldn't find where in the `aws-embedded-metrics` where these defaults were described, and there in fact seems to be more defaults than just the three mentioned.