### PR TITLE
Green CI for 5.0

### DIFF
--- a/packages/error-logger/index.test-d.ts
+++ b/packages/error-logger/index.test-d.ts
@@ -8,6 +8,6 @@ expectType<middy.MiddlewareObj>(middleware)
 
 // use with all options
 middleware = errorLogger({
-  logger: ({error}) => console.log(error)
+  logger: ({ error }) => console.log(error)
 })
 expectType<middy.MiddlewareObj>(middleware)

--- a/packages/http-content-negotiation/index.d.ts
+++ b/packages/http-content-negotiation/index.d.ts
@@ -12,6 +12,7 @@ interface Options {
   failOnMismatch?: boolean
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface Event {}
 
 export interface Context {
@@ -25,7 +26,7 @@ export interface Context {
   preferredMediaType: string
 }
 
-declare function httpContentNegotiation(
+declare function httpContentNegotiation (
   options?: Options
 ): middy.MiddlewareObj<Event>
 

--- a/packages/s3-object-response/package-lock.json
+++ b/packages/s3-object-response/package-lock.json
@@ -8,12 +8,8 @@
       "name": "@middy/s3-object-response",
       "version": "5.0.0-alpha.0",
       "license": "MIT",
-      "dependencies": {
-        "@middy/util": "5.0.0-alpha.0"
-      },
       "devDependencies": {
         "@aws-sdk/client-s3": "^3.0.0",
-        "@middy/core": "5.0.0-alpha.0",
         "@types/aws-lambda": "^8.10.101",
         "aws-xray-sdk": "^3.3.3"
       },
@@ -832,31 +828,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@middy/core": {
-      "version": "5.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-5.0.0-alpha.0.tgz",
-      "integrity": "sha512-7nkjoxuQ57vMD5S6IJmVsec6ebeM9JSkk8YQf3LpUUCqMLgbVfyFT9bcXY90vb/UICNuDEnkLyEbi0/bCFYgBg==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/willfarrell"
-      }
-    },
-    "node_modules/@middy/util": {
-      "version": "5.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@middy/util/-/util-5.0.0-alpha.0.tgz",
-      "integrity": "sha512-XZu3BeueQ+hrbP0tKJPeFtRRZklGDOaFQHwXKDS5ECp5jL99HNQ8CNQ6jwF7wYt7ltYjNwFFojzmc/o6VEYeVw==",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/willfarrell"
       }
     },
     "node_modules/@smithy/abort-controller": {


### PR DESCRIPTION
I noticed some CI issues on the 5.0 branch. This PR attempts to have a green happy CI so we can have a good starting point for the other typings changes that are expected for the final 5.0 version.

In particular this PR changes:

- missing types for `@middy/s3-object-response` (potentially due to a non up to date package-lock)
- fixing some `ts-standard` errors
- fixing some broken tests


Current status:

- Some tests are still broken apparently, more work to do!