### PR TITLE
fix: allow charset in multipart/formdata content-type

### DIFF
--- a/packages/http-multipart-body-parser/__tests__/index.js
+++ b/packages/http-multipart-body-parser/__tests__/index.js
@@ -345,3 +345,25 @@ test('It should parse a field with multiple files successfully', async (t) => {
   ok(Object.keys(response).includes('files'))
   equal(response.files.length, 3)
 })
+
+test('It should parse form data when the charset is in the header', async (t) => {
+  const handler = middy((event, context) => {
+    return event.body // propagates the body as a response
+  })
+
+  handler.use(httpMultipartBodyParser())
+
+  // invokes the handler
+  // Base64 encoded form data with field 'foo' of value 'bar'
+  const event = {
+    headers: {
+      'content-type':
+        'multipart/form-data; boundary=----WebKitFormBoundaryppsQEwf2BVJeCe0M; charset=UTF-8'
+    },
+    body: 'LS0tLS0tV2ViS2l0Rm9ybUJvdW5kYXJ5cHBzUUV3ZjJCVkplQ2UwTQ0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJmb28iDQoNCmJhcg0KLS0tLS0tV2ViS2l0Rm9ybUJvdW5kYXJ5cHBzUUV3ZjJCVkplQ2UwTS0t',
+    isBase64Encoded: true
+  }
+  const response = await handler(event, defaultContext)
+
+  deepEqual(response, { foo: 'bar' })
+})

--- a/packages/http-multipart-body-parser/index.js
+++ b/packages/http-multipart-body-parser/index.js
@@ -1,7 +1,8 @@
 import BusBoy from '@fastify/busboy'
 import { createError } from '@middy/util'
 
-const mimePattern = /^multipart\/form-data; boundary=[-]*[a-zA-Z0-9]*$/
+const mimePattern =
+  /^multipart\/form-data; boundary=[-]*[a-zA-Z0-9]*(; ?[cC]harset=[\w-]+)?$/
 const fieldnamePattern = /(.+)\[(.*)]$/
 
 const defaults = {


### PR DESCRIPTION
I was testing my freshly cooked lambda using Bruno and cURL. Both tools really want to add a charset to the content-type header. But the http-multipart-body-parser of Middy does not approve of that. I believe that having a charset in the content-type header is valid so I added support for it.

Based on [RFC 7231, section 3.1.1.1](https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.1.1) the charset can be written in various different ways:

text/html;charset=utf-8
text/html;charset=UTF-8
Text/HTML;Charset="utf-8"
text/html; charset="utf-8"

so I made the mimePattern very lenient. The header is also passed to Busboy, I have not checked if it also uses it properly.

Let me know if it needs some additional tests or other changes!