### PR TITLE
Validation error cause typo

### DIFF
--- a/packages/validator/index.js
+++ b/packages/validator/index.js
@@ -30,7 +30,7 @@ const validatorMiddleware = (opts = {}) => {
         // Bad Request
         throw createError(400, 'Event object failed validation', {
           cause: {
-            pacakge: '@middy/validator',
+            package: '@middy/validator',
             data: eventSchema.errors
           }
         })


### PR DESCRIPTION
Just went to read validator tests and found a typo in "before" validation error details