### PR TITLE
chore: add `@aws-sdk/client-secrets-manager` as a peer dependency to `@middy/secrets-manager`

### DIFF
--- a/packages/secrets-manager/package.json
+++ b/packages/secrets-manager/package.json
@@ -60,6 +60,9 @@
   "dependencies": {
     "@middy/util": "5.2.3"
   },
+  "peerDependencies": {
+    "@aws-sdk/client-secrets-manager": "^3.0.0"
+  },
   "devDependencies": {
     "@aws-sdk/client-secrets-manager": "^3.0.0",
     "@middy/core": "5.2.3",


### PR DESCRIPTION
This PR adds `@aws-sdk/client-secrets-manager` as a peer dependency to `@middy/secrets-manager`.

I came across an issue today where I was moving around some dependencies on a project that I worked on and I started getting an error that `@aws-sdk/client-secrets-manager` was missing.

I would expect it to be marked as a peer dependency if it's required to run `@middy/secrets-manager`.