### PR TITLE
fix(log): display nested objects in lambda request and response in @middy/input-output-logger

### DIFF
--- a/packages/input-output-logger/index.js
+++ b/packages/input-output-logger/index.js
@@ -35,7 +35,7 @@ const inputOutputLoggerMiddleware = (opts = {}) => {
       cloneMessage = structuredClone(message) // Full clone to prevent nested mutations
       omit(cloneMessage, { [param]: omitPathTree[param] })
     }
-    logger(cloneMessage)
+    logger(typeof cloneMessage === "object" ? JSON.stringify(cloneMessage, null, 2) : cloneMessage)
   }
 
   // needs `mask`


### PR DESCRIPTION
Currently, nested objects, such as identity within the requestContext of the request event, are displayed as [Object] in the logs. This makes it difficult to debug and understand the full structure of the request and response objects.

Updating the logging mechanism to stringify nested objects using JSON.stringify(cloneMessage, null, 2) ensures that all nested objects are properly represented in the logs, making them more readable and informative.