### PR TITLE
Do not throw error if event is not http (http-cors)

### DIFF
--- a/packages/http-cors/__tests__/index.js
+++ b/packages/http-cors/__tests__/index.js
@@ -819,15 +819,11 @@ test('it should set Vary header if present in config', async (t) => {
   })
 })
 
-test('it should throw when not a http event', async (t) => {
+test('it should not throw when not a http event', async (t) => {
   const handler = middy((event, context) => {})
 
   handler.use(cors())
 
   const event = {}
-  try {
-    await handler(event, context)
-  } catch (e) {
-    t.is(e.message, 'Unknown http event format')
-  }
+  t.notThrows(async () => await handler(event, context))
 })

--- a/packages/http-cors/index.js
+++ b/packages/http-cors/index.js
@@ -131,11 +131,6 @@ const modifyHeaders = (headers, options, request) => {
   const httpMethod = getVersionHttpMethod[request.event.version ?? '1.0']?.(
     request.event
   )
-  if (!httpMethod) {
-    throw new Error('Unknown http event format', {
-      cause: { package: '@middy/http-cors' }
-    })
-  }
   if (
     httpMethod === 'OPTIONS' &&
     options.cacheControl &&


### PR DESCRIPTION
for reference: https://github.com/middyjs/middy/pull/1133

we can call lambdas using invoke or any other way other than API gateway.

I don't think http-cors middleware should break the whole code if the event it is receiving is not a real http event, it will append to headers and that's it.