### PR TITLE
feat(http-json-body-parser): #1266 allow undefined body when no content length

### DIFF
--- a/packages/http-json-body-parser/__tests__/index.js
+++ b/packages/http-json-body-parser/__tests__/index.js
@@ -123,7 +123,8 @@ test('It should handle undefined as an UnprocessableEntity', async (t) => {
   // invokes the handler
   const event = {
     headers: {
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      'Content-Length': '10', // body should be some content
     },
     body: undefined
   }
@@ -138,6 +139,27 @@ test('It should handle undefined as an UnprocessableEntity', async (t) => {
       /(^Unexpected token)|"undefined" is not valid JSON/
     )
   }
+})
+
+test('It should process undefined JSON as long as the content-length header is missing', async (t) => {
+  const handler = middy((event) => {
+    return event.body // propagates the body as a response
+  })
+
+  handler.use(jsonBodyParser())
+
+  // invokes the handler
+  const event = {
+    headers: {
+      'Content-Type': 'application/json',
+      // 'Content-Length': '10', body could be realistically undefined in this edge-case
+    },
+  }
+
+
+  const body = await handler(event, defaultContext)
+
+  equal(body, undefined)
 })
 
 test("It shouldn't process the body if no header is passed", async (t) => {

--- a/packages/http-json-body-parser/index.js
+++ b/packages/http-json-body-parser/index.js
@@ -23,6 +23,13 @@ const httpJsonBodyParserMiddleware = (opts = {}) => {
       })
     }
 
+    if (body === undefined) {
+      const contentLength = headers?.['Content-Length'] ?? headers?.['content-length']
+      if (!contentLength || contentLength === '0') {
+        return
+      }
+    }
+
     try {
       const data = request.event.isBase64Encoded
         ? Buffer.from(body, 'base64').toString()


### PR DESCRIPTION
See issue https://github.com/middyjs/middy/issues/1266

> **Describe the solution you'd like**
>
> In the middleware [http-json-body-parser](https://github.com/middyjs/middy/blob/da5d1939f0f255f21060fd69bc1ad818af400f19/packages/http-json-body-parser/index.js):
>
> IF `event.body === undefined` AND the content-length header is 0 or undefined
   ignore event, do not try to parse as JSON body