### PR TITLE
chore: remove @middy in plugin error messages

### DIFF
--- a/packages/http-json-body-parser/__tests__/index.js
+++ b/packages/http-json-body-parser/__tests__/index.js
@@ -172,7 +172,7 @@ test("It shouldn't process the body and throw error if no header is passed", asy
     await handler(event, defaultContext)
   } catch (e) {
     t.is(e.statusCode, 415)
-    t.is(e.message, '@middy/http-json-body-parser Unsupported Media Type')
+    t.is(e.message, 'Unsupported Media Type')
     t.is(e.cause, undefined)
   }
 })

--- a/packages/http-json-body-parser/index.js
+++ b/packages/http-json-body-parser/index.js
@@ -18,13 +18,9 @@ const httpJsonBodyParserMiddleware = (opts = {}) => {
       if (options.disableContentTypeError) {
         return
       }
-      throw createError(
-        415,
-        '@middy/http-json-body-parser Unsupported Media Type',
-        {
-          cause: contentType
-        }
-      )
+      throw createError(415, 'Unsupported Media Type', {
+        cause: contentType
+      })
     }
 
     try {

--- a/packages/http-multipart-body-parser/__tests__/index.js
+++ b/packages/http-multipart-body-parser/__tests__/index.js
@@ -233,7 +233,7 @@ test("It shouldn't process the body and throw error if no header is passed", asy
     await handler(event, defaultContext)
   } catch (e) {
     t.is(e.statusCode, 415)
-    t.is(e.message, '@middy/http-multipart-body-parser Unsupported Media Type')
+    t.is(e.message, 'Unsupported Media Type')
     t.is(e.cause, undefined)
   }
 })

--- a/packages/http-multipart-body-parser/index.js
+++ b/packages/http-multipart-body-parser/index.js
@@ -23,13 +23,9 @@ const httpMultipartBodyParserMiddleware = (opts = {}) => {
       if (options.disableContentTypeError) {
         return
       }
-      throw createError(
-        415,
-        '@middy/http-multipart-body-parser Unsupported Media Type',
-        {
-          cause: contentType
-        }
-      )
+      throw createError(415, 'Unsupported Media Type', {
+        cause: contentType
+      })
     }
 
     return parseMultipartData(request.event, options)

--- a/packages/http-urlencode-body-parser/__tests__/index.js
+++ b/packages/http-urlencode-body-parser/__tests__/index.js
@@ -90,7 +90,7 @@ test("It shouldn't process the body and throw error if no header is passed", asy
     await handler(event, defaultContext)
   } catch (e) {
     t.is(e.statusCode, 415)
-    t.is(e.message, '@middy/http-urlencode-body-parser Unsupported Media Type')
+    t.is(e.message, 'Unsupported Media Type')
     t.is(e.cause, undefined)
   }
 })

--- a/packages/http-urlencode-body-parser/index.js
+++ b/packages/http-urlencode-body-parser/index.js
@@ -16,13 +16,9 @@ const httpUrlencodeBodyParserMiddleware = (opts = {}) => {
       if (options.disableContentTypeError) {
         return
       }
-      throw createError(
-        415,
-        '@middy/http-urlencode-body-parser Unsupported Media Type',
-        {
-          cause: contentType
-        }
-      )
+      throw createError(415, 'Unsupported Media Type', {
+        cause: contentType
+      })
     }
 
     const data = request.event.isBase64Encoded


### PR DESCRIPTION
I don't think information about what libraries a developer is using should be exposed to the public.