### PR TITLE
fix: use lowercased aws embedded metrics import for replacement

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           ./node_modules/.bin/lerna exec --bail --concurrency 2 -- ../../node_modules/.bin/swc --config-file ../../swc.cjs.config.json --source-maps false index.js --out-file index.cjs
           ./node_modules/.bin/lerna exec --bail --concurrency 2 -- sed -i.bak 's/exports,\ \"default\"/module,\ \"exports\"/g' index.cjs # Fix CommonJS default import
-          sed -i.bak 's/awsEmbeddedMetrics.default.createMetricsLogger/awsEmbeddedMetrics.createMetricsLogger/g' packages/cloudwatch-metrics/index.cjs # Fix CommonJS default import
+          sed -i.bak 's/awsembeddedmetrics.default.createMetricsLogger/awsembeddedmetrics.createMetricsLogger/g' packages/cloudwatch-metrics/index.cjs # Fix CommonJS default import
           ./node_modules/.bin/lerna exec --bail --concurrency 2 -- ../../node_modules/.bin/swc --config-file ../../swc.esm.config.json --source-maps false index.js --out-file index.js
 
           ./node_modules/.bin/swc --config-file ./swc.cjs.config.json --source-maps false packages/validator/transpile.js --out-file packages/validator/transpile.cjs


### PR DESCRIPTION
Fixes: https://github.com/middyjs/middy/issues/1074