### PR TITLE
fix(types): declare HttpError as class

### DIFF
--- a/packages/util/index.d.ts
+++ b/packages/util/index.d.ts
@@ -12,7 +12,7 @@ interface Options<Client, ClientOptions> {
   setToContext?: boolean
 }
 
-type HttpError = Error & {
+declare class HttpError extends Error {
   status: number
   statusCode: number
   expose: boolean

--- a/packages/util/index.test-d.ts
+++ b/packages/util/index.test-d.ts
@@ -134,3 +134,8 @@ expectType<any>(parsed)
 
 const normalizedResponse = util.normalizeHttpResponse({}, {})
 expectType<any>(normalizedResponse)
+
+// should be able to use HttpError as a proper class 
+const err = util.createError(500, 'An unexpected error occurred');
+expectType<util.HttpError>(err)
+err instanceof util.HttpError // would throw a type error if not a class


### PR DESCRIPTION
Typescript was throwing an error when trying to work with the HttpError class (e.g. instantiating, using `instanceof`, or extending the class). I think it should declared as a class in types, since that's what it is.