### PR TITLE
Feature zstd support for http-content-encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@commitlint/config-conventional": "^19.0.0",
     "aws-sdk-client-mock": "^4.0.0",
     "husky": "^9.0.0",
-    "lint-staged": "15.2.8",
+    "lint-staged": "^15.0.0",
     "prettier": "^3.0.0",
     "sinon": "^18.0.0",
     "tinybench": "^2.5.1",

--- a/packages/http-content-encoding/__tests__/index.js
+++ b/packages/http-content-encoding/__tests__/index.js
@@ -5,12 +5,68 @@ import httpContentEncoding from '../index.js'
 
 import { createReadableStream, streamToBuffer } from '@datastream/core'
 import { brotliCompressSync, gzipSync, deflateSync } from 'node:zlib'
+import ZstdStream from 'zstd-codec/lib/zstd-stream.js'
+
+const zstdAsync = async (data) => {
+  const init = new Promise((resolve) => {
+    ZstdStream.run((streams) => {
+      resolve(streams.ZstdCompressTransform)
+    })
+  })
+
+  const ZstdCompressStream = await init
+  return streamToBuffer(
+    createReadableStream(data).pipe(new ZstdCompressStream())
+  )
+}
 
 const context = {
   getRemainingTimeInMillis: () => 1000
 }
 
 const compressibleBody = JSON.stringify(new Array(100).fill(0))
+
+test('It should encode string using zstd', async (t) => {
+  const body = compressibleBody
+  const handler = middy((event, context) => ({ statusCode: 200, body })).use(
+    httpContentEncoding()
+  )
+
+  const event = {}
+
+  const response = await handler(event, {
+    ...context,
+    preferredEncoding: 'zstd'
+  })
+  deepEqual(response, {
+    statusCode: 200,
+    body: (await zstdAsync(body)).toString('base64'),
+    headers: { 'Content-Encoding': 'zstd' },
+    isBase64Encoded: true
+  })
+})
+
+test('It should encode stream using br', async (t) => {
+  const body = compressibleBody
+  const handler = middy((event, context) => ({
+    statusCode: 200,
+    body: createReadableStream(body)
+  })).use(httpContentEncoding())
+
+  const event = {}
+
+  const response = await handler(event, {
+    ...context,
+    preferredEncoding: 'zstd'
+  })
+  response.body = await streamToBuffer(response.body)
+  response.body = response.body.toString('base64')
+  deepEqual(response, {
+    statusCode: 200,
+    body: (await zstdAsync(body)).toString('base64'),
+    headers: { 'Content-Encoding': 'zstd' }
+  })
+})
 
 test('It should encode string using br', async (t) => {
   const body = compressibleBody

--- a/packages/http-content-encoding/package.json
+++ b/packages/http-content-encoding/package.json
@@ -63,7 +63,8 @@
     "url": "https://github.com/sponsors/willfarrell"
   },
   "dependencies": {
-    "@middy/util": "5.4.7"
+    "@middy/util": "5.4.7",
+    "zstd-codec": "0.1.5"
   },
   "devDependencies": {
     "@datastream/core": "0.0.38",

--- a/packages/input-output-logger/package.json
+++ b/packages/input-output-logger/package.json
@@ -60,7 +60,7 @@
     "url": "https://github.com/sponsors/willfarrell"
   },
   "devDependencies": {
-    "@datastream/core": "0.0.36",
+    "@datastream/core": "0.0.38",
     "@middy/core": "5.4.7",
     "@types/node": "^20.0.0"
   },


### PR DESCRIPTION
Does anyone need this?

Downside, adds 2MB to the packages, zstd isn't smaller than brotli in my testing.

Will leave as PR, only Chrome supports right now.