### PR TITLE
fix: list @middy/util as dependency in @middy/http-json-body-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21427,6 +21427,9 @@
       "name": "@middy/http-json-body-parser",
       "version": "5.2.6",
       "license": "MIT",
+      "dependencies": {
+        "@middy/util": "5.2.6"
+      },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.101",
         "type-fest": "^4.0.0"

--- a/packages/http-json-body-parser/package.json
+++ b/packages/http-json-body-parser/package.json
@@ -61,6 +61,9 @@
     "type": "github",
     "url": "https://github.com/sponsors/willfarrell"
   },
+  "dependencies": {
+    "@middy/util": "5.2.6"
+  },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.101",
     "type-fest": "^4.0.0"


### PR DESCRIPTION
## Context

`@middy/util` is not listed as a dependency in `@middy/http-json-body-parser`.  This causes bundlers and test runners to error when resolving the dependencies. 

In most situations, this won't cause any error because this middleware is often used in combination with another one, like `@middy/http-cors`. In this scenario `@middy/util` can be resolved since it's [listed as a dependency](https://github.com/middyjs/middy/blob/main/packages/http-cors/package.json#L63) in `@middy/http-cors`. 

## Changes

* Add `@middy/core` as a dependy in `@middy/http-json-body-parser`