### PR TITLE
[secret-manager]: Add in support for secret rotation date

### DIFF
--- a/packages/appconfig/index.js
+++ b/packages/appconfig/index.js
@@ -20,6 +20,7 @@ const defaults = {
   fetchData: {},
   disablePrefetch: false,
   cacheKey: 'appconfig',
+  cacheKeyExpiry: {},
   cacheExpiry: -1,
   setToContext: false
 }

--- a/packages/dynamodb/index.js
+++ b/packages/dynamodb/index.js
@@ -18,6 +18,7 @@ const defaults = {
   fetchData: {},
   disablePrefetch: false,
   cacheKey: 'dynamodb',
+  cacheKeyExpiry: {},
   cacheExpiry: -1,
   setToContext: false
 }

--- a/packages/rds-signer/index.js
+++ b/packages/rds-signer/index.js
@@ -13,6 +13,7 @@ const defaults = {
   fetchData: {},
   disablePrefetch: false,
   cacheKey: 'rds-signer',
+  cacheKeyExpiry: {},
   cacheExpiry: -1,
   setToContext: false
 }

--- a/packages/s3/index.js
+++ b/packages/s3/index.js
@@ -17,6 +17,7 @@ const defaults = {
   fetchData: {},
   disablePrefetch: false,
   cacheKey: 's3',
+  cacheKeyExpiry: {},
   cacheExpiry: -1,
   setToContext: false
 }

--- a/packages/service-discovery/index.js
+++ b/packages/service-discovery/index.js
@@ -20,6 +20,7 @@ const defaults = {
   fetchData: {}, // { contextKey: {NamespaceName, ServiceName, HealthStatus} }
   disablePrefetch: false,
   cacheKey: 'cloud-map',
+  cacheKeyExpiry: {},
   cacheExpiry: -1,
   setToContext: false
 }

--- a/packages/ssm/index.js
+++ b/packages/ssm/index.js
@@ -24,6 +24,7 @@ const defaults = {
   fetchData: {}, // { contextKey: fetchKey, contextPrefix: fetchPath/ }
   disablePrefetch: false,
   cacheKey: 'ssm',
+  cacheKeyExpiry: {},
   cacheExpiry: -1,
   setToContext: false
 }

--- a/packages/sts/index.js
+++ b/packages/sts/index.js
@@ -17,6 +17,7 @@ const defaults = {
   fetchData: {}, // { contextKey: {RoleArn, RoleSessionName} }
   disablePrefetch: false,
   cacheKey: 'sts',
+  cacheKeyExpiry: {},
   cacheExpiry: -1,
   setToContext: false
 }

--- a/packages/util/__tests__/index.js
+++ b/packages/util/__tests__/index.js
@@ -287,6 +287,46 @@ test.serial(
     clearCache()
   }
 )
+test.serial(
+  'processCache should cache when not expired using cacheKeyExpire',
+  async (t) => {
+    const fetch = sinon.stub().resolves('value')
+    const options = {
+      cacheKey: 'key',
+      cacheExpiry: 0,
+      cacheKeyExpiry: { key: Date.now() + 100 }
+    }
+    processCache(options, fetch, cacheRequest)
+    await setTimeout(50)
+    const cacheValue = getCache('key').value
+    t.is(await cacheValue, 'value')
+    const { value, cache } = processCache(options, fetch, cacheRequest)
+    t.is(await value, 'value')
+    t.is(cache, true)
+    t.is(fetch.callCount, 1)
+    clearCache()
+  }
+)
+test.serial(
+  'processCache should cache when not expired using cacheKeyExpire w/ unix timestamp',
+  async (t) => {
+    const fetch = sinon.stub().resolves('value')
+    const options = {
+      cacheKey: 'key',
+      cacheExpiry: Date.now() + 0,
+      cacheKeyExpiry: { key: Date.now() + 100 }
+    }
+    processCache(options, fetch, cacheRequest)
+    await setTimeout(50)
+    const cacheValue = getCache('key').value
+    t.is(await cacheValue, 'value')
+    const { value, cache } = processCache(options, fetch, cacheRequest)
+    t.is(await value, 'value')
+    t.is(cache, true)
+    t.is(fetch.callCount, 1)
+    clearCache()
+  }
+)
 
 test.serial(
   'processCache should clear and re-fetch modified cache',

--- a/packages/util/index.js
+++ b/packages/util/index.js
@@ -118,12 +118,14 @@ export const processCache = (options, fetch = () => undefined, request) => {
     }
   }
   const value = fetch(request)
