### PR TITLE
chore: update `ws-router` handler type

### DIFF
--- a/packages/ws-router/index.d.ts
+++ b/packages/ws-router/index.d.ts
@@ -1,9 +1,9 @@
 import middy from '@middy/core'
-import { APIGatewayProxyHandlerV2 } from 'aws-lambda'
+import { APIGatewayProxyWebsocketHandlerV2 } from 'aws-lambda'
 
 interface Route<T = never> {
   routeKey: string
-  handler: APIGatewayProxyHandlerV2<T>
+  handler: APIGatewayProxyWebsocketHandlerV2<T>
 }
 
 declare function wsRouterHandler (routes: Route[]): middy.MiddyfiedHandler

--- a/packages/ws-router/index.test-d.ts
+++ b/packages/ws-router/index.test-d.ts
@@ -1,16 +1,16 @@
 import middy from '@middy/core'
-import { APIGatewayProxyHandlerV2 } from 'aws-lambda'
+import { APIGatewayProxyWebsocketHandlerV2 } from 'aws-lambda'
 import { expectType } from 'tsd'
 import wsRouterHandler from '.'
 
-const connectLambdaHandler: APIGatewayProxyHandlerV2 = async () => {
+const connectLambdaHandler: APIGatewayProxyWebsocketHandlerV2 = async () => {
   return {
     statusCode: 200,
     body: 'Connected to websocket'
   }
 }
 
-const disconnectLambdaHandler: APIGatewayProxyHandlerV2 = async () => {
+const disconnectLambdaHandler: APIGatewayProxyWebsocketHandlerV2 = async () => {
   return {
     statusCode: 200,
     body: 'Disconnected to websocket'


### PR DESCRIPTION
Shouldn't the type of each handler of the `ws-router` be `APIGatewayProxyWebsocketHandlerV2` instead of `APIGatewayProxyHandlerV2`? For example, in `APIGatewayProxyHandlerV2`, there is no `event.requestContext.connectionId` or most of the properties listed here:
https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-mapping-template-reference.html

This includes updating the type of the `handler` property of the `Route` type in the declaration file.