### PR TITLE
feat: add parser middleware

### DIFF
--- a/packages/http-json-body-parser/package-lock.json
+++ b/packages/http-json-body-parser/package-lock.json
@@ -8,39 +8,10 @@
       "name": "@middy/http-json-body-parser",
       "version": "4.6.2",
       "license": "MIT",
-      "dependencies": {
-        "@middy/util": "4.6.2"
-      },
       "devDependencies": {
-        "@middy/core": "4.6.2",
         "@types/aws-lambda": "^8.10.101",
         "type-fest": "^4.0.0"
       },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/willfarrell"
-      }
-    },
-    "node_modules/@middy/core": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-4.6.1.tgz",
-      "integrity": "sha512-3fBaaL2fTX0564pkniDBcTm3S8qOatHVZKDZ8GG3ZrmEJhVkWGkv1e4iWywjtBsLaXzho75uuSUFwdeEbl3x5A==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/willfarrell"
-      }
-    },
-    "node_modules/@middy/util": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@middy/util/-/util-4.6.1.tgz",
-      "integrity": "sha512-EylBSkcSU+vg8dBFUu0x494EXzjG3DrTSzePf5pFHzaGeTh0GliButSQXO4PU4eK1p2XUW2Cx0vCYoTbsNAtYA==",
       "engines": {
         "node": ">=16"
       },

--- a/packages/http-multipart-body-parser/package-lock.json
+++ b/packages/http-multipart-body-parser/package-lock.json
@@ -9,39 +9,12 @@
       "version": "4.6.2",
       "license": "MIT",
       "dependencies": {
-        "@middy/util": "4.6.2",
         "busboy": "1.6.0"
       },
       "devDependencies": {
-        "@middy/core": "4.6.2",
         "@types/aws-lambda": "^8.10.101",
         "type-fest": "^4.0.0"
       },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/willfarrell"
-      }
-    },
-    "node_modules/@middy/core": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-4.6.1.tgz",
-      "integrity": "sha512-3fBaaL2fTX0564pkniDBcTm3S8qOatHVZKDZ8GG3ZrmEJhVkWGkv1e4iWywjtBsLaXzho75uuSUFwdeEbl3x5A==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/willfarrell"
-      }
-    },
-    "node_modules/@middy/util": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@middy/util/-/util-4.6.1.tgz",
-      "integrity": "sha512-EylBSkcSU+vg8dBFUu0x494EXzjG3DrTSzePf5pFHzaGeTh0GliButSQXO4PU4eK1p2XUW2Cx0vCYoTbsNAtYA==",
       "engines": {
         "node": ">=16"
       },

--- a/packages/http-response-serializer/package-lock.json
+++ b/packages/http-response-serializer/package-lock.json
@@ -9,11 +9,7 @@
       "version": "4.6.2",
       "license": "MIT",
       "dependencies": {
-        "@hapi/accept": "6.0.2",
-        "@middy/util": "4.6.2"
-      },
-      "devDependencies": {
-        "@middy/core": "4.6.2"
+        "@hapi/accept": "6.0.2"
       },
       "engines": {
         "node": ">=16"
@@ -44,31 +40,6 @@
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.2.tgz",
       "integrity": "sha512-aKmlCO57XFZ26wso4rJsW4oTUnrgTFw2jh3io7CAtO9w4UltBNwRXvXIVzzyfkaaLRo3nluP/19msA8vDUUuKw=="
-    },
-    "node_modules/@middy/core": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-4.6.1.tgz",
-      "integrity": "sha512-3fBaaL2fTX0564pkniDBcTm3S8qOatHVZKDZ8GG3ZrmEJhVkWGkv1e4iWywjtBsLaXzho75uuSUFwdeEbl3x5A==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/willfarrell"
-      }
-    },
-    "node_modules/@middy/util": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@middy/util/-/util-4.6.1.tgz",
-      "integrity": "sha512-EylBSkcSU+vg8dBFUu0x494EXzjG3DrTSzePf5pFHzaGeTh0GliButSQXO4PU4eK1p2XUW2Cx0vCYoTbsNAtYA==",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/willfarrell"
-      }
     }
   }
 }

--- a/packages/http-urlencode-body-parser/package-lock.json
+++ b/packages/http-urlencode-body-parser/package-lock.json
@@ -9,39 +9,12 @@
       "version": "4.6.2",
       "license": "MIT",
       "dependencies": {
-        "@middy/util": "4.6.2",
         "qs": "6.11.2"
       },
       "devDependencies": {
-        "@middy/core": "4.6.2",
         "@types/aws-lambda": "^8.10.101",
         "type-fest": "^4.0.0"
       },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/willfarrell"
-      }
-    },
-    "node_modules/@middy/core": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-4.6.1.tgz",
-      "integrity": "sha512-3fBaaL2fTX0564pkniDBcTm3S8qOatHVZKDZ8GG3ZrmEJhVkWGkv1e4iWywjtBsLaXzho75uuSUFwdeEbl3x5A==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/willfarrell"
-      }
-    },
-    "node_modules/@middy/util": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@middy/util/-/util-4.6.1.tgz",
-      "integrity": "sha512-EylBSkcSU+vg8dBFUu0x494EXzjG3DrTSzePf5pFHzaGeTh0GliButSQXO4PU4eK1p2XUW2Cx0vCYoTbsNAtYA==",
       "engines": {
         "node": ">=16"
       },

--- a/packages/http-urlencode-path-parser/package-lock.json
+++ b/packages/http-urlencode-path-parser/package-lock.json
@@ -9,23 +9,9 @@
       "version": "4.6.2",
       "license": "MIT",
       "devDependencies": {
-        "@middy/core": "4.6.2",
         "@types/aws-lambda": "^8.10.101",
         "type-fest": "^4.0.0"
       },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/willfarrell"
