### PR TITLE
fix: don't throw an error on undefined response or event

### DIFF
--- a/packages/http-event-normalizer/__tests__/index.js
+++ b/packages/http-event-normalizer/__tests__/index.js
@@ -206,3 +206,28 @@ test('It should not overwrite pathParameters with HTTP API', async (t) => {
 
   t.deepEqual(normalizedEvent.pathParameters, { param: 'hello' })
 })
+
+test('It should default headers prop with HTTP API', async (t) => {
+  const event = {
+    httpMethod: 'GET'
+  }
+
+  const handler = middy((event) => event).use(httpEventNormalizer())
+  const normalizedEvent = await handler(event, context)
+
+  t.deepEqual(normalizedEvent.headers, {})
+})
+
+test('It should not overwrite headers prop with HTTP API', async (t) => {
+  const event = {
+    httpMethod: 'GET',
+    headers: {
+      foo: true
+    }
+  }
+
+  const handler = middy((event) => event).use(httpEventNormalizer())
+  const normalizedEvent = await handler(event, context)
+
+  t.deepEqual(normalizedEvent.headers, { foo: true })
+})

--- a/packages/http-event-normalizer/index.js
+++ b/packages/http-event-normalizer/index.js
@@ -21,6 +21,7 @@ const httpEventNormalizerMiddleware = () => {
     // event.headers ??= {} // Will always have at least one header
     event.pathParameters ??= {}
     event.queryStringParameters ??= {}
+    event.headers ??= {}
   }
 
   return {

--- a/packages/http-response-serializer/__tests__/index.js
+++ b/packages/http-response-serializer/__tests__/index.js
@@ -350,3 +350,46 @@ test('It should return false when response body is falsey', async (t) => {
     body: false
   })
 })
+
+test('It should handle undefined response without throwing error', async (t) => {
+  const handler = middy((event, context) => {
+    return undefined
+  })
+
+  const event = {
+    headers: {
+      Accept: 'text/plain'
+    }
+  }
+  handler.use(httpResponseSerializer(standardConfiguration))
+  const response = await handler(event, context)
+
+  t.deepEqual(response, {
+    statusCode: 500,
+    headers: {
+      'Content-Type': 'text/plain'
+    },
+    body: undefined
+  })
+})
+
+test('It should handle undefined event without throwing error', async (t) => {
+  const handler = middy((event, context) => createHttpResponse())
+
+  const event = undefined
+  handler.use(
+    httpResponseSerializer({
+      ...standardConfiguration,
+      defaultContentType: 'text/plain'
+    })
+  )
+  const response = await handler(event, context)
+
+  t.deepEqual(response, {
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'text/plain'
+    },
+    body: 'Hello World'
+  })
+})

--- a/packages/http-response-serializer/index.js
+++ b/packages/http-response-serializer/index.js
@@ -9,7 +9,10 @@ const defaults = {
 const httpResponseSerializerMiddleware = (opts = {}) => {
   const { serializers, defaultContentType } = { ...defaults, ...opts }
   const httpResponseSerializerMiddlewareAfter = async (request) => {
-    normalizeHttpResponse(request)
+    request.response = normalizeHttpResponse(request)
+
+    request.event ??= {}
+    request.event.headers ??= {}
 
     // skip serialization when Content-Type or content-type is already set
     if (

--- a/packages/http-response-serializer/index.js
+++ b/packages/http-response-serializer/index.js
@@ -11,9 +11,6 @@ const httpResponseSerializerMiddleware = (opts = {}) => {
   const httpResponseSerializerMiddlewareAfter = async (request) => {
     request.response = normalizeHttpResponse(request)
 
-    request.event ??= {}
-    request.event.headers ??= {}
-
     // skip serialization when Content-Type or content-type is already set
     if (
       request.response.headers['Content-Type'] ??
@@ -29,7 +26,8 @@ const httpResponseSerializerMiddleware = (opts = {}) => {
       types = [request.event.requiredContentType]
     } else {
       const acceptHeader =
-        request.event.headers.Accept ?? request.event.headers.accept
+        request.event.headers &&
+        (request.event.headers.Accept ?? request.event.headers.accept)
       types = [
         ...((acceptHeader && Accept.mediaTypes(acceptHeader)) ?? []),
         request.event.preferredContentType,

--- a/packages/http-response-serializer/index.js
+++ b/packages/http-response-serializer/index.js
@@ -26,8 +26,7 @@ const httpResponseSerializerMiddleware = (opts = {}) => {
       types = [request.event.requiredContentType]
     } else {
       const acceptHeader =
-        request.event.headers &&
-        (request.event.headers.Accept ?? request.event.headers.accept)
+        request.event.headers?.Accept ?? request.event.headers?.accept
       types = [
         ...((acceptHeader && Accept.mediaTypes(acceptHeader)) ?? []),
         request.event.preferredContentType,


### PR DESCRIPTION
Closes #1121 

> It appears that normalizeHttpResponse() in the event of undefined or an empty object creates new objects and returns them. This function is relying on side effects for the changes so if new objects are created they're not seen. The result is that if an undefined object is passed in you get an error. It should probably be more like