### PR TITLE
feat: implement wildcard support for cors origins option

### DIFF
--- a/packages/http-cors/__tests__/index.js
+++ b/packages/http-cors/__tests__/index.js
@@ -258,6 +258,32 @@ test('It should return whitelisted origin', async (t) => {
   })
 })
 
+test('It should return whitelisted origin (wildcard)', async (t) => {
+  const handler = middy((event, context) => ({ statusCode: 200 }))
+
+  handler.use(
+    cors({
+      disableBeforePreflightResponse: false,
+      origins: ['https://example.com', 'https://*.example.com']
+    })
+  )
+
+  const event = {
+    httpMethod: 'OPTIONS',
+    headers: { Origin: 'https://subdomain.example.com' }
+  }
+
+  const response = await handler(event, context)
+
+  t.deepEqual(response, {
+    statusCode: 204,
+    headers: {
+      'Access-Control-Allow-Origin': 'https://subdomain.example.com',
+      Vary: 'Origin'
+    }
+  })
+})
+
 test('It should exclude `Access-Control-Allow-Origin` if no match in origins', async (t) => {
   const handler = middy((event, context) => ({ statusCode: 200 }))
 

--- a/packages/http-cors/__tests__/index.js
+++ b/packages/http-cors/__tests__/index.js
@@ -284,6 +284,55 @@ test('It should return whitelisted origin (wildcard)', async (t) => {
   })
 })
 