-  const expiry = Date.now() + cacheExpiry
-
+  const now = Date.now()
+  // secrets-manager overrides to unix timestamp
+  const expiry = cacheExpiry > 86400000 ? cacheExpiry : now + cacheExpiry
+  const duration = cacheExpiry > 86400000 ? cacheExpiry - now : cacheExpiry
   if (cacheExpiry) {
     const refresh =
-      cacheExpiry > 0
-        ? setInterval(() => processCache(options, fetch, request), cacheExpiry)
+      duration > 0
+        ? setInterval(() => processCache(options, fetch, request), duration)
         : undefined
     cache[cacheKey] = { value, expiry, refresh }
   }

--- a/packages/util/index.js
+++ b/packages/util/index.js
@@ -99,7 +99,8 @@ export const sanitizeKey = (key) => {
 // fetch Cache
 const cache = {} // key: { value:{fetchKey:Promise}, expiry }
 export const processCache = (options, fetch = () => undefined, request) => {
-  const { cacheExpiry, cacheKey } = options
+  let { cacheKey, cacheKeyExpiry, cacheExpiry } = options
+  cacheExpiry = cacheKeyExpiry?.[cacheKey] ?? cacheExpiry
   if (cacheExpiry) {
     const cached = getCache(cacheKey)
     const unexpired =

--- a/website/docs/middlewares/secrets-manager.md
+++ b/website/docs/middlewares/secrets-manager.md
@@ -36,7 +36,7 @@ npm install --save-dev @aws-sdk/client-secrets-manager
 
 NOTES:
 
-- Lambda is required to have IAM permission for `secretsmanager:GetSecretValue`
+- Lambda is required to have IAM permission for `secretsmanager:GetSecretValue`. If using `fetchRotationDate` add `secretsmanager:DescribeSecret` in as well.
 
 ## Sample usage
 

--- a/website/docs/middlewares/secrets-manager.md
+++ b/website/docs/middlewares/secrets-manager.md
@@ -28,7 +28,7 @@ npm install --save-dev @aws-sdk/client-secrets-manager
 - `awsClientAssumeRole` (string) (optional): Internal key where secrets are stored. See [@middy/sts](/docs/middlewares/sts) on to set this.
 - `awsClientCapture` (function) (optional): Enable XRay by passing `captureAWSv3Client` from `aws-xray-sdk` in.
 - `fetchData` (object) (required): Mapping of internal key name to API request parameter `SecretId`.
-- `fetchRotationDate` (boolean|object) (default `false`): Boolean to apply to all or mapping of internal key name to boolean indicating what secrets should fetch NextRotationDate before the secret. `cacheExpiry` is ignored when this is not `false`.
+- `fetchRotationDate` (boolean|object) (default `false`): Boolean to apply to all or mapping of internal key name to boolean. This indicates what secrets should fetch and cached based on `NextRotationDate`/`LastRotationDate`/`LastChangedDate`. `cacheExpiry` of `-1` will use `NextRotationDate`, while any other value will be added to the `LastRotationDate` or `LastChangedDate`, whichever is more recent. If secrets have different rotation schedules, use multiple instances of this middleware.
 - `disablePrefetch` (boolean) (default `false`): On cold start requests will trigger early if they can. Setting `awsClientAssumeRole` disables prefetch.
 - `cacheKey` (string) (default `secrets-manager`): Cache key for the fetched data responses. Must be unique across all middleware.
 - `cacheExpiry` (number) (default `-1`): How long fetch data responses should be cached for. `-1`: cache forever, `0`: never cache, `n`: cache for n ms.

--- a/website/docs/middlewares/secrets-manager.md
+++ b/website/docs/middlewares/secrets-manager.md
@@ -28,6 +28,7 @@ npm install --save-dev @aws-sdk/client-secrets-manager
 - `awsClientAssumeRole` (string) (optional): Internal key where secrets are stored. See [@middy/sts](/docs/middlewares/sts) on to set this.
 - `awsClientCapture` (function) (optional): Enable XRay by passing `captureAWSv3Client` from `aws-xray-sdk` in.
 - `fetchData` (object) (required): Mapping of internal key name to API request parameter `SecretId`.
+- `fetchRotationDate` (boolean|object) (default `false`): Boolean to apply to all or mapping of internal key name to boolean indicating what secrets should fetch NextRotationDate before the secret. `cacheExpiry` is ignored when this is not `false`.
 - `disablePrefetch` (boolean) (default `false`): On cold start requests will trigger early if they can. Setting `awsClientAssumeRole` disables prefetch.
 - `cacheKey` (string) (default `secrets-manager`): Cache key for the fetched data responses. Must be unique across all middleware.
 - `cacheExpiry` (number) (default `-1`): How long fetch data responses should be cached for. `-1`: cache forever, `0`: never cache, `n`: cache for n ms.


### PR DESCRIPTION
@KillDozerX2 Can you give this a review and test? I don't personally use this service.

Adds in support for scheduled secret rotation.
Does not support manual secret rotation.

Closes: #1063