### PR TITLE
fix(website): extra padding on mobile

### DIFF
--- a/website/src/components/Example.js
+++ b/website/src/components/Example.js
@@ -96,7 +96,7 @@ export default function Example () {
           Do you want to see some more <em>realistic</em> examples?
         </h3>
 
-        <p className='text--center'>
+        <p className={styles.buttons_list}>
           <Link
             to='/docs/events/api-gateway-http'
             className='button button--info'

--- a/website/src/components/Example.module.css
+++ b/website/src/components/Example.module.css
@@ -5,9 +5,16 @@
 .heading2 {
   text-align: center;
   font-size: 3em;
+  margin-bottom: 2rem;
 }
 
 .heading3 {
   text-align: center;
   font-size: 2.5em;
+  margin-bottom: 1.5rem;
+}
+
+.buttons_list {
+  text-align: center;
+  line-height: 3rem;
 }

--- a/website/src/components/HomepageSponsors.module.css
+++ b/website/src/components/HomepageSponsors.module.css
@@ -3,8 +3,16 @@
   align-items: center;
   padding: 2rem 0;
   width: 100%;
+  text-align: center;
+}
+
+.features h2 {
+  font-size: 2.5rem;
+  margin-bottom: 2.75rem;
 }
 
 .featureSvg {
   width: 100%;
+  max-width: 250px;
+  max-height: 100px;
 }


### PR DESCRIPTION
Fixes some extra padding on mobile that was introduced by adding the AWS logo (which had unexpected proportions). Also adds some other minor graphic adjustments.

## Mobile screenshot

![Screenshot 2023-11-08 at 22 08 09](https://github.com/middyjs/middy/assets/205629/1df671e9-47a7-4eda-9e19-2fb1c9d76a04)


## Desktop screenshot

![Screenshot 2023-11-08 at 22 08 20](https://github.com/middyjs/middy/assets/205629/b1cdefc1-1545-43cd-b986-8fa47bfbc109)
