### PR TITLE
feat: Add name property to MiddlewareObj typings

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -56,6 +56,7 @@ export interface MiddlewareObj<
   before?: MiddlewareFn<TEvent, TResult, TErr, TContext, TInternal>
   after?: MiddlewareFn<TEvent, TResult, TErr, TContext, TInternal>
   onError?: MiddlewareFn<TEvent, TResult, TErr, TContext, TInternal>
+  name?: string
 }
 
 // The AWS provided Handler type uses void | Promise<TResult> so we have no choice but to follow and suppress the linter warning


### PR DESCRIPTION
Each middleware can be assigned an optional name that might then handed to a plugin in the `beforeMiddleware` or `afterMiddleware` hook. This is currently not possible when using TypeScript with the default `MiddlewareObj` interface, as it does not allow the `name` property.

This PR adds an optional `name` property to the `MiddlewareObj`.