### PR TITLE
Pick 1.0 before vpc when both methods are present

### DIFF
--- a/packages/http-event-normalizer/index.js
+++ b/packages/http-event-normalizer/index.js
@@ -30,7 +30,7 @@ const httpEventNormalizerMiddleware = () => {
 
 const pickVersion = (event) => {
   // '1.0' is a safer default
-  return event.version ?? (event.method ? 'vpc' : '1.0')
+  return event.version ?? (event.httpMethod ? '1.0' : event.method ? 'vpc' : '1.0')
 }
 
 const isVersionHttpEvent = {


### PR DESCRIPTION
This was found when using `http-event-normalizer` with `LocalLambda` that sends an event with both methods (see [here](https://github.com/vcfvct/ts-lambda-local-dev/blob/9d5f0eb22c3a1201cced58f33a5c4e22a35eca8c/src/local.lambda.ts#L70-L71)).