### PR TITLE
fix: don't throw error for non http event

### DIFF
--- a/packages/http-event-normalizer/__tests__/index.js
+++ b/packages/http-event-normalizer/__tests__/index.js
@@ -7,30 +7,22 @@ const context = {
   getRemainingTimeInMillis: () => 1000
 }
 
-test('It should throw error when invalid version', async (t) => {
+test('It should not throw error when invalid version', async (t) => {
   const event = {
     version: '3.0'
   }
 
   const handler = middy((event) => event).use(httpEventNormalizer())
-  try {
-    await handler(event, context)
-  } catch (e) {
-    t.is(e.message, 'Unknown http event format')
-  }
+  t.notThrows(async () => await handler(event, context))
 })
 
-test('It should do nothing if not HTTP event', async (t) => {
+test('It should not error if not an HTTP event', async (t) => {
   const event = {
     source: 's3'
   }
 
   const handler = middy((event) => event).use(httpEventNormalizer())
-  try {
-    await handler(event, context)
-  } catch (e) {
-    t.is(e.message, 'Unknown http event format')
-  }
+  t.notThrows(async () => await handler(event, context))
 })
 
 test('It should default queryStringParameters with REST API', async (t) => {

--- a/packages/http-event-normalizer/index.js
+++ b/packages/http-event-normalizer/index.js
@@ -3,12 +3,6 @@ const httpEventNormalizerMiddleware = () => {
     const { event } = request
 
     const version = pickVersion(event)
-    const isHttpEvent = isVersionHttpEvent[version]?.(event)
-    if (!isHttpEvent) {
-      throw new Error('Unknown http event format', {
-        cause: { package: '@middy/http-event-normalizer' }
-      })
-    }
     // VPC Lattice is an http event, however uses a different notation
     // - query_string_parameters
     // - is_base64_encoded
@@ -33,12 +27,6 @@ const httpEventNormalizerMiddleware = () => {
 const pickVersion = (event) => {
   // '1.0' is a safer default
   return event.version ?? (event.method ? 'vpc' : '1.0')
-}
-
-const isVersionHttpEvent = {
-  '1.0': (event) => typeof event.httpMethod !== 'undefined',
-  '2.0': (event) => typeof event.requestContext.http.method !== 'undefined',
-  vpc: (event) => typeof event.method !== 'undefined'
 }
 
 export default httpEventNormalizerMiddleware


### PR DESCRIPTION
**What does this implement/fix? Explain your changes.**

A PR to propose changing the behaviour of the http-event-normalizer (more as a discussion point that formal PR)

Currently, the http-event-normalizer middleware [will throw an error](https://github.com/middyjs/middy/blob/main/packages/http-event-normalizer/index.js#L8) if the HTTP version cannot be established. For example if HTTP Method is missing from the event.

- (discussion point) should the middleware care? Or care enough to throw an error which breaks the code flow. My argument is that it's designed to ensure objects are instantiated/normalised,  and not to police the HTTP validity of an event object.
- It differs in behaviour (inconsistency) from the http-header-normalizer which does not throw an error if the HTTP version cannot be figured out. This PR would make the behaviour more consistent.

Impact:

It is a breaking change as the behaviour of the middleware will be different

**Does this close any currently open issues?**

No

**Any relevant logs, error output, etc?**

N/A

**Environment:**
 - Node.js: 18

**Any other comments?**

**Todo List:**
- [ ] Feature/Fix fully implemented
- [x] Amended tests
  - [x] Unit tests
  - [ ] Benchmark tests (if applicable)
- [ ] Updated relevant documentation
- [ ] Updated relevant examples
