### PR TITLE
SSM: fix: some mixes of named/paths results in undefined named param values

### DIFF
--- a/packages/ssm/index.js
+++ b/packages/ssm/index.js
@@ -44,19 +44,24 @@ const ssmMiddleware = (opts = {}) => {
     let batchReq = null
     let batchInternalKeys = []
     let batchFetchKeys = []
+    const namedKeys = []
 
     const internalKeys = Object.keys(options.fetchData)
     const fetchKeys = Object.values(options.fetchData)
-    for (const [idx, internalKey] of internalKeys.entries()) {
+    for (const internalKey of internalKeys) {
       if (cachedValues[internalKey]) continue
+      if (options.fetchData[internalKey].substr(-1) === '/') continue // Skip path passed in
+      namedKeys.push(internalKey)
+    }
+
+    for (const [idx, internalKey] of namedKeys.entries()) {
       const fetchKey = options.fetchData[internalKey]
-      if (fetchKey.substr(-1) === '/') continue // Skip path passed in
       batchInternalKeys.push(internalKey)
       batchFetchKeys.push(fetchKey)
       // from the first to the batch size skip, unless it's the last entry
       if (
         (!idx || (idx + 1) % awsRequestLimit !== 0) &&
-        !(idx + 1 === internalKeys.length)
+        !(idx + 1 === namedKeys.length)
       ) {
         continue
       }


### PR DESCRIPTION
In the SSM  middleware when `fetchData` is a mix of names and paths we're seeing an issue where in some cases unless the parameters are ordered as `[...pathParams, ...namedParams]` we end up with named parameters being `undefined`

PR here for your review/discussion: it looks like the issue happens when the condition for batching causes a `continue` on all named items in a mixed list