-      }
-    },
-    "node_modules/@middy/core": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-4.6.1.tgz",
-      "integrity": "sha512-3fBaaL2fTX0564pkniDBcTm3S8qOatHVZKDZ8GG3ZrmEJhVkWGkv1e4iWywjtBsLaXzho75uuSUFwdeEbl3x5A==",
-      "dev": true,
       "engines": {
         "node": ">=16"
       },

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -1,0 +1,46 @@
+<div align="center">
+  <h1>Middy parser middleware</h1>
+  <img alt="Middy logo" src="https://raw.githubusercontent.com/middyjs/middy/main/docs/img/middy-logo.svg"/>
+  <p><strong>Parser middleware for the middy framework, the stylish Node.js middleware engine for AWS Lambda</strong></p>
+<p>
+  <a href="https://www.npmjs.com/package/@middy/parser?activeTab=versions">
+    <img src="https://badge.fury.io/js/%40middy%2Fparser.svg" alt="npm version" style="max-width:100%;">
+  </a>
+  <a href="https://packagephobia.com/result?p=@middy/parser">
+    <img src="https://packagephobia.com/badge?p=@middy/parser" alt="npm install size" style="max-width:100%;">
+  </a>
+  <a href="https://github.com/middyjs/middy/actions/workflows/tests.yml">
+    <img src="https://github.com/middyjs/middy/actions/workflows/tests.yml/badge.svg?branch=main&event=push" alt="GitHub Actions CI status badge" style="max-width:100%;">
+  </a>
+  <br/>
+   <a href="https://standardjs.com/">
+    <img src="https://img.shields.io/badge/code_style-standard-brightgreen.svg" alt="Standard Code Style"  style="max-width:100%;">
+  </a>
+  <a href="https://snyk.io/test/github/middyjs/middy">
+    <img src="https://snyk.io/test/github/middyjs/middy/badge.svg" alt="Known Vulnerabilities" data-canonical-src="https://snyk.io/test/github/middyjs/middy" style="max-width:100%;">
+  </a>
+  <a href="https://github.com/middyjs/middy/actions/workflows/sast.yml">
+    <img src="https://github.com/middyjs/middy/actions/workflows/sast.yml/badge.svg
+?branch=main&event=push" alt="CodeQL" style="max-width:100%;">
+  </a>
+  <a href="https://bestpractices.coreinfrastructure.org/projects/5280">
+    <img src="https://bestpractices.coreinfrastructure.org/projects/5280/badge" alt="Core Infrastructure Initiative (CII) Best Practices"  style="max-width:100%;">
+  </a>
+  <br/>
+  <a href="https://gitter.im/middyjs/Lobby">
+    <img src="https://badges.gitter.im/gitterHQ/gitter.svg" alt="Chat on Gitter" style="max-width:100%;">
+  </a>
+  <a href="https://stackoverflow.com/questions/tagged/middy?sort=Newest&uqlId=35052">
+    <img src="https://img.shields.io/badge/StackOverflow-[middy]-yellow" alt="Ask questions on StackOverflow" style="max-width:100%;">
+  </a>
+</p>
+<p>You can read the documentation at: <a href="https://middy.js.org/docs/middlewares/parser">https://middy.js.org/docs/middlewares/parser</a></p>
+</div>
+
+## License
+
+Licensed under [MIT License](LICENSE). Copyright (c) 2017-2023 [Luciano Mammino](https://github.com/lmammino), [will Farrell](https://github.com/willfarrell), and the [Middy team](https://github.com/middyjs/middy/graphs/contributors).
+
+<a href="https://app.fossa.io/projects/git%2Bgithub.com%2Fmiddyjs%2Fmiddy?ref=badge_large">
+  <img src="https://app.fossa.io/api/projects/git%2Bgithub.com%2Fmiddyjs%2Fmiddy.svg?type=large" alt="FOSSA Status"  style="max-width:100%;">
+</a>

--- a/packages/parser/__benchmarks__/index.js
+++ b/packages/parser/__benchmarks__/index.js
@@ -1,0 +1,32 @@
+import Benchmark from 'benchmark'
+import middy from '../../core/index.js'
+import middleware from '../index.js'
+import { z } from 'zod'
+
+const suite = new Benchmark.Suite('@middy/parser')
+
+const context = {
+  getRemainingTimeInMillis: () => 30000
+}
+const setupHandler = () => {
+  const baseHandler = () => {}
+  return middy(baseHandler).use(
+    middleware({
+      eventSchema: z.object({}),
+      responseSchema: z.object({})
+    })
+  )
+}
+
+const warmHandler = setupHandler()
+
+suite
+  .add('type check input & output', async (event = {}) => {
+    try {
+      await warmHandler(event, context)
+    } catch (e) {}
+  })
+  .on('cycle', (event) => {
+    console.log(suite.name, String(event.target))
+  })
+  .run({ async: true })

--- a/packages/parser/__tests__/index.js
+++ b/packages/parser/__tests__/index.js
@@ -1,0 +1,261 @@
+import test from 'ava'
+import middy from '../../core/index.js'
+import parser, {
+  eventParsingErrorMessage,
+  contextParsingErrorMessage,
+  responseParsingErrorMessage
+} from '../index.js'
+import { z } from 'zod'
+
+const event = {}
+const context = {
+  getRemainingTimeInMillis: () => 1000,
+  callbackWaitsForEmptyEventLoop: true,
+  functionVersion: '$LATEST',
+  functionName: 'lambda',
+  memoryLimitInMB: '128',
+  logGroupName: '/aws/lambda/lambda',
+  logStreamName: '2022/04/01/[$LATEST]7a7ac3439a3b4635ba18460a3c7cea81',
+  clientContext: undefined,
+  identity: undefined,
+  invokedFunctionArn:
+    'arn:aws:lambda:ca-central-1:000000000000:function:lambda',
+  awsRequestId: '00000000-0000-0000-0000-0000000000000'
+}
+const contextSchema = z.object({
+  getRemainingTimeInMillis: z.function(),
+  functionVersion: z.string(),
+  invokedFunctionArn: z.string(),
+  memoryLimitInMB: z.string(),
+  awsRequestId: z.string(),
+  logGroupName: z.string(),
+  logStreamName: z.string(),
+  identity: z
+    .object({
+      cognitoIdentityId: z.string(),
+      cognitoIdentityPoolId: z.string()
+    })
+    .optional(),
+  clientContext: z
+    .object({
+      'client.installation_id': z.string(),
+      'client.app_title': z.string(),
+      'client.app_version_name': z.string(),
+      'client.app_version_code': z.string(),
+      'client.app_package_name': z.string(),
+      'env.platform_version': z.string(),
+      'env.platform': z.string(),
+      'env.make': z.string(),
+      'env.model': z.string(),
+      'env.locale': z.string()
+    })
+    .optional(),
+  callbackWaitsForEmptyEventLoop: z.boolean()
+})
+
+test('It should parse an event object', async (t) => {
+  const handler = middy((event, context) => {
+    return event.body // propagates the body as a response
+  })
+
+  const eventSchema = z.object({
+    body: z.object({
+      string: z.string(),
+      boolean: z.boolean(),
+      integer: z.number().int(),
+      number: z.number()
+    })
+  })
+
+  handler.use(parser({ eventSchema }))
+
+  // invokes the handler
+  const event = {
+    body: {
+      string: JSON.stringify({ foo: 'bar' }),
+      boolean: true,
+      integer: 0,
+      number: 0.1
+    }
+  }
+
+  const body = await handler(event, context)
+
+  t.deepEqual(body, {
+    boolean: true,
+    integer: 0,
+    number: 0.1,
+    string: '{"foo":"bar"}'
+  })
+})
+
+test('It should parse an event object with formats', async (t) => {
+  const handler = middy((event, context) => {
+    return event.body // propagates the body as a response
+  })
+
+  const eventSchema = z.object({
+    body: z.object({
+      datetime: z.string().datetime(),
+      email: z.string().email(),
+      url: z.string().url(),
+      ipv4: z.string().ip({ version: 'v4' }),
+      ipv6: z.string().ip({ version: 'v6' }),
+      uuid: z.string().uuid()
+    })
+  })
+
+  handler.use(parser({ eventSchema }))
+
+  const event = {
+    body: {
+      datetime: '2020-01-01T00:00:00Z',
+      url: 'https://example.org',
+      email: 'username@example.org',
+      ipv4: '127.0.0.1',
+      ipv6: '2001:0db8:0000:0000:0000:ff00:0042:8329',
+      uuid: '123e4567-e89b-12d3-a456-426614174000'
+    }
+  }
+
+  const body = await handler(event, context)
+
+  t.deepEqual(body, {
+    datetime: '2020-01-01T00:00:00Z',
+    url: 'https://example.org',
+    email: 'username@example.org',
+    ipv4: '127.0.0.1',
+    ipv6: '2001:0db8:0000:0000:0000:ff00:0042:8329',
+    uuid: '123e4567-e89b-12d3-a456-426614174000'
+  })
+})
+
+test('It should handle invalid schema as a BadRequest', async (t) => {
+  const handler = middy((event, context) => {
+    return event.body // propagates the body as a response
+  })
+
+  const eventSchema = z.object({
+    body: z.string(),
+    foo: z.string()
+  })
+
+  handler.use(parser({ eventSchema }))
+
+  // invokes the handler, note that property foo is missing
+  const event = {
+    body: JSON.stringify({ something: 'somethingelse' })
+  }
+
+  try {
+    await handler(event, context)
+  } catch (e) {
+    t.is(e.message, eventParsingErrorMessage)
+    t.deepEqual(e.cause.issues, [
+      {
+        code: 'invalid_type',
+        expected: 'string',
+        message: 'Required',
+        path: ['foo'],
+        received: 'undefined'
+      }
+    ])
+  }
+})
+
+test('It should parse context object', async (t) => {
+  const expectedResponse = {
+    body: 'Hello world',
+    statusCode: 200
+  }
+
+  const handler = middy((event, context) => {
+    return expectedResponse
+  })
+
+  handler.use(parser({ contextSchema }))
+
+  const response = await handler(event, context)
+
+  t.deepEqual(response, expectedResponse)
+})
+
+test('It should throw an Internal Server Error if invalid context', async (t) => {
+  const handler = middy((event, context) => {
+    return {}
+  })
+
+  handler
+    .before((request) => {
+      request.context.callbackWaitsForEmptyEventLoop = 'fail'
+    })
+    .use(parser({ contextSchema }))
+
+  try {
+    await handler(event, context)
+  } catch (e) {
+    t.not(e, null)
+    t.is(e.message, contextParsingErrorMessage)
+  }
+})
+
+test('It should parse response object', async (t) => {
+  const expectedResponse = {
+    body: 'Hello world',
+    statusCode: 200
+  }
+
+  const handler = middy((event, context) => {
+    return expectedResponse
+  })
+
+  const responseSchema = z.object({
+    body: z.string(),
+    statusCode: z.number()
+  })
+
+  handler.use(parser({ responseSchema }))
+
+  const response = await handler(event, context)
+
+  t.deepEqual(response, expectedResponse)
+})
+
+test('It should throw an Internal Server Error if invalid response', async (t) => {
+  const handler = middy((event, context) => {
+    return {}
+  })
+
+  const responseSchema = z.object({
+    body: z.object({}),
+    statusCode: z.object({})
+  })
+
+  handler.use(parser({ responseSchema }))
+
+  try {
+    await handler(event, context)
+  } catch (e) {
+    t.not(e, null)
+    t.is(e.message, responseParsingErrorMessage)
+  }
+})
+
+test('It should not allow bad email format', async (t) => {
+  const eventSchema = z.object({
+    email: z.string().email()
+  })
+  const handler = middy((event, context) => {
+    return {}
+  })
+
+  handler.use(parser({ eventSchema }))
+
+  const event = { email: 'abc@abc' }
+  try {
+    // This same email is not a valid one in 'full' validation mode
+    await handler(event, context)
+  } catch (e) {
+    t.is(e.cause.issues[0].message, 'Invalid email')
+  }
+})

--- a/packages/parser/index.d.ts
+++ b/packages/parser/index.d.ts
@@ -1,0 +1,27 @@
+import middy from '@middy/core'
+import type { ZodSchema, ZodError, infer as Infer } from 'zod'
+import type { Context } from 'aws-lambda'
+
+export const eventParsingErrorMessage: string
+export const contextParsingErrorMessage: string
+export const responseParsingErrorMessage: string
+
+interface Options<T, U, V> {
+  eventSchema?: T
+  contextSchema?: U
+  responseSchema?: V
+  createErrorFunc?: (statusCode: number, message: string, properties: { cause: ZodError }) => Error
+}
+
+declare function parser<
+  T extends ZodSchema | undefined = undefined,
+  U extends ZodSchema | undefined = undefined,
+  V extends ZodSchema | undefined = undefined
+>(options?: Options<T, U, V>): middy.MiddlewareObj<
+  T extends ZodSchema ? Infer<T> : unknown,
+  V extends ZodSchema ? Infer<V> : unknown,
+  Error,
+  U extends ZodSchema ? Infer<U> & Context : Context
+>
+
+export default parser

--- a/packages/parser/index.d.ts
+++ b/packages/parser/index.d.ts
@@ -17,11 +17,11 @@ declare function parser<
   T extends ZodSchema | undefined = undefined,
   U extends ZodSchema | undefined = undefined,
   V extends ZodSchema | undefined = undefined
->(options?: Options<T, U, V>): middy.MiddlewareObj<
-  T extends ZodSchema ? Infer<T> : unknown,
-  V extends ZodSchema ? Infer<V> : unknown,
-  Error,
-  U extends ZodSchema ? Infer<U> & Context : Context
+> (options?: Options<T, U, V>): middy.MiddlewareObj<
+T extends ZodSchema ? Infer<T> : unknown,
+V extends ZodSchema ? Infer<V> : any,
+Error,
+U extends ZodSchema ? Infer<U> & Context : Context
 >
 
 export default parser

--- a/packages/parser/index.js
+++ b/packages/parser/index.js
@@ -1,0 +1,69 @@
+import { createError } from '@middy/util'
+
+export const eventParsingErrorMessage = 'Event object failed parsing'
+export const contextParsingErrorMessage = 'Context object failed parsing'
+export const responseParsingErrorMessage = 'Response object failed parsing'
+
+/**
+ * @type {import('./index').default}
+ */
+const parserMiddleware = ({
+  eventSchema,
+  contextSchema,
+  responseSchema,
+  createErrorFunc = createError
+} = {}) => {
+  /**
+   * @param {import('@middy/core').Request} request
+   */
+  const parserMiddlewareBefore = (request) => {
+    if (eventSchema) {
+      const parseResult = eventSchema.safeParse(request.event)
+
+      if (!parseResult.success) {
+        // Bad Request
+        throw createErrorFunc(400, eventParsingErrorMessage, {
+          cause: parseResult.error
+        })
+      }
+      // assign the parsed event back
+      request.event = parseResult.data
+    }
+
+    if (contextSchema) {
+      const parseResult = contextSchema.safeParse(request.context)
+
+      if (!parseResult.success) {
+        // Internal Server Error
+        throw createErrorFunc(500, contextParsingErrorMessage, {
+          cause: parseResult.error
+        })
+      }
+      // assign the parsed context back
+      request.context = parseResult.data
+    }
+  }
+
+  /**
+   * @param {import('@middy/core').Request} request
+   */
+  const parserMiddlewareAfter = (request) => {
+    const parseResult = responseSchema.safeParse(request.response)
+
+    if (!parseResult.success) {
+      // Internal Server Error
+      throw createErrorFunc(500, responseParsingErrorMessage, {
+        cause: parseResult.error
+      })
+    }
+    // assign the parsed result back
+    request.response = parseResult.data
+  }
+
+  return {
+    before: eventSchema ?? contextSchema ? parserMiddlewareBefore : undefined,
+    after: responseSchema ? parserMiddlewareAfter : undefined
+  }
+}
+
+export default parserMiddleware

--- a/packages/parser/index.test-d.ts
+++ b/packages/parser/index.test-d.ts
@@ -28,7 +28,7 @@ middy().use(fullMiddleware).handler(async (event, context) => {
 const eventMiddleware = parser({
   eventSchema: z.object({ body: z.object({ records: z.array(z.string()).min(1).max(100) }) })
 })
-expectType<middy.MiddlewareObj<{ body: { records: string[] } }, unknown, Error, Context>>(eventMiddleware)
+expectType<middy.MiddlewareObj<{ body: { records: string[] } }, any, Error, Context>>(eventMiddleware)
 
 // with a customError
 const customErrorMiddleware = parser({
@@ -44,4 +44,4 @@ const customErrorMiddleware = parser({
     return createError(status, message, { cause })
   }
 })
-expectType<middy.MiddlewareObj<{ body: { records: string[] } }, unknown, Error, Context>>(customErrorMiddleware)
+expectType<middy.MiddlewareObj<{ body: { records: string[] } }, any, Error, Context>>(customErrorMiddleware)

--- a/packages/parser/index.test-d.ts
+++ b/packages/parser/index.test-d.ts
@@ -1,0 +1,48 @@
+import { expectType } from 'tsd'
+import middy from '@middy/core'
+import parser from '.'
+import { z, type ZodError } from 'zod';
+import type { Context } from 'aws-lambda'
+import { createError } from '@middy/util'
+import { eventParsingErrorMessage } from './index'
+
+// use with default options
+const defaultMiddleware = parser()
+expectType<middy.MiddlewareObj>(defaultMiddleware)
+
+// use with all options
+const fullMiddleware = parser({
+  eventSchema: z.object({ body: z.string() }),
+  contextSchema: z.object({ config: z.object({ batchSize: z.number().int() }) }),
+  responseSchema: z.object({ results: z.array(z.string()).min(1).max(100) })
+})
+expectType<middy.MiddlewareObj<{ body: string }, { results: string[] }, Error, Context & { config: { batchSize: number } }>>(fullMiddleware)
+
+// handler event and context has type correct inference
+const handler = middy().use(fullMiddleware).handler(async (event, context) => {
+  expectType<{ body: string }>(event)
+  expectType<Context & { config: { batchSize: number } }>(context)
+  return { results: [''] }
+})
+
+// event only
+const eventMiddleware = parser({
+  eventSchema: z.object({ body: z.object({ records: z.array(z.string()).min(1).max(100) }) })
+})
+expectType<middy.MiddlewareObj<{ body: { records: string[] } }, unknown, Error, Context>>(eventMiddleware)
+
+// with a customError
+const customErrorMiddleware = parser({
+  eventSchema: z.object({ body: z.object({ records: z.array(z.string()).min(1).max(100) }) }),
+  createErrorFunc: (status, message, { cause }) => {
+    expectType<number>(status);
+    expectType<string>(message);
+    expectType<ZodError>(cause);
+    if (message === eventParsingErrorMessage) {
+      return createError(400, JSON.stringify({ code: '10003', message: cause.format()._errors.join(', ') }), { cause })
+    }
+
+    return createError(status, message, { cause })
+  }
+})
+expectType<middy.MiddlewareObj<{ body: { records: string[] } }, unknown, Error, Context>>(customErrorMiddleware)

--- a/packages/parser/index.test-d.ts
+++ b/packages/parser/index.test-d.ts
@@ -1,10 +1,9 @@
 import { expectType } from 'tsd'
 import middy from '@middy/core'
-import parser from '.'
-import { z, type ZodError } from 'zod';
+import parser, { eventParsingErrorMessage } from '.'
+import { z, type ZodError } from 'zod'
 import type { Context } from 'aws-lambda'
 import { createError } from '@middy/util'
-import { eventParsingErrorMessage } from './index'
 
 // use with default options
 const defaultMiddleware = parser()
@@ -19,7 +18,7 @@ const fullMiddleware = parser({
 expectType<middy.MiddlewareObj<{ body: string }, { results: string[] }, Error, Context & { config: { batchSize: number } }>>(fullMiddleware)
 
 // handler event and context has type correct inference
-const handler = middy().use(fullMiddleware).handler(async (event, context) => {
+middy().use(fullMiddleware).handler(async (event, context) => {
   expectType<{ body: string }>(event)
   expectType<Context & { config: { batchSize: number } }>(context)
   return { results: [''] }
@@ -35,9 +34,9 @@ expectType<middy.MiddlewareObj<{ body: { records: string[] } }, unknown, Error, 
 const customErrorMiddleware = parser({
   eventSchema: z.object({ body: z.object({ records: z.array(z.string()).min(1).max(100) }) }),
   createErrorFunc: (status, message, { cause }) => {
-    expectType<number>(status);
-    expectType<string>(message);
-    expectType<ZodError>(cause);
+    expectType<number>(status)
+    expectType<string>(message)
+    expectType<ZodError>(cause)
     if (message === eventParsingErrorMessage) {
       return createError(400, JSON.stringify({ code: '10003', message: cause.format()._errors.join(', ') }), { cause })
     }

--- a/packages/parser/package-lock.json
+++ b/packages/parser/package-lock.json
@@ -1,0 +1,3114 @@
+{
+  "name": "@middy/parser",
+  "version": "4.6.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@middy/parser",
+      "version": "4.6.2",
+      "license": "MIT",
+      "dependencies": {
+        "@middy/util": "4.6.2"
+      },
+      "devDependencies": {
+        "@middy/core": "4.6.2",
+        "@types/aws-lambda": "^8.10.121",
+        "@types/http-errors": "^2.0.0",
+        "tsd": "^0.29.0",
+        "zod": "^3.22.2"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/willfarrell"
+      }
+    },
+    "../core": {
+      "name": "@middy/core",
+      "version": "4.6.2",
+      "dev": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@datastream/core": "0.0.35",
+        "@types/aws-lambda": "^8.10.76",
+        "@types/node": "^20.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/willfarrell"
+      }
+    },
+    "../core/node_modules/@datastream/core": {
+      "version": "0.0.35",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cloneable-readable": "3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "../core/node_modules/@types/aws-lambda": {
+      "version": "8.10.120",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../core/node_modules/@types/node": {
+      "version": "20.6.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../core/node_modules/abort-controller": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "../core/node_modules/base64-js": {
+      "version": "1.5.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "../core/node_modules/buffer": {
+      "version": "6.0.3",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "../core/node_modules/cloneable-readable": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^4.0.0"
+      }
+    },
+    "../core/node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../core/node_modules/events": {
+      "version": "3.3.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "../core/node_modules/ieee754": {
+      "version": "1.2.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "../core/node_modules/process": {
+      "version": "0.11.10",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "../core/node_modules/readable-stream": {
+      "version": "4.4.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "../core/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "../core/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "../util": {
+      "name": "@middy/util",
+      "version": "4.6.2",
+      "license": "MIT",
+      "devDependencies": {
+        "@aws-sdk/client-ssm": "^3.0.0",
+        "@middy/core": "4.6.2",
+        "@types/aws-lambda": "^8.10.76",
+        "@types/node": "^20.0.0",
+        "aws-xray-sdk": "^3.3.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/willfarrell"
+      }
+    },
+    "../util/node_modules/@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "../util/node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "../util/node_modules/@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "../util/node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "../util/node_modules/@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "../util/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "../util/node_modules/@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "../util/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "../util/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "../util/node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "../util/node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "../util/node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "../util/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/client-ssm": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.342.0",
+        "@aws-sdk/config-resolver": "3.342.0",
+        "@aws-sdk/credential-provider-node": "3.342.0",
+        "@aws-sdk/fetch-http-handler": "3.342.0",
+        "@aws-sdk/hash-node": "3.342.0",
+        "@aws-sdk/invalid-dependency": "3.342.0",
+        "@aws-sdk/middleware-content-length": "3.342.0",
+        "@aws-sdk/middleware-endpoint": "3.342.0",
+        "@aws-sdk/middleware-host-header": "3.342.0",
+        "@aws-sdk/middleware-logger": "3.342.0",
+        "@aws-sdk/middleware-recursion-detection": "3.342.0",
+        "@aws-sdk/middleware-retry": "3.342.0",
+        "@aws-sdk/middleware-serde": "3.342.0",
+        "@aws-sdk/middleware-signing": "3.342.0",
+        "@aws-sdk/middleware-stack": "3.342.0",
+        "@aws-sdk/middleware-user-agent": "3.342.0",
+        "@aws-sdk/node-config-provider": "3.342.0",
+        "@aws-sdk/node-http-handler": "3.342.0",
+        "@aws-sdk/smithy-client": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/url-parser": "3.342.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.342.0",
+        "@aws-sdk/util-defaults-mode-node": "3.342.0",
+        "@aws-sdk/util-endpoints": "3.342.0",
+        "@aws-sdk/util-retry": "3.342.0",
+        "@aws-sdk/util-user-agent-browser": "3.342.0",
+        "@aws-sdk/util-user-agent-node": "3.342.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/util-waiter": "3.342.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/client-sso": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.342.0",
+        "@aws-sdk/fetch-http-handler": "3.342.0",
+        "@aws-sdk/hash-node": "3.342.0",
+        "@aws-sdk/invalid-dependency": "3.342.0",
+        "@aws-sdk/middleware-content-length": "3.342.0",
+        "@aws-sdk/middleware-endpoint": "3.342.0",
+        "@aws-sdk/middleware-host-header": "3.342.0",
+        "@aws-sdk/middleware-logger": "3.342.0",
+        "@aws-sdk/middleware-recursion-detection": "3.342.0",
+        "@aws-sdk/middleware-retry": "3.342.0",
+        "@aws-sdk/middleware-serde": "3.342.0",
+        "@aws-sdk/middleware-stack": "3.342.0",
+        "@aws-sdk/middleware-user-agent": "3.342.0",
+        "@aws-sdk/node-config-provider": "3.342.0",
+        "@aws-sdk/node-http-handler": "3.342.0",
+        "@aws-sdk/smithy-client": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/url-parser": "3.342.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.342.0",
+        "@aws-sdk/util-defaults-mode-node": "3.342.0",
+        "@aws-sdk/util-endpoints": "3.342.0",
+        "@aws-sdk/util-retry": "3.342.0",
+        "@aws-sdk/util-user-agent-browser": "3.342.0",
+        "@aws-sdk/util-user-agent-node": "3.342.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.342.0",
+        "@aws-sdk/fetch-http-handler": "3.342.0",
+        "@aws-sdk/hash-node": "3.342.0",
+        "@aws-sdk/invalid-dependency": "3.342.0",
+        "@aws-sdk/middleware-content-length": "3.342.0",
+        "@aws-sdk/middleware-endpoint": "3.342.0",
+        "@aws-sdk/middleware-host-header": "3.342.0",
+        "@aws-sdk/middleware-logger": "3.342.0",
+        "@aws-sdk/middleware-recursion-detection": "3.342.0",
+        "@aws-sdk/middleware-retry": "3.342.0",
+        "@aws-sdk/middleware-serde": "3.342.0",
+        "@aws-sdk/middleware-stack": "3.342.0",
+        "@aws-sdk/middleware-user-agent": "3.342.0",
+        "@aws-sdk/node-config-provider": "3.342.0",
+        "@aws-sdk/node-http-handler": "3.342.0",
+        "@aws-sdk/smithy-client": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/url-parser": "3.342.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.342.0",
+        "@aws-sdk/util-defaults-mode-node": "3.342.0",
+        "@aws-sdk/util-endpoints": "3.342.0",
+        "@aws-sdk/util-retry": "3.342.0",
+        "@aws-sdk/util-user-agent-browser": "3.342.0",
+        "@aws-sdk/util-user-agent-node": "3.342.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/client-sts": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.342.0",
+        "@aws-sdk/credential-provider-node": "3.342.0",
+        "@aws-sdk/fetch-http-handler": "3.342.0",
+        "@aws-sdk/hash-node": "3.342.0",
+        "@aws-sdk/invalid-dependency": "3.342.0",
+        "@aws-sdk/middleware-content-length": "3.342.0",
+        "@aws-sdk/middleware-endpoint": "3.342.0",
+        "@aws-sdk/middleware-host-header": "3.342.0",
+        "@aws-sdk/middleware-logger": "3.342.0",
+        "@aws-sdk/middleware-recursion-detection": "3.342.0",
+        "@aws-sdk/middleware-retry": "3.342.0",
+        "@aws-sdk/middleware-sdk-sts": "3.342.0",
+        "@aws-sdk/middleware-serde": "3.342.0",
+        "@aws-sdk/middleware-signing": "3.342.0",
+        "@aws-sdk/middleware-stack": "3.342.0",
+        "@aws-sdk/middleware-user-agent": "3.342.0",
+        "@aws-sdk/node-config-provider": "3.342.0",
+        "@aws-sdk/node-http-handler": "3.342.0",
+        "@aws-sdk/smithy-client": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/url-parser": "3.342.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.342.0",
+        "@aws-sdk/util-defaults-mode-node": "3.342.0",
+        "@aws-sdk/util-endpoints": "3.342.0",
+        "@aws-sdk/util-retry": "3.342.0",
+        "@aws-sdk/util-user-agent-browser": "3.342.0",
+        "@aws-sdk/util-user-agent-node": "3.342.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "fast-xml-parser": "4.1.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "@aws-sdk/util-middleware": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.342.0",
+        "@aws-sdk/property-provider": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/url-parser": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.342.0",
+        "@aws-sdk/credential-provider-imds": "3.342.0",
+        "@aws-sdk/credential-provider-process": "3.342.0",
+        "@aws-sdk/credential-provider-sso": "3.342.0",
+        "@aws-sdk/credential-provider-web-identity": "3.342.0",
+        "@aws-sdk/property-provider": "3.342.0",
+        "@aws-sdk/shared-ini-file-loader": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.342.0",
+        "@aws-sdk/credential-provider-imds": "3.342.0",
+        "@aws-sdk/credential-provider-ini": "3.342.0",
+        "@aws-sdk/credential-provider-process": "3.342.0",
+        "@aws-sdk/credential-provider-sso": "3.342.0",
+        "@aws-sdk/credential-provider-web-identity": "3.342.0",
+        "@aws-sdk/property-provider": "3.342.0",
+        "@aws-sdk/shared-ini-file-loader": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.342.0",
+        "@aws-sdk/shared-ini-file-loader": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.342.0",
+        "@aws-sdk/property-provider": "3.342.0",
+        "@aws-sdk/shared-ini-file-loader": "3.342.0",
+        "@aws-sdk/token-providers": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/eventstream-codec": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.342.0",
+        "@aws-sdk/querystring-builder": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/hash-node": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.310.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/url-parser": "3.342.0",
+        "@aws-sdk/util-middleware": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.342.0",
+        "@aws-sdk/service-error-classification": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-middleware": "3.342.0",
+        "@aws-sdk/util-retry": "3.342.0",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.342.0",
+        "@aws-sdk/protocol-http": "3.342.0",
+        "@aws-sdk/signature-v4": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-middleware": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-endpoints": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.342.0",
+        "@aws-sdk/shared-ini-file-loader": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.342.0",
+        "@aws-sdk/protocol-http": "3.342.0",
+        "@aws-sdk/querystring-builder": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/property-provider": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/eventstream-codec": "3.342.0",
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-middleware": "3.342.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/token-providers": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.342.0",
+        "@aws-sdk/property-provider": "3.342.0",
+        "@aws-sdk/shared-ini-file-loader": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/types": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/url-parser": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/util-base64": {
+      "version": "3.310.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.310.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.310.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.310.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.310.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.342.0",
+        "@aws-sdk/credential-provider-imds": "3.342.0",
+        "@aws-sdk/node-config-provider": "3.342.0",
+        "@aws-sdk/property-provider": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.310.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.310.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/util-retry": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.310.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.342.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "../util/node_modules/@aws-sdk/util-utf8": {
+      "version": "3.310.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "../util/node_modules/@aws-sdk/util-waiter": {
+      "version": "3.342.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@middy/core": {
+      "resolved": "../core",
+      "link": true
+    },
+    "../util/node_modules/@smithy/protocol-http": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@smithy/types": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../util/node_modules/@types/aws-lambda": {
+      "version": "8.10.115",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../util/node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "../util/node_modules/@types/cls-hooked": {
+      "version": "4.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "../util/node_modules/@types/connect": {
+      "version": "3.4.35",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "../util/node_modules/@types/express": {
+      "version": "4.17.17",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "../util/node_modules/@types/express-serve-static-core": {
+      "version": "4.17.35",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "../util/node_modules/@types/mime": {
+      "version": "1.3.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../util/node_modules/@types/mysql": {
+      "version": "2.15.21",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "../util/node_modules/@types/node": {
+      "version": "20.2.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../util/node_modules/@types/pg": {
+      "version": "8.10.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^4.0.1"
+      }
+    },
+    "../util/node_modules/@types/qs": {
+      "version": "6.9.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../util/node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../util/node_modules/@types/send": {
+      "version": "0.17.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "../util/node_modules/@types/serve-static": {
+      "version": "1.15.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "*",
+        "@types/node": "*"
+      }
+    },
+    "../util/node_modules/async-hook-jl": {
+      "version": "1.7.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stack-chain": "^1.3.7"
+      },
+      "engines": {
+        "node": "^4.7 || >=6.9 || >=7.3"
+      }
+    },
+    "../util/node_modules/atomic-batcher": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../util/node_modules/aws-xray-sdk": {
+      "version": "3.5.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "aws-xray-sdk-core": "3.5.0",
+        "aws-xray-sdk-express": "3.5.0",
+        "aws-xray-sdk-mysql": "3.5.0",
+        "aws-xray-sdk-postgres": "3.5.0"
+      },
+      "engines": {
+        "node": ">= 14.x"
+      }
+    },
+    "../util/node_modules/aws-xray-sdk-core": {
+      "version": "3.5.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "^3.4.1",
+        "@aws-sdk/types": "^3.4.1",
+        "@types/cls-hooked": "^4.3.3",
+        "atomic-batcher": "^1.0.2",
+        "cls-hooked": "^4.2.2",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">= 14.x"
+      }
+    },
+    "../util/node_modules/aws-xray-sdk-express": {
+      "version": "3.5.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/express": "*"
+      },
+      "engines": {
+        "node": ">= 14.x"
+      },
+      "peerDependencies": {
+        "aws-xray-sdk-core": "^3.5.0"
+      }
+    },
+    "../util/node_modules/aws-xray-sdk-mysql": {
+      "version": "3.5.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/mysql": "*"
+      },
+      "engines": {
+        "node": ">= 14.x"
+      },
+      "peerDependencies": {
+        "aws-xray-sdk-core": "^3.5.0"
+      }
+    },
+    "../util/node_modules/aws-xray-sdk-postgres": {
+      "version": "3.5.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/pg": "*"
+      },
+      "engines": {
+        "node": ">= 14.x"
+      },
+      "peerDependencies": {
+        "aws-xray-sdk-core": "^3.5.0"
+      }
+    },
+    "../util/node_modules/bowser": {
+      "version": "2.11.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../util/node_modules/cls-hooked": {
+      "version": "4.2.2",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "async-hook-jl": "^1.7.6",
+        "emitter-listener": "^1.0.1",
+        "semver": "^5.4.1"
+      },
+      "engines": {
+        "node": "^4.7 || >=6.9 || >=7.3 || >=8.2.1"
+      }
+    },
+    "../util/node_modules/cls-hooked/node_modules/semver": {
+      "version": "5.7.1",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "../util/node_modules/emitter-listener": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "shimmer": "^1.2.0"
+      }
+    },
+    "../util/node_modules/fast-xml-parser": {
+      "version": "4.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
+    },
+    "../util/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../util/node_modules/obuf": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../util/node_modules/pg-int8": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "../util/node_modules/pg-numeric": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../util/node_modules/pg-protocol": {
+      "version": "1.6.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../util/node_modules/pg-types": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "pg-numeric": "1.0.2",
+        "postgres-array": "~3.0.1",
+        "postgres-bytea": "~3.0.0",
+        "postgres-date": "~2.0.1",
+        "postgres-interval": "^3.0.0",
+        "postgres-range": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../util/node_modules/postgres-array": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "../util/node_modules/postgres-bytea": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "obuf": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "../util/node_modules/postgres-date": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "../util/node_modules/postgres-interval": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "../util/node_modules/postgres-range": {
+      "version": "1.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../util/node_modules/semver": {
+      "version": "7.5.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../util/node_modules/shimmer": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "../util/node_modules/stack-chain": {
+      "version": "1.3.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../util/node_modules/strnum": {
+      "version": "1.0.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../util/node_modules/tslib": {
+      "version": "2.5.2",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "../util/node_modules/uuid": {
+      "version": "8.3.2",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "../util/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.22.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.22.13",
+        "chalk": "^2.4.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/@babel/code-frame/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.22.19",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.19.tgz",
+      "integrity": "sha512-Tinq7ybnEPFFXhlYOYFiSjespWQk0dq2dRNAiMdRTOYQzEGqnnNyrTxPYHP5r6wGjlF1rFgABdDV0g8EwD6Qbg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.22.13",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.13.tgz",
+      "integrity": "sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.22.5",
+        "chalk": "^2.4.2",
+        "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/@babel/highlight/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@middy/core": {
+      "resolved": "../core",
+      "link": true
+    },
+    "node_modules/@middy/util": {
+      "resolved": "../util",
+      "link": true
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true
+    },
+    "node_modules/@tsd/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-VtjHPAKJqLJoHHKBDNofzvQB2+ZVxjXU/Gw6INAS9aINLQYVsxfzrQ2s84huCeYWZRTtrr7R0J7XgpZHjNwBCw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.121",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.121.tgz",
+      "integrity": "sha512-Y/jsUwO18HuC0a39BuMQkSOd/kMGATh/h5LNksw8FlTafbQ3Ge3578ZoT8w8gSOsWl2qH1p/SS/R61vc0X5jIQ==",
+      "dev": true
+    },
+    "node_modules/@types/eslint": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
+      "integrity": "sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+      "dev": true
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
+      "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==",
+      "dev": true
+    },
+    "node_modules/@types/minimist": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+      "dev": true
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decamelize-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
+      "dev": true,
+      "dependencies": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decamelize-keys/node_modules/map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/eslint-formatter-pretty": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-4.1.0.tgz",
+      "integrity": "sha512-IsUTtGxF1hrH6lMWiSl1WbGaiP01eT6kzywdY1U+zLc0MP+nwEnUiS9UI8IaOTUhTeQJLlCEWIbXINBH4YJbBQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint": "^7.2.13",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "eslint-rule-docs": "^1.1.5",
+        "log-symbols": "^4.0.0",
+        "plur": "^4.0.0",
+        "string-width": "^4.2.0",
+        "supports-hyperlinks": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-rule-docs": {
+      "version": "1.1.235",
+      "resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.235.tgz",
+      "integrity": "sha512-+TQ+x4JdTnDoFEXXb3fDvfGOwnyNV7duH8fXWTPD1ieaBmB8omj7Gw/pMBBu4uI2uJCCU8APDaQJzWuXnTsH4A==",
+      "dev": true
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/irregular-plurals": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.5.0.tgz",
+      "integrity": "sha512-1ANGLZ+Nkv1ptFb2pa8oG8Lem4krflKuX/gINiHJHjJUKaJHk/SXk5x6K3J+39/p0h1RQ2saROclJJ+QLvETCQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
+    },
+    "node_modules/is-core-module": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
+      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize": "^1.2.0",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/type-fest": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dev": true,
+      "dependencies": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/normalize-package-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/plur": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
+      "integrity": "sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==",
+      "dev": true,
+      "dependencies": {
+        "irregular-plurals": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
+    },
+    "node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
+    },
+    "node_modules/read-pkg/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/read-pkg/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/read-pkg/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.6",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.6.tgz",
+      "integrity": "sha512-njhxM7mV12JfufShqGy3Rz8j11RPdLy4xi15UurGJeoHLfJpVXKdh3ueuOqbYUcDZnffr6X739JBo5LzyahEsw==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
+      "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/trim-newlines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tsd": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.29.0.tgz",
+      "integrity": "sha512-5B7jbTj+XLMg6rb9sXRBGwzv7h8KJlGOkTHxY63eWpZJiQ5vJbXEjL0u7JkIxwi5EsrRE1kRVUWmy6buK/ii8A==",
+      "dev": true,
+      "dependencies": {
+        "@tsd/typescript": "~5.2.2",
+        "eslint-formatter-pretty": "^4.1.0",
+        "globby": "^11.0.1",
+        "jest-diff": "^29.0.3",
+        "meow": "^9.0.0",
+        "path-exists": "^4.0.0",
+        "read-pkg-up": "^7.0.0"
+      },
+      "bin": {
+        "tsd": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.2.tgz",
+      "integrity": "sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "@middy/parser",
+  "version": "4.6.2",
+  "description": "Parser middleware for the middy framework",
+  "type": "module",
+  "engines": {
+    "node": ">=16"
+  },
+  "engineStrict": true,
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./index.cjs",
+  "module": "./index.js",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.js"
+      },
+      "require": {
+        "types": "./index.d.ts",
+        "default": "./index.cjs"
+      }
+    }
+  },
+  "types": "index.d.ts",
+  "files": [
+    "index.js",
+    "index.cjs",
+    "index.d.ts"
+  ],
+  "scripts": {
+    "test": "npm run test:unit",
+    "test:unit": "ava",
+    "test:benchmark": "node __benchmarks__/index.js"
+  },
+  "license": "MIT",
+  "keywords": [
+    "Lambda",
+    "Middleware",
+    "Serverless",
+    "Framework",
+    "AWS",
+    "AWS Lambda",
+    "Middy",
+    "Parser",
+    "Zod"
+  ],
+  "author": {
+    "name": "Middy contributors",
+    "url": "https://github.com/middyjs/middy/graphs/contributors"
+  },
+  "repository": {
+    "type": "git",
+    "url": "github:middyjs/middy",
+    "directory": "packages/parser"
+  },
+  "bugs": {
+    "url": "https://github.com/middyjs/middy/issues"
+  },
+  "homepage": "https://middy.js.org",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/willfarrell"
+  },
+  "dependencies": {
+    "@middy/util": "4.6.2"
+  },
+  "devDependencies": {
+    "@middy/core": "4.6.2",
+    "@types/aws-lambda": "^8.10.121",
+    "@types/http-errors": "^2.0.0",
+    "tsd": "^0.29.0",
+    "zod": "^3.22.2"
+  },
+  "gitHead": "7a6c0fbb8ab71d6a2171e678697de9f237568431"
+}

--- a/packages/ssm/package-lock.json
+++ b/packages/ssm/package-lock.json
@@ -8,12 +8,8 @@
       "name": "@middy/ssm",
       "version": "4.6.2",
       "license": "MIT",
-      "dependencies": {
-        "@middy/util": "4.6.2"
-      },
       "devDependencies": {
         "@aws-sdk/client-ssm": "^3.0.0",
-        "@middy/core": "4.6.2",
         "@types/aws-lambda": "^8.10.101",
         "aws-xray-sdk": "^3.3.3",
         "type-fest": "^4.0.0"
@@ -618,31 +614,6 @@
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@middy/core": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-4.6.1.tgz",
-      "integrity": "sha512-3fBaaL2fTX0564pkniDBcTm3S8qOatHVZKDZ8GG3ZrmEJhVkWGkv1e4iWywjtBsLaXzho75uuSUFwdeEbl3x5A==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/willfarrell"
-      }
-    },
-    "node_modules/@middy/util": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@middy/util/-/util-4.6.1.tgz",
-      "integrity": "sha512-EylBSkcSU+vg8dBFUu0x494EXzjG3DrTSzePf5pFHzaGeTh0GliButSQXO4PU4eK1p2XUW2Cx0vCYoTbsNAtYA==",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/willfarrell"
       }
     },
     "node_modules/@smithy/abort-controller": {

--- a/packages/ws-json-body-parser/package-lock.json
+++ b/packages/ws-json-body-parser/package-lock.json
@@ -8,39 +8,10 @@
       "name": "@middy/ws-json-body-parser",
       "version": "4.6.2",
       "license": "MIT",
-      "dependencies": {
-        "@middy/util": "4.6.2"
-      },
       "devDependencies": {
-        "@middy/core": "4.6.2",
         "@types/aws-lambda": "^8.10.101",
         "type-fest": "^4.0.0"
       },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/willfarrell"
-      }
-    },
-    "node_modules/@middy/core": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-4.6.1.tgz",
-      "integrity": "sha512-3fBaaL2fTX0564pkniDBcTm3S8qOatHVZKDZ8GG3ZrmEJhVkWGkv1e4iWywjtBsLaXzho75uuSUFwdeEbl3x5A==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/willfarrell"
-      }
-    },
-    "node_modules/@middy/util": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@middy/util/-/util-4.6.1.tgz",
-      "integrity": "sha512-EylBSkcSU+vg8dBFUu0x494EXzjG3DrTSzePf5pFHzaGeTh0GliButSQXO4PU4eK1p2XUW2Cx0vCYoTbsNAtYA==",
       "engines": {
         "node": ">=16"
       },


### PR DESCRIPTION
## Feature: Parser Middleware

- adds a new package for a parser middleware
- heavily based on the existing validator middleware
- also performs validation, just like the validator middleware
- relies on [Zod](https://zod.dev/) ("TypeScript-first schema validation with static type inference")
- provides type inference from the schema into the handler

Example: 
```javascript
const middleware = parser({
  eventSchema: z.object({ body: z.string() }),
  contextSchema: z.object({ config: z.object({ batchSize: z.number().int() }) }),
  responseSchema: z.object({ results: z.array(z.string()).min(1).max(100) })
})

// handler event and context has type correct inference
const handler = middy().use(middleware).handler(async (event, context) => {
  expectType<{ body: string }>(event)
  expectType<Context & { config: { batchSize: number } }>(context)
  return { results: [''] }
})
```

### Why another package?

This parser package and the validator package are very similar. But, teams already using Zod for other parsing or who don't want to use JSON-schema for validation, might want an alternative. AWS Powertools, for example, is considering separate RFCs for a validator and a parser (https://github.com/aws-powertools/powertools-lambda-typescript/issues/1334). The main thing, though, is providing a more lightweight and intuitive way to do parsing and validation, while getting good type inference. Also, JSON-schema is a completely valid way to solve the problem, hence this parser package is just another option depending on user preference.

### Error handling

The error handling in this package differs slightly from the existing validator package. The reason for this is I have run into the need in projects to customize the error: from the status code to the message. The `createErrorFunc` option gives full control over the error creation, so users can make the middleware easily fit their requirements. This also means the package doesn't need to have any responsibility for i18n, since the user can handle that in the error creation.

### Performance

Based on the benchmark tests, the validator package does seem to be much more performant. Zod has made improvements in performance, but there is still room to improve there. See https://github.com/colinhacks/zod/issues/205

Note:
totally understand if you choose not to accept this package into Middy and prefer to keep as a community package