### PR TITLE
Fixes doc list typo

### DIFF
--- a/website/docs/intro/06-testing.md
+++ b/website/docs/intro/06-testing.md
@@ -11,9 +11,10 @@ This page is a work in progress. If you want to help us to make this page better
 
 As of Middy v3, by default it will trigger an Abort signal shortly before a lambda times out to allow your handler to safely stop up and middleware to clean before the lambda terminates.
 When writing tests for lambda handlers wrapped with middy you'll need to account for this. There are a few  approaches:
-3. Set `context.getRemainingTimeInMillis = falsy` to disable the creation of the AbortController.
+
 1. Set `middy(handler, { timeoutEarlyInMillis: 0 })` to alternatively disable the creation of the AbortController.
 2. Set `middy(handler, { timeoutEarlyResponse: () => {} })` to disable the timeout error from being thrown using a no-op.
+3. Set `context.getRemainingTimeInMillis = falsy` to disable the creation of the AbortController.
 
 When using Middy `cache` and `cacheExpiry` in unit tests for functions in your code, it is important to conditionally disable them for test cases by setting both Middy `options` fields as follows:
 


### PR DESCRIPTION
Reorders list on https://middy.js.org/docs/intro/testing from 3->1->2 to 1->2->3