### PR TITLE
fix: make request.earlyResponse an optional field in TypeScript type definitions

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -30,7 +30,7 @@ export interface Request<
   event: TEvent
   context: TContext
   response: TResult | null
-  earlyResponse: TResult | null
+  earlyResponse?: TResult | null | undefined
   error: TErr | null
   internal: TInternal
 }

--- a/packages/core/index.test-d.ts
+++ b/packages/core/index.test-d.ts
@@ -539,12 +539,15 @@ expectType<middy.MiddyfiedHandler<APIGatewayProxyEvent, number>>(
 )
 
 // Issue #1275 Early Response type
-middy()
+middy<unknown, string>()
   .before(async (request) => {
     request.earlyResponse = 'Hello, world!'
   })
   .use({
     after: (request) => {
-      request.earlyResponse = 'Hello, world!'
+      request.earlyResponse = null
     }
+  })
+  .onError(async (request) => {
+    request.earlyResponse = undefined
   })

--- a/packages/util/index.test-d.ts
+++ b/packages/util/index.test-d.ts
@@ -89,7 +89,6 @@ TInternal
     succeed: () => {}
   },
   response: null,
-  earlyResponse: null,
   error: null,
   internal: {
     boolean: true,


### PR DESCRIPTION
Another follow-up to https://github.com/middyjs/middy/pull/1277, I realized the `request.earlyResponse` field should be optional because the runtime code checks for it using `Object.hasOwnProperty`. Thus leaving it "empty" with a `null` value will also override the response.

So I believe this PR better aligns align the type to match the implementation. Sorry for missing this in the original PR.