### PR TITLE
fix(typescript): ssm context is enriched correctly

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -50,7 +50,8 @@ export interface MiddlewareObj<
   TEvent = unknown,
   TResult = any,
   TErr = Error,
-  TContext extends LambdaContext = LambdaContext
+  TContext extends LambdaContext = LambdaContext,
+  TInternal = {}
 > {
   before?: MiddlewareFn<TEvent, TResult, TErr, TContext>
   after?: MiddlewareFn<TEvent, TResult, TErr, TContext>

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -43,7 +43,7 @@ declare type MiddlewareFn<
   TEvent = any,
   TResult = any,
   TErr = Error,
-  TContext extends LambdaContext = LambdaContext
+  TContext extends LambdaContext = LambdaContext,
 > = (request: Request<TEvent, TResult, TErr, TContext>) => any
 
 export interface MiddlewareObj<
@@ -51,7 +51,6 @@ export interface MiddlewareObj<
   TResult = any,
   TErr = Error,
   TContext extends LambdaContext = LambdaContext,
-  TInternal = {}
 > {
   before?: MiddlewareFn<TEvent, TResult, TErr, TContext>
   after?: MiddlewareFn<TEvent, TResult, TErr, TContext>

--- a/packages/ssm/index.d.ts
+++ b/packages/ssm/index.d.ts
@@ -12,7 +12,7 @@ type ExtractSingles<T> = T extends `/${infer _}` ? never : T
 
 export type Internal<TOptions extends Options> = Record<ExtractSingles<keyof TOptions['fetchData']>, JsonValue>
 
-export type Context<TOptions extends Options | undefined> = TOptions extends {
+export type Context<TOptions extends Options | undefined = undefined> = TOptions extends {
   setToContext: true
 }
   ? LambdaContext &
@@ -25,6 +25,6 @@ export type Context<TOptions extends Options | undefined> = TOptions extends {
 
 declare function ssm<TOptions extends Options> (
   options?: TOptions
-): middy.MiddlewareObj<unknown, any, Error, Context<TOptions>, Internal<TOptions>>
+): middy.MiddlewareObj<unknown, any, Error, Context<TOptions>>
 
 export default ssm

--- a/packages/ssm/index.d.ts
+++ b/packages/ssm/index.d.ts
@@ -10,8 +10,6 @@ interface Options<AwsSSMClient = SSMClient>
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type ExtractSingles<T> = T extends `/${infer _}` ? never : T
 
-export type Internal<TOptions extends Options> = Record<ExtractSingles<keyof TOptions['fetchData']>, JsonValue>
-
 export type Context<TOptions extends Options | undefined = undefined> = TOptions extends {
   setToContext: true
 }

--- a/packages/ssm/index.d.ts
+++ b/packages/ssm/index.d.ts
@@ -10,6 +10,8 @@ interface Options<AwsSSMClient = SSMClient>
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type ExtractSingles<T> = T extends `/${infer _}` ? never : T
 
+export type Internal<TOptions extends Options> = Record<ExtractSingles<keyof TOptions['fetchData']>, JsonValue>
+
 export type Context<TOptions extends Options | undefined> = TOptions extends {
   setToContext: true
 }
@@ -23,6 +25,6 @@ export type Context<TOptions extends Options | undefined> = TOptions extends {
 
 declare function ssm<TOptions extends Options> (
   options?: TOptions
-): middy.MiddlewareObj<unknown, any, Error, Context<TOptions>>
+): middy.MiddlewareObj<unknown, any, Error, Context<TOptions>, Internal<TOptions>>
 
 export default ssm

--- a/packages/ssm/index.test-d.ts
+++ b/packages/ssm/index.test-d.ts
@@ -26,7 +26,6 @@ expectType<middy.MiddlewareObj<unknown, any, Error, Context<typeof options>>>(
   ssm(options)
 )
 
-
 // checks that values fetched are actually enriching the context correctly (#1084)
 middy()
   .use(
@@ -41,9 +40,9 @@ middy()
   )
   .before((request) => {
     // checks that the context is correctly enriched in before
-    expectType<Record<"accessToken" | "dbParams" | "defaults", JsonValue>>(request.context)
+    expectType<Record<'accessToken' | 'dbParams' | 'defaults', JsonValue>>(request.context)
   })
   .handler(async (req, context) => {
     // checks that the context is correctly enriched in handler
-    expectType<Record<"accessToken" | "dbParams" | "defaults", JsonValue>>(context)
+    expectType<Record<'accessToken' | 'dbParams' | 'defaults', JsonValue>>(context)
   })

--- a/packages/ssm/index.test-d.ts
+++ b/packages/ssm/index.test-d.ts
@@ -1,12 +1,12 @@
 import middy from '@middy/core'
 import { SSMClient } from '@aws-sdk/client-ssm'
 import { captureAWSv3Client } from 'aws-xray-sdk'
-import { expectType } from 'tsd'
+import { expectType, expectAssignable } from 'tsd'
 import ssm, { Context } from '.'
 import { JsonValue } from 'type-fest'
 
 // use with default options
-expectType<middy.MiddlewareObj<unknown, any, Error, Context<undefined>>>(ssm())
+expectType<middy.MiddlewareObj<unknown, any, Error, Context>>(ssm())
 
 // use with all options
 const options = {
@@ -40,9 +40,9 @@ middy()
   )
   .before((request) => {
     // checks that the context is correctly enriched in before
-    expectType<Record<'accessToken' | 'dbParams' | 'defaults', JsonValue>>(request.context)
+    expectAssignable<Context & Record<'accessToken' | 'dbParams' | 'defaults', JsonValue>>(request.context)
   })
   .handler(async (req, context) => {
     // checks that the context is correctly enriched in handler
-    expectType<Record<'accessToken' | 'dbParams' | 'defaults', JsonValue>>(context)
+    expectAssignable<Record<'accessToken' | 'dbParams' | 'defaults', JsonValue>>(context)
   })


### PR DESCRIPTION
Fixes #1084 

~~@m-radzikowski, I have a first draft for a potential solution to what you suggested in #1084. I am not sure I understood your point about JsonValue.~~

~~I'd love if you can give this a quick review and let me know if this is going in the right direction.~~

On a second look at what I originally did in this PR, I understood that what I did was only testing the current existing solution for `ssm`. 😓 

Now I think I understand that your suggestion is to generalise that approach to something that would work for all the other middleware that change the context. Is that correct?

With that being said, there's a bit of TS magic here that I am not entirely comfortable with... Can you, please, expand a bit on your pseudo-code maybe providing something more concrete that I can work with?

Thanks