### PR TITLE
chore: add missing input type supporting notFoundResponse in http-router

### DIFF
--- a/packages/http-router/index.d.ts
+++ b/packages/http-router/index.d.ts
@@ -9,13 +9,28 @@ import {
   Handler as LambdaHandler
 } from 'aws-lambda'
 
-export type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'ANY'
+export type Method =
+  | 'GET'
+  | 'POST'
+  | 'PUT'
+  | 'PATCH'
+  | 'DELETE'
+  | 'OPTIONS'
+  | 'HEAD'
+  | 'ANY'
 
 export interface Route<TEvent, TResult> {
   method: Method
   path: string
-  handler: LambdaHandler<TEvent, TResult> | MiddyfiedHandler<TEvent, TResult, any, any>
+  handler:
+  | LambdaHandler<TEvent, TResult>
+  | MiddyfiedHandler<TEvent, TResult, any, any>
 }
+
+export type RouteNotFoundResponseFn = (input: {
+  method: string
+  path: string
+}) => never
 
 declare function httpRouterHandler<
   TEvent extends
@@ -26,6 +41,13 @@ declare function httpRouterHandler<
   | ALBResult
   | APIGatewayProxyResult
   | APIGatewayProxyResultV2 = APIGatewayProxyResult
-> (routes: Array<Route<TEvent, TResult>>): middy.MiddyfiedHandler<TEvent, TResult>
+> (
+  routes:
+  | Array<Route<TEvent, TResult>>
+  | {
+    routes: Array<Route<TEvent, TResult>>
+    notFoundResponse: RouteNotFoundResponseFn
+  }
+): middy.MiddyfiedHandler<TEvent, TResult>
 
 export default httpRouterHandler

--- a/packages/http-router/index.test-d.ts
+++ b/packages/http-router/index.test-d.ts
@@ -2,7 +2,8 @@ import { expectType } from 'tsd'
 import middy from '@middy/core'
 import httpRouterHandler from '.'
 import {
-  ALBEvent, ALBResult,
+  ALBEvent,
+  ALBResult,
   APIGatewayProxyEvent,
   APIGatewayProxyEventV2,
   APIGatewayProxyResult,
@@ -10,7 +11,10 @@ import {
   Handler as LambdaHandler
 } from 'aws-lambda'
 
-const lambdaHandler: LambdaHandler<APIGatewayProxyEvent, APIGatewayProxyResult> = async (event) => {
+const lambdaHandler: LambdaHandler<
+APIGatewayProxyEvent,
+APIGatewayProxyResult
+> = async (event) => {
   return {
     statusCode: 200,
     body: 'Hello world'
@@ -24,9 +28,14 @@ const middleware = httpRouterHandler([
     handler: lambdaHandler
   }
 ])
-expectType<middy.MiddyfiedHandler<APIGatewayProxyEvent, APIGatewayProxyResult>>(middleware)
+expectType<middy.MiddyfiedHandler<APIGatewayProxyEvent, APIGatewayProxyResult>>(
+  middleware
+)
 
-const lambdaHandlerV2: LambdaHandler<APIGatewayProxyEventV2, APIGatewayProxyResultV2> = async (event) => {
+const lambdaHandlerV2: LambdaHandler<
+APIGatewayProxyEventV2,
+APIGatewayProxyResultV2
+> = async (event) => {
   return {
     statusCode: 200,
     body: 'Hello world'
@@ -40,7 +49,9 @@ const middlewareV2 = httpRouterHandler([
     handler: lambdaHandlerV2
   }
 ])
-expectType<middy.MiddyfiedHandler<APIGatewayProxyEventV2, APIGatewayProxyResultV2>>(middlewareV2)
+expectType<
+middy.MiddyfiedHandler<APIGatewayProxyEventV2, APIGatewayProxyResultV2>
+>(middlewareV2)
 
 const lambdaHandlerALB: LambdaHandler<ALBEvent, ALBResult> = async (event) => {
   return {
@@ -58,3 +69,20 @@ const middlewareALB = httpRouterHandler([
 ])
 
 expectType<middy.MiddyfiedHandler<ALBEvent, ALBResult>>(middlewareALB)
+
+const middlewareRouteNotFound = httpRouterHandler({
+  routes: [
+    {
+      method: 'GET',
+      path: '/',
+      handler: lambdaHandler
+    }
+  ],
+  notFoundResponse: ({ method, path }) => {
+    throw new Error(`Route not found: ${method} ${path}`)
+  }
+})
+
+expectType<middy.MiddyfiedHandler<APIGatewayProxyEvent, APIGatewayProxyResult>>(
+  middlewareRouteNotFound
+)


### PR DESCRIPTION
The `httpRouterHandler` interface is overloaded to allow the user to pass an object with the routes and a function that throws an error when the route is not found. 

This overloading was not being declared in the types, forcing the usage of `as any` when you need to pass the `notFoundResponse` method. 