### PR TITLE
handler return type checking #1228

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -96,12 +96,12 @@ export interface MiddyfiedHandler<
   before: AttachMiddlewareFn<TEvent, TResult, TErr, TContext, TInternal>
   after: AttachMiddlewareFn<TEvent, TResult, TErr, TContext, TInternal>
   onError: AttachMiddlewareFn<TEvent, TResult, TErr, TContext, TInternal>
-  handler: <TInputHandlerEventProps = TEvent, TInputHandlerResultProps = TResult>(
+  handler: <TInputHandlerEventProps = TEvent>(
     handler: MiddlewareHandler<
-    LambdaHandler<TInputHandlerEventProps, TInputHandlerResultProps>,
+    LambdaHandler<TInputHandlerEventProps, TResult>,
     TContext
     >
-  ) => MiddyfiedHandler<TInputHandlerEventProps, TInputHandlerResultProps, TErr, TContext, TInternal>
+  ) => MiddyfiedHandler<TInputHandlerEventProps, TResult, TErr, TContext, TInternal>
 }
 
 declare type AttachMiddlewareFn<

--- a/packages/core/index.test-d.ts
+++ b/packages/core/index.test-d.ts
@@ -409,3 +409,22 @@ const s3Handler = async (event: S3Event): Promise<void> => {
 
 const handler1182 = middy().handler(s3Handler)
 expectType<MiddyfiedHandler<S3Event, void, Error, Context, {}>>(handler1182)
+
+let handler1228 = middy<APIGatewayProxyEvent, APIGatewayProxyResult, Error, Context>();
+// @ts-expect-error - should enforce the return type
+handler1228.handler(async (req, context) => {
+  return '123';
+});
+
+handler1228.handler(async (event) => {
+  return { 
+    statusCode: 200,
+    body: `Hello from ${event.path}`
+  };
+});
+
+// @ts-expect-error - should enforce the return type
+handler1228.handler<APIGatewayProxyEvent>(async (req, context) => { return '123'; });
+
+// @ts-expect-error - can't change the return type
+handler1228.handler<APIGatewayProxyEvent, string>(async (event) => { return { statusCode: 200, body: `Hello from ${event.path}` }; });


### PR DESCRIPTION
I think what was happening was because `, TInputHandlerResultProps = TResult` was passed it allowed the return type to be inferred or overridden by the handler. 

After removing `, TInputHandlerResultProps = TResult` from the handler the return type will be enforced by what is passed in to `Middy<Event, Result...` 

This does mean, however, you cannot override the handler return type.