### PR TITLE
refactor(ws-response): mutability on response

### DIFF
--- a/packages/ws-response/index.js
+++ b/packages/ws-response/index.js
@@ -27,10 +27,9 @@ const wsResponseMiddleware = (opts) => {
   }
 
   const wsResponseMiddlewareAfter = async (request) => {
-    normalizeWsResponse(request)
-    const { response } = request
+    const normalizedResponse = normalizeWsResponse(request)
 
-    if (!response.ConnectionId) return
+    if (!normalizedResponse.ConnectionId) return
 
     if (!options.awsClientOptions.endpoint && request.event.requestContext) {
       options.awsClientOptions.endpoint =
@@ -43,7 +42,7 @@ const wsResponseMiddleware = (opts) => {
       client = await createClient(options, request)
     }
 
-    const command = new PostToConnectionCommand(response)
+    const command = new PostToConnectionCommand(normalizedResponse)
     await client
       .send(command)
       .catch((e) => catchInvalidSignatureException(e, client, command))
@@ -68,7 +67,6 @@ const normalizeWsResponse = (request) => {
     response = { Data: response }
   }
   response.ConnectionId ??= request.event.requestContext?.connectionId
-  request.response = response
   return response
 }
 


### PR DESCRIPTION
With commit d44e6797b2cf9dbca0b66c855217a8d0adf37200, fixing issue https://github.com/middyjs/middy/issues/1219, mutability is not required anymore on `request.response`.