### PR TITLE
fix: type for new AWS SDK Clients with optional config parameter

### DIFF
--- a/packages/util/index.d.ts
+++ b/packages/util/index.d.ts
@@ -1,7 +1,7 @@
 import middy from '@middy/core'
 
 interface Options<Client, ClientOptions> {
-  AwsClient?: new (...args: any[]) => Client
+  AwsClient?: new (...[config]: [any] | any) => Client
   awsClientOptions?: Partial<ClientOptions>
   awsClientAssumeRole?: string
   awsClientCapture?: (service: Client) => Client


### PR DESCRIPTION
AWS SDK [v3.387.0](https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.387.0) introduces the possibility to create Clients without (empty) configuration object (finally). This caused the AWS Client's middy type to be incompatible with the new SDK.

The changed type works well for both old and new SDK versions (with and without the required config parameter) and fixes failing typings tests. Although it would be best if another pair of eyes would check it with old and new SDK, just to be sure.