### PR TITLE
fix: #1176 add callback argument to support aws types

### DIFF
--- a/packages/core/__tests__/index.js
+++ b/packages/core/__tests__/index.js
@@ -673,7 +673,7 @@ globalThis.awslambda = {
 test('Should throw with streamifyResponse:true using object', async (t) => {
   const input = {}
   const handler = middy(
-    (event, context, { signal }) => {
+    (event, context, callback, { signal }) => {
       return input
     },
     {
@@ -693,7 +693,7 @@ test('Should throw with streamifyResponse:true using object', async (t) => {
 test('Should return with streamifyResponse:true using body undefined', async (t) => {
   const input = ''
   const handler = middy(
-    (event, context, { signal }) => {
+    (event, context, callback, { signal }) => {
       return {
         statusCode: 200,
         headers: {
@@ -719,7 +719,7 @@ test('Should return with streamifyResponse:true using string', async (t) => {
   const input = 'x'.repeat(1024 * 1024)
   const handler = middy({
     streamifyResponse: true
-  }).handler((event, context, { signal }) => {
+  }).handler((event, context, callback, { signal }) => {
     return input
   })
 
@@ -736,7 +736,7 @@ test('Should return with streamifyResponse:true using body string', async (t) =>
   const input = 'x'.repeat(1024 * 1024)
   const handler = middy({
     streamifyResponse: true
-  }).handler((event, context, { signal }) => {
+  }).handler((event, context, callback, { signal }) => {
     return {
       statusCode: 200,
       headers: {
@@ -758,7 +758,7 @@ test('Should return with streamifyResponse:true using body string', async (t) =>
 test('Should return with streamifyResponse:true using ReadableStream', async (t) => {
   const input = 'x'.repeat(1024 * 1024)
   const handler = middy(
-    async (event, context, { signal }) => {
+    async (event, context, callback, { signal }) => {
       return createReadableStream(input)
     },
     {
@@ -778,7 +778,7 @@ test('Should return with streamifyResponse:true using ReadableStream', async (t)
 test('Should return with streamifyResponse:true using body ReadableStream', async (t) => {
   const input = 'x'.repeat(1024 * 1024)
   const handler = middy(
-    async (event, context, { signal }) => {
+    async (event, context, callback, { signal }) => {
       return {
         statusCode: 200,
         headers: {
@@ -804,7 +804,7 @@ test('Should return with streamifyResponse:true using body ReadableStream', asyn
 test('Should return with streamifyResponse:true using ReadableStream.pipe(...)', async (t) => {
   const input = 'x'.repeat(1024 * 1024)
   const handler = middy(
-    async (event, context, { signal }) => {
+    async (event, context, callback, { signal }) => {
       return pipejoin([createReadableStream(input), createPassThroughStream()])
     },
     {
@@ -824,7 +824,7 @@ test('Should return with streamifyResponse:true using ReadableStream.pipe(...)',
 test('Should return with streamifyResponse:true using body ReadableStream.pipe(...)', async (t) => {
   const input = 'x'.repeat(1024 * 1024)
   const handler = middy(
-    async (event, context, { signal }) => {
+    async (event, context, callback, { signal }) => {
       return {
         statusCode: 200,
         headers: {
@@ -886,7 +886,7 @@ test('Should abort handler when timeout expires', async (t) => {
     getRemainingTimeInMillis: () => 2
   }
 
-  const handler = middy((event, context, { signal }) => {
+  const handler = middy((event, context, callback, { signal }) => {
     signal.onabort = function (abort) {
       t.true(abort.target.aborted)
     }
@@ -906,7 +906,7 @@ test('Should throw error when timeout expires', async (t) => {
   const context = {
     getRemainingTimeInMillis: () => 100
   }
-  const handler = middy(async (event, context, { signal }) => {
+  const handler = middy(async (event, context, callback, { signal }) => {
     await setTimeout(100)
     return true
   }, plugin)
@@ -931,7 +931,7 @@ test('Should not invoke timeoutEarlyResponse on success', async (t) => {
   const context = {
     getRemainingTimeInMillis: () => 100
   }
-  const handler = middy(async (event, context, { signal }) => {
+  const handler = middy(async (event, context, callback, { signal }) => {
     return true
   }, plugin)
 
@@ -955,7 +955,7 @@ test('Should not invoke timeoutEarlyResponse on error', async (t) => {
     getRemainingTimeInMillis: () => 100
   }
   const error = new Error('Oops!')
-  const handler = middy(async (event, context, { signal }) => {
+  const handler = middy(async (event, context, callback, { signal }) => {
     throw error
   }, plugin)
 

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -1,6 +1,7 @@
 import {
   Context as LambdaContext,
-  Handler as LambdaHandler
+  Handler as LambdaHandler,
+  Callback as LambdaCallback
 } from 'aws-lambda'
 
 declare type PluginHook = () => void
@@ -75,6 +76,7 @@ type MiddyInputHandler<
 > = (
   event: TEvent,
   context: TContext,
+  callback: LambdaCallback,
   opts: MiddyHandlerObject,
 ) => // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 void | Promise<TResult> | TResult

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -157,7 +157,7 @@ const runRequest = async (
         handlerAbort = new AbortController()
       }
       const promises = [
-        lambdaHandler(request.event, request.context, {
+        lambdaHandler(request.event, request.context, () => undefined, {
           signal: handlerAbort.signal
         })
       ]

--- a/packages/core/index.test-d.ts
+++ b/packages/core/index.test-d.ts
@@ -1,19 +1,21 @@
 import { expectType, expectAssignable } from 'tsd'
 import middy from '.'
-import {
+import type {
   APIGatewayProxyEvent,
   APIGatewayProxyResult,
   Context,
-  Handler as AWSLambdaHandler
+  Handler as AWSLambdaHandler,
+  Callback as LambdaCallback
 } from 'aws-lambda'
 
 // extends Handler type from aws-lambda
 type EnhanceHandlerType<T, NewReturn> = T extends (
   event: infer TEvent,
   context: infer TContextType,
+  callback: infer LambdaCallback,
   opts: infer TOptsType
 ) => infer R
-  ? (event: TEvent, context: TContextType, opts: TOptsType) => R | NewReturn
+  ? (event: TEvent, context: TContextType, callback: LambdaCallback, opts: TOptsType) => R | NewReturn
   : never
 
 type AWSLambdaHandlerWithoutCallback<TEvent = any, TResult = any> = (
@@ -64,7 +66,7 @@ expectType<Handler>(handler)
 expectAssignable<AWSLambdaHandler<APIGatewayProxyEvent, APIGatewayProxyResult>>(handler)
 
 // Middy handlers third argument is an object containing a abort signal
-middy((event, context, { signal }) => expectType<AbortSignal>(signal))
+middy((event, context, callback, { signal }) => expectType<AbortSignal>(signal))
 
 // invokes the handler to test that it is callable
 // eslint-disable-next-line @typescript-eslint/no-invalid-void-type


### PR DESCRIPTION
Fixes https://github.com/middyjs/middy/issues/1176 by adding an additional callback field to match the types set by the AWS library. Retain the `opt` object as the final argument.