### PR TITLE
fix(http-error-handler): non http errors will always be handled 

### DIFF
--- a/packages/http-error-handler/index.js
+++ b/packages/http-error-handler/index.js
@@ -20,7 +20,7 @@ const httpErrorHandlerMiddleware = (opts = {}) => {
     }
 
     // Non-http error OR expose set to false
-    if (!request.error.expose || !request.error.statusCode)) {
+    if (!request.error.expose || !request.error.statusCode) {
       request.error = {
         statusCode: 500,
         message: options.fallbackMessage || 'Internal Server Error',

--- a/packages/http-error-handler/index.js
+++ b/packages/http-error-handler/index.js
@@ -20,13 +20,10 @@ const httpErrorHandlerMiddleware = (opts = {}) => {
     }
 
     // Non-http error OR expose set to false
-    if (
-      options.fallbackMessage &&
-      (!request.error.statusCode || !request.error.expose)
-    ) {
+    if (!request.error.expose || !request.error.statusCode)) {
       request.error = {
         statusCode: 500,
-        message: options.fallbackMessage,
+        message: options.fallbackMessage || 'Internal Server Error',
         expose: true
       }
     }


### PR DESCRIPTION
http-error-handler currently does not handle non http errors if `fallbackMessage` is not set.

This PR will handled all non http errors as 'Internal Server Error' even if no fallback message is configured.
I think this is a more expected behaviour of an error handler.