### PR TITLE
fix: updated dynamo unmarshall object reducer to mutate instead of spread

### DIFF
--- a/packages/event-normalizer/index.js
+++ b/packages/event-normalizer/index.js
@@ -165,10 +165,10 @@ const convertValue = {
   L: (value) => value.map((item) => convertToNative(item)),
   M: (value) =>
     Object.entries(value).reduce(
-      (acc, [key, value]) => ({
-        ...acc,
-        [key]: convertToNative(value)
-      }),
+      (acc, [key, value]) => {
+        acc[key] = convertToNative(value)
+        return acc
+      },
       {}
     ),
   NS: (value) => new Set(value.map(convertValue.N)),


### PR DESCRIPTION
The event normalizer middleware was doing a spread inside the reducer for dynamo db object unmarshalling. 

Replaced with mutation to reduce time complexity. 