### PR TITLE
Pkg: httpHeaderNormalizer to handle canonical sanitized headers

### DIFF
--- a/packages/http-header-normalizer/__tests__/index.js
+++ b/packages/http-header-normalizer/__tests__/index.js
@@ -285,3 +285,26 @@ test('It should not fail if the event does not contain headers', async (t) => {
   t.deepEqual(resultingEvent, expectedEvent)
   t.deepEqual(resultingEvent.rawHeaders, undefined)
 })
+
+test('It should not fail given a corrupted header key', async (t) => {
+  const handler = middy((event, context) => event)
+
+  handler.use(httpHeaderNormalizer({ canonical: true }))
+
+  const event = {
+    headers: {
+      'X----': 'foo'
+    }
+  }
+
+  const expectedHeaders = {
+    'X----': 'foo'
+  }
+
+  const originalHeaders = { ...event.headers }
+
+  const resultingEvent = await handler(event, context)
+
+  t.deepEqual(resultingEvent.headers, expectedHeaders)
+  t.deepEqual(resultingEvent.rawHeaders, originalHeaders)
+})

--- a/packages/http-header-normalizer/index.js
+++ b/packages/http-header-normalizer/index.js
@@ -46,7 +46,7 @@ const normalizeHeaderKey = (key, canonical) => {
 
   return lowerCaseKey
     .split('-')
-    .map((text) => text[0].toUpperCase() + text.substr(1))
+    .map((text) => (text[0] || '').toUpperCase() + text.substr(1))
     .join('-')
 }
 

--- a/packages/http-json-body-parser/__tests__/index.js
+++ b/packages/http-json-body-parser/__tests__/index.js
@@ -228,26 +228,3 @@ test('It should handle invalid base64 JSON as an UnprocessableEntity', async (t)
     t.regex(e.cause.data.message, /^Unexpected token/)
   }
 })
-
-test('It should not fail given a corrupted header key', async (t) => {
-  const handler = middy((event, context) => event)
-
-  handler.use(httpHeaderNormalizer({ canonical: true }))
-
-  const event = {
-    headers: {
-      'X----': 'foo'
-    }
-  }
-
-  const expectedHeaders = {
-    'X----': 'foo'
-  }
-
-  const originalHeaders = { ...event.headers }
-
-  const resultingEvent = await handler(event, context)
-
-  t.deepEqual(resultingEvent.headers, expectedHeaders)
-  t.deepEqual(resultingEvent.rawHeaders, originalHeaders)
-})

--- a/packages/http-json-body-parser/__tests__/index.js
+++ b/packages/http-json-body-parser/__tests__/index.js
@@ -228,3 +228,26 @@ test('It should handle invalid base64 JSON as an UnprocessableEntity', async (t)
     t.regex(e.cause.data.message, /^Unexpected token/)
   }
 })
+
+test('It should not fail given a corrupted header key', async (t) => {
+  const handler = middy((event, context) => event)
+
+  handler.use(httpHeaderNormalizer({ canonical: true }))
+
+  const event = {
+    headers: {
+      'X----': 'foo'
+    }
+  }
+
+  const expectedHeaders = {
+    'X----': 'foo'
+  }
+
+  const originalHeaders = { ...event.headers }
+
+  const resultingEvent = await handler(event, context)
+
+  t.deepEqual(resultingEvent.headers, expectedHeaders)
+  t.deepEqual(resultingEvent.rawHeaders, originalHeaders)
+})


### PR DESCRIPTION
Given `canonical:  true`,
And an event containing a header that's "sanitized" (X----)
A runtime error occurs, "Cannot read property 'toUpperCase' of undefined".

**To Reproduce:**

**Unit test** 
```
test('It should not fail given a corrupted header key', async (t) => {
  const handler = middy((event, context) => event)

  handler.use(httpHeaderNormalizer({ canonical: true }))

  const event = {
    headers: {
      'X----': 'foo'
    }
  }

  const expectedHeaders = {
    'X----': 'foo'
  }

  const originalHeaders = { ...event.headers }

  const resultingEvent = await handler(event, context)

  t.deepEqual(resultingEvent.headers, expectedHeaders)
  t.deepEqual(resultingEvent.rawHeaders, originalHeaders)
})
```
**Thrown error:**  "Cannot read property 'toUpperCase' of undefined".

**Expected behavior:** Should simply return the raw header


**Additional context:**
We had a client who appears to be sanitizing headers resulting in our lambdas receiving a header that looks like `X----`. Though this is a one-off, rather than push the onus to our client, an empty string fallback gets them back up an running.