+test('It should exclude `Access-Control-Allow-Origin` if no match in origins (wildcard)', async (t) => {
+  const handler = middy((event, context) => ({ statusCode: 200 }))
+
+  handler.use(
+    cors({
+      disableBeforePreflightResponse: false,
+      origins: ['https://example.com', 'https://*.example.com']
+    })
+  )
+
+  const event = {
+    httpMethod: 'OPTIONS',
+    headers: { Origin: 'https://nested.subdomain.example.com' }
+  }
+
+  const response = await handler(event, context)
+
+  t.deepEqual(response, {
+    statusCode: 204,
+    headers: {}
+  })
+})
+
+test('It should match nested sub-domains when nested wildcard values are specified', async (t) => {
+  const handler = middy((event, context) => ({ statusCode: 200 }))
+
+  handler.use(
+    cors({
+      disableBeforePreflightResponse: false,
+      origins: ['https://example.com', 'https://*.*.example.com']
+    })
+  )
+
+  const event = {
+    httpMethod: 'OPTIONS',
+    headers: { Origin: 'https://nested.subdomain.example.com' }
+  }
+
+  const response = await handler(event, context)
+
+  t.deepEqual(response, {
+    statusCode: 204,
+    headers: {
+      'Access-Control-Allow-Origin': 'https://nested.subdomain.example.com',
+      Vary: 'Origin'
+    }
+  })
+})
+
 test('It should exclude `Access-Control-Allow-Origin` if no match in origins', async (t) => {
   const handler = middy((event, context) => ({ statusCode: 200 }))
 

--- a/packages/http-cors/index.js
+++ b/packages/http-cors/index.js
@@ -1,8 +1,18 @@
 import { normalizeHttpResponse } from '@middy/util'
 
 const getOrigin = (incomingOrigin, options = {}) => {
-  if (options.origins.length > 0) {
-    if (incomingOrigin && options.origins.includes(incomingOrigin)) {
+  const { origins } = options
+
+  const wildcardMatch = (origin) => {
+    const regString = origin.replace(/\./g, '\\.').replace(/\*/g, '[^ ]*') // escape periods + convert start symbol to wildcard
+    return new RegExp(regString).test(incomingOrigin)
+  }
+
+  if (origins.length > 0) {
+    if (incomingOrigin && origins.includes(incomingOrigin)) {
+      return incomingOrigin
+    }
+    if (incomingOrigin && origins.some((o) => wildcardMatch(o))) {
       return incomingOrigin
     }
   } else {

--- a/packages/http-cors/index.js
+++ b/packages/http-cors/index.js
@@ -2,7 +2,8 @@ import { normalizeHttpResponse } from '@middy/util'
 
 const getOrigin = (incomingOrigin, options = {}) => {
   const wildcardMatch = (origin) => {
-    const regString = origin.replace(/\./g, '\\.').replace(/\*/g, '[^ ]*') // escape periods + convert asterisk to regex wildcard
+    const escapedString = origin.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const regString = escapedString.replace(/\\\*/g, '[^ .]*') // convert asterisk to regex wildcard
     return new RegExp(regString).test(incomingOrigin)
   }
 

--- a/packages/http-cors/index.js
+++ b/packages/http-cors/index.js
@@ -1,18 +1,16 @@
 import { normalizeHttpResponse } from '@middy/util'
 
 const getOrigin = (incomingOrigin, options = {}) => {
-  const { origins } = options
-
   const wildcardMatch = (origin) => {
     const regString = origin.replace(/\./g, '\\.').replace(/\*/g, '[^ ]*') // escape periods + convert start symbol to wildcard
     return new RegExp(regString).test(incomingOrigin)
   }
 
-  if (origins.length > 0) {
-    if (incomingOrigin && origins.includes(incomingOrigin)) {
+  if (options.origins.length > 0) {
+    if (incomingOrigin && options.origins.includes(incomingOrigin)) {
       return incomingOrigin
     }
-    if (incomingOrigin && origins.some((o) => wildcardMatch(o))) {
+    if (incomingOrigin && options.origins.some((o) => wildcardMatch(o))) {
       return incomingOrigin
     }
   } else {

--- a/packages/http-cors/index.js
+++ b/packages/http-cors/index.js
@@ -2,7 +2,7 @@ import { normalizeHttpResponse } from '@middy/util'
 
 const getOrigin = (incomingOrigin, options = {}) => {
   const wildcardMatch = (origin) => {
-    const regString = origin.replace(/\./g, '\\.').replace(/\*/g, '[^ ]*') // escape periods + convert start symbol to wildcard
+    const regString = origin.replace(/\./g, '\\.').replace(/\*/g, '[^ ]*') // escape periods + convert asterisk to regex wildcard
     return new RegExp(regString).test(incomingOrigin)
   }
 

--- a/website/docs/middlewares/http-cors.md
+++ b/website/docs/middlewares/http-cors.md
@@ -22,7 +22,7 @@ npm install --save @middy/http-cors
 - `methods` (string) (optional): value to put in `Access-Control-Allow-Methods` (default: `false`)
 - `getOrigin` (function(incomingOrigin:string, options)) (optional): take full control of the generating the returned origin. Defaults to using the origin or origins option.
 - `origin` (string) (optional): default origin to put in the header (default: `'*'`). Setting to `null` will default to excluding the header. Note: will default to `null` in next major release
-- `origins` (array) (optional): An array of allowed origins. The incoming origin is matched against the list and is returned if present. If the incoming origin is not found, the header will not be returned.
+- `origins` (array) (optional): An array of allowed origins. The incoming origin is matched against the list and is returned if present. If the incoming origin is not found, the header will not be returned. Wildcards can be used within the origin to match multiple origins.
 - `exposeHeaders` (string) (optional): value to put in `Access-Control-Expose-Headers` (default: `false`)
 - `maxAge` (string) (optional): value to put in Access-Control-Max-Age header (default: `null`)
 - `requestHeaders` (string) (optional): value to put in `Access-Control-Request-Headers` (default: `false`)


### PR DESCRIPTION
## What's Changed

- Implemented support for wildcard origins
- no breaking change

## Example

When configuring the cors middleware, it is now possible to provide a wildcard origin to the origins array:

```
  handler.use(
    cors({
      disableBeforePreflightResponse: false,
      origins: ['https://example.com', 'https://*.example.com']
    })
  )
```

A request from a sub-domain (`https://example-subdomain.example.com`) would then result in a header that matches the subdomain:

```
 'Access-Control-Allow-Origin': 'https://subdomain.example.com',
```

## Notes

Hey @willfarrell , I'm proposing this change be added to the project. This change will allow user's to pass wildcard origins to the middleware. This will make it easier to administer cors headers when traffic is coming from multiple different sub-domains. 

Please let me know your thoughts! It's been fun working on the codebase 🥳