### PR TITLE
Fixes TypeScript definition for http-router

### DIFF
--- a/packages/http-router/index.d.ts
+++ b/packages/http-router/index.d.ts
@@ -5,12 +5,13 @@ import {
   APIGatewayProxyEvent,
   APIGatewayProxyEventV2,
   APIGatewayProxyResult,
+  APIGatewayProxyResultV2,
   Handler as LambdaHandler
 } from 'aws-lambda'
 
 export type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'ANY'
 
-type TResult = ALBResult | APIGatewayProxyResult
+type TResult = ALBResult | APIGatewayProxyResult | APIGatewayProxyResultV2
 
 export interface Route<TEvent> {
   method: Method

--- a/packages/http-router/index.test-d.ts
+++ b/packages/http-router/index.test-d.ts
@@ -3,7 +3,9 @@ import middy from '@middy/core'
 import httpRouterHandler from '.'
 import {
   APIGatewayProxyEvent,
+  APIGatewayProxyEventV2,
   APIGatewayProxyResult,
+  APIGatewayProxyResultV2,
   Handler as LambdaHandler
 } from 'aws-lambda'
 
@@ -22,3 +24,19 @@ const middleware = httpRouterHandler([
   }
 ])
 expectType<middy.MiddyfiedHandler>(middleware)
+
+const lambdaHandlerV2: LambdaHandler<APIGatewayProxyEventV2, APIGatewayProxyResultV2> = async (event) => {
+  return {
+    statusCode: 200,
+    body: 'Hello world'
+  }
+}
+
+const middlewareV2 = httpRouterHandler([
+  {
+    method: 'GET',
+    path: '/',
+    handler: lambdaHandlerV2
+  }
+])
+expectType<middy.MiddyfiedHandler>(middlewareV2)


### PR DESCRIPTION
This PR allows the writing of handlers that use APIGatewayProxyEventV2 / APIGatewayProxyResultV2 like the following one:

```typescript
async function postHandler(event: APIGatewayProxyEventV2, context: any): Promise<APIGatewayProxyResultV2> {
  return {
    statusCode: 200,
    body: JSON.stringify({ message: 'POST event submitted successfully', post: event.body }),
  }
}
```

I've also added a dedicated TS def test.