### PR TITLE
Update 07-with-typescript.md

### DIFF
--- a/website/docs/writing-middlewares/07-with-typescript.md
+++ b/website/docs/writing-middlewares/07-with-typescript.md
@@ -12,7 +12,7 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda'
 const middleware = (): middy.MiddlewareObj<APIGatewayProxyEvent, APIGatewayProxyResult> => {
   const before: middy.MiddlewareFn<APIGatewayProxyEvent, APIGatewayProxyResult> = async (
     request
-  ): Promise<void> => {
+  ): Promise<APIGatewayProxyResult> => {
     // Your middleware logic
   }
 


### PR DESCRIPTION
The type of the before middleware promise should be **APIGatewayProxyResult** not void, because it can return early.