### PR TITLE
Update sqs-partial-batch-failure.md

### DIFF
--- a/website/docs/middlewares/sqs-partial-batch-failure.md
+++ b/website/docs/middlewares/sqs-partial-batch-failure.md
@@ -44,16 +44,16 @@ import middy from '@middy/core'
 import sqsBatch from '@middy/sqs-partial-batch-failure'
 
 const lambdaHandler = (event, context) => {
-  const promises = [];
+  const statusPromises = [];
   for (const [idx, record] of Object.entries(Records)) {
     try {
       /* Custom message processing logic */
-      promises.push(Promise.resolve());
+      statusPromises.push(Promise.resolve());
     } catch (error) {
-      promises.push(Promise.reject(error));
+      statusPromises.push(Promise.reject(error));
     }
   }
-  return Promise.allSettled(recordPromises)
+  return Promise.allSettled(statusPromises)
 }
 
 export const handler = middy().use(sqsBatch()).handler(lambdaHandler)

--- a/website/docs/middlewares/sqs-partial-batch-failure.md
+++ b/website/docs/middlewares/sqs-partial-batch-failure.md
@@ -20,6 +20,8 @@ npm install --save-dev @aws-sdk/client-sqs
 
 ## Sample usage
 
+Standrad Queue (All records handled in parallel):
+
 ```javascript
 import middy from '@middy/core'
 import sqsBatch from '@middy/sqs-partial-batch-failure'
@@ -29,6 +31,28 @@ const lambdaHandler = (event, context) => {
     /* Custom message processing logic */
     return record
   })
+  return Promise.allSettled(recordPromises)
+}
+
+export const handler = middy().use(sqsBatch()).handler(lambdaHandler)
+```
+
+FIFO Queue (Records handled sequentially):
+
+```javascript
+import middy from '@middy/core'
+import sqsBatch from '@middy/sqs-partial-batch-failure'
+
+const lambdaHandler = (event, context) => {
+  const promises = [];
+  for (const [idx, record] of Object.entries(Records)) {
+    try {
+      /* Custom message processing logic */
+      promises.push(Promise.resolve());
+    } catch (error) {
+      promises.push(Promise.reject(error));
+    }
+  }
   return Promise.allSettled(recordPromises)
 }
 


### PR DESCRIPTION
I guess it is worth mentioning for users that when they use the Sample Usage, there events are being executed in parallel, so if they are using SQS FIFO then it might produce some bugs, because batches in FIFO sends messages from same MessageGroupID and assume you are handling them in sequential.

So just an addition for newbies like me who spent hours trying to solve this :)