### PR TITLE
chore: extend from `@tsconfig/node20`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@biomejs/biome": "^1.0.0",
         "@commitlint/cli": "^19.0.0",
         "@commitlint/config-conventional": "^19.0.0",
+        "@tsconfig/node20": "^20.1.6",
         "aws-sdk-client-mock": "^4.0.0",
         "fast-check": "^4.0.0",
         "husky": "^9.0.0",
@@ -3525,6 +3526,13 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@tsconfig/node20": {
+      "version": "20.1.6",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.6.tgz",
+      "integrity": "sha512-sz+Hqx9zwZDpZIV871WSbUzSqNIsXzghZydypnfgzPKLltVJfkINfUeTct31n/tTSa9ZE1ZOfKdRre1uHHquYQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tsd/typescript": {
       "version": "5.8.3",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
 		"@biomejs/biome": "^1.0.0",
 		"@commitlint/cli": "^19.0.0",
 		"@commitlint/config-conventional": "^19.0.0",
+		"@tsconfig/node20": "^20.1.6",
 		"aws-sdk-client-mock": "^4.0.0",
 		"fast-check": "^4.0.0",
 		"husky": "^9.0.0",

--- a/packages/appconfig/index.test-d.ts
+++ b/packages/appconfig/index.test-d.ts
@@ -4,7 +4,7 @@ import { getInternal } from "@middy/util";
 import type { Context as LambdaContext } from "aws-lambda";
 import { captureAWSv3Client } from "aws-xray-sdk";
 import { expectType } from "tsd";
-import appConfig, { type Context, appConfigReq } from ".";
+import appConfig, { type Context, appConfigReq } from "./index.js";
 
 const options = {
 	AwsClient: AppConfigDataClient,

--- a/packages/cloudformation-response/index.test-d.ts
+++ b/packages/cloudformation-response/index.test-d.ts
@@ -1,7 +1,7 @@
 import type middy from "@middy/core";
 import { expectType } from "tsd";
 
-import cloudformationResponse from ".";
+import cloudformationResponse from "./index.js";
 
 // use with default options
 const middleware = cloudformationResponse();

--- a/packages/cloudformation-router/index.test-d.ts
+++ b/packages/cloudformation-router/index.test-d.ts
@@ -1,7 +1,7 @@
 import type middy from "@middy/core";
 // import { CloudFormationCustomResourceHandler } from 'aws-lambda'
 import { expectType } from "tsd";
-import cloudformationRouterHandler from ".";
+import cloudformationRouterHandler from "./index.js";
 
 const createLambdaHandler: any = async () => {
 	return {

--- a/packages/cloudwatch-metrics/index.test-d.ts
+++ b/packages/cloudwatch-metrics/index.test-d.ts
@@ -1,6 +1,6 @@
 import type middy from "@middy/core";
 import { expectType } from "tsd";
-import cloudwatchMetrics, { type Context } from ".";
+import cloudwatchMetrics, { type Context } from "./index.js";
 
 // use with default options
 let middleware = cloudwatchMetrics();

--- a/packages/core/index.test-d.ts
+++ b/packages/core/index.test-d.ts
@@ -6,7 +6,7 @@ import type {
 	S3Event,
 } from "aws-lambda";
 import { expectAssignable, expectType } from "tsd";
-import middy, { type MiddyfiedHandler } from ".";
+import middy, { type MiddyfiedHandler } from "./index.js";
 
 // extends Handler type from aws-lambda
 type EnhanceHandlerType<T, NewReturn> = T extends (

--- a/packages/do-not-wait-for-empty-event-loop/index.test-d.ts
+++ b/packages/do-not-wait-for-empty-event-loop/index.test-d.ts
@@ -1,6 +1,6 @@
 import type middy from "@middy/core";
 import { expectType } from "tsd";
-import doNotWaitForEmptyEventLoop from ".";
+import doNotWaitForEmptyEventLoop from "./index.js";
 
 // use with default options
 let middleware = doNotWaitForEmptyEventLoop();

--- a/packages/dynamodb/index.test-d.ts
+++ b/packages/dynamodb/index.test-d.ts
@@ -4,7 +4,7 @@ import { getInternal } from "@middy/util";
 import type { Context as LambdaContext } from "aws-lambda";
 import { captureAWSv3Client } from "aws-xray-sdk";
 import { expectType } from "tsd";
-import dynamodb, { type Context, dynamoDbReq } from ".";
+import dynamodb, { type Context, dynamoDbReq } from "./index.js";
 
 const options = {
 	AwsClient: DynamoDBClient,

--- a/packages/error-logger/index.test-d.ts
+++ b/packages/error-logger/index.test-d.ts
@@ -1,6 +1,6 @@
 import type middy from "@middy/core";
 import { expectType } from "tsd";
-import errorLogger from ".";
+import errorLogger from "./index.js";
 
 // use with default options
 let middleware = errorLogger();

--- a/packages/event-normalizer/index.test-d.ts
+++ b/packages/event-normalizer/index.test-d.ts
@@ -1,6 +1,6 @@
 import type middy from "@middy/core";
 import { expectType } from "tsd";
-import eventNormalizer from ".";
+import eventNormalizer from "./index.js";
 
 // use with default options
 let middleware = eventNormalizer();

--- a/packages/http-content-encoding/index.test-d.ts
+++ b/packages/http-content-encoding/index.test-d.ts
@@ -1,6 +1,6 @@
 import type middy from "@middy/core";
 import { expectType } from "tsd";
-import httpContentEncodingMiddleware from ".";
+import httpContentEncodingMiddleware from "./index.js";
 
 // use with default options
 let middleware = httpContentEncodingMiddleware();

--- a/packages/http-content-negotiation/index.test-d.ts
+++ b/packages/http-content-negotiation/index.test-d.ts
@@ -1,6 +1,6 @@
 import type middy from "@middy/core";
 import { expectType } from "tsd";
-import httpContentNegotiationMiddleware, { type Event } from ".";
+import httpContentNegotiationMiddleware, { type Event } from "./index.js";
 
 // use with default options
 let middleware = httpContentNegotiationMiddleware();

--- a/packages/http-cors/index.test-d.ts
+++ b/packages/http-cors/index.test-d.ts
@@ -1,6 +1,6 @@
 import type middy from "@middy/core";
 import { expectType } from "tsd";
-import httpCors, { type Options } from ".";
+import httpCors, { type Options } from "./index.js";
 
 // use with default options
 let middleware = httpCors();

--- a/packages/http-error-handler/index.test-d.ts
+++ b/packages/http-error-handler/index.test-d.ts
@@ -1,7 +1,7 @@
 import type middy from "@middy/core";
 import type { HttpError } from "http-errors";
 import { expectType } from "tsd";
-import httpErrorHandler from ".";
+import httpErrorHandler from "./index.js";
 
 // use with default options
 let middleware = httpErrorHandler();

--- a/packages/http-event-normalizer/index.test-d.ts
+++ b/packages/http-event-normalizer/index.test-d.ts
@@ -1,6 +1,6 @@
 import type middy from "@middy/core";
 import { expectType } from "tsd";
-import httpEventNormalizer, { type Event } from ".";
+import httpEventNormalizer, { type Event } from "./index.js";
 
 // use with default options
 let middleware = httpEventNormalizer();

--- a/packages/http-header-normalizer/index.test-d.ts
+++ b/packages/http-header-normalizer/index.test-d.ts
@@ -1,6 +1,6 @@
 import type middy from "@middy/core";
 import { expectType } from "tsd";
-import httpHeaderNormalizer, { type Event } from ".";
+import httpHeaderNormalizer, { type Event } from "./index.js";
 
 // use with default options
 let middleware = httpHeaderNormalizer();

--- a/packages/http-json-body-parser/index.test-d.ts
+++ b/packages/http-json-body-parser/index.test-d.ts
@@ -5,7 +5,7 @@ import type {
 	APIGatewayProxyEventV2,
 } from "aws-lambda";
 import { expectType } from "tsd";
-import jsonBodyParser from ".";
+import jsonBodyParser from "./index.js";
 
 // use with default options
 let middleware = jsonBodyParser();

--- a/packages/http-multipart-body-parser/index.test-d.ts
+++ b/packages/http-multipart-body-parser/index.test-d.ts
@@ -1,6 +1,6 @@
 import type middy from "@middy/core";
 import { expectType } from "tsd";
-import multipartBodyParser, { type Event } from ".";
+import multipartBodyParser, { type Event } from "./index.js";
 
 // use with default options
 let middleware = multipartBodyParser();

--- a/packages/http-partial-response/index.test-d.ts
+++ b/packages/http-partial-response/index.test-d.ts
@@ -1,6 +1,6 @@
 import type middy from "@middy/core";
 import { expectType } from "tsd";
-import httpPartialResponse from ".";
+import httpPartialResponse from "./index.js";
 
 // use with default options
 let middleware = httpPartialResponse();

--- a/packages/http-response-serializer/index.test-d.ts
+++ b/packages/http-response-serializer/index.test-d.ts
@@ -1,6 +1,6 @@
 import type middy from "@middy/core";
 import { expectType } from "tsd";
-import httpResponseSerializer from ".";
+import httpResponseSerializer from "./index.js";
 
 // use with default options
 let middleware = httpResponseSerializer();

--- a/packages/http-router/index.test-d.ts
+++ b/packages/http-router/index.test-d.ts
@@ -9,7 +9,7 @@ import type {
 	Handler as LambdaHandler,
 } from "aws-lambda";
 import { expectType } from "tsd";
-import httpRouterHandler from ".";
+import httpRouterHandler from "./index.js";
 
 const lambdaHandler: LambdaHandler<
 	APIGatewayProxyEvent,

--- a/packages/http-security-headers/index.test-d.ts
+++ b/packages/http-security-headers/index.test-d.ts
@@ -1,6 +1,6 @@
 import type middy from "@middy/core";
 import { expectType } from "tsd";
-import httpSecurityHeaders from ".";
+import httpSecurityHeaders from "./index.js";
 
 // use with default options
 let middleware = httpSecurityHeaders();

--- a/packages/http-urlencode-body-parser/index.test-d.ts
+++ b/packages/http-urlencode-body-parser/index.test-d.ts
@@ -1,6 +1,6 @@
 import type middy from "@middy/core";
 import { expectType } from "tsd";
-import urlEncodeBodyParser, { type Event } from ".";
+import urlEncodeBodyParser, { type Event } from "./index.js";
 
 // use with default options
 const middleware = urlEncodeBodyParser();

--- a/packages/http-urlencode-path-parser/index.test-d.ts
+++ b/packages/http-urlencode-path-parser/index.test-d.ts
@@ -1,6 +1,6 @@
 import type middy from "@middy/core";
 import { expectType } from "tsd";
-import urlEncodePathParser, { type Event } from ".";
+import urlEncodePathParser, { type Event } from "./index.js";
 
 // use with default options
 const middleware = urlEncodePathParser();

--- a/packages/input-output-logger/index.test-d.ts
+++ b/packages/input-output-logger/index.test-d.ts
@@ -1,6 +1,6 @@
 import type middy from "@middy/core";
 import { expectType } from "tsd";
-import inputOutputLogger from ".";
+import inputOutputLogger from "./index.js";
 
 // use with default options
 let middleware = inputOutputLogger();

--- a/packages/rds-signer/index.test-d.ts
+++ b/packages/rds-signer/index.test-d.ts
@@ -3,7 +3,7 @@ import middy from "@middy/core";
 import { getInternal } from "@middy/util";
 import type { Context as LambdaContext } from "aws-lambda";
 import { expectType } from "tsd";
-import rdsSigner from ".";
+import rdsSigner from "./index.js";
 
 // use with default options
 const middleware = rdsSigner();

--- a/packages/s3-object-response/index.test-d.ts
+++ b/packages/s3-object-response/index.test-d.ts
@@ -9,7 +9,7 @@ import s3ObjectResponse, {
 	type S3ObjectResponseOptions,
 	type Context,
 	type Internal,
-} from ".";
+} from "./index.js";
 
 // use with default options
 let middleware = s3ObjectResponse();

--- a/packages/s3/index.test-d.ts
+++ b/packages/s3/index.test-d.ts
@@ -4,7 +4,7 @@ import { getInternal } from "@middy/util";
 import type { Context as LambdaContext } from "aws-lambda";
 import { captureAWSv3Client } from "aws-xray-sdk";
 import { expectType } from "tsd";
-import s3, { type Context, s3Req } from ".";
+import s3, { type Context, s3Req } from "./index.js";
 
 const options = {
 	AwsClient: S3Client,

--- a/packages/secrets-manager/index.test-d.ts
+++ b/packages/secrets-manager/index.test-d.ts
@@ -1,10 +1,10 @@
 import { SecretsManagerClient } from "@aws-sdk/client-secrets-manager";
 import middy from "@middy/core";
 import { getInternal } from "@middy/util";
-import type { Context as LambdaContext } from "aws-lambda/handler";
+import type { Context as LambdaContext } from "aws-lambda";
 import { captureAWSv3Client } from "aws-xray-sdk";
 import { expectType } from "tsd";
-import secretsManager, { type Context, secret } from ".";
+import secretsManager, { type Context, secret } from "./index.js";
 
 // use with default options
 expectType<middy.MiddlewareObj<unknown, any, Error, Context<undefined>>>(

--- a/packages/service-discovery/index.test-d.ts
+++ b/packages/service-discovery/index.test-d.ts
@@ -7,7 +7,7 @@ import { getInternal } from "@middy/util";
 import type { Context as LambdaContext } from "aws-lambda";
 import { captureAWSv3Client } from "aws-xray-sdk";
 import { expectType } from "tsd";
-import serviceDiscovery, { type Context } from ".";
+import serviceDiscovery, { type Context } from "./index.js";
 
 // use with default options
 expectType<middy.MiddlewareObj<unknown, any, Error, Context<undefined>>>(

--- a/packages/sqs-partial-batch-failure/index.test-d.ts
+++ b/packages/sqs-partial-batch-failure/index.test-d.ts
@@ -1,6 +1,6 @@
 import type middy from "@middy/core";
 import { expectType } from "tsd";
-import sqsPartialBatchFailure from ".";
+import sqsPartialBatchFailure from "./index.js";
 
 // use with default options
 let middleware = sqsPartialBatchFailure();

--- a/packages/ssm/index.test-d.ts
+++ b/packages/ssm/index.test-d.ts
@@ -1,10 +1,10 @@
 import { SSMClient } from "@aws-sdk/client-ssm";
 import middy from "@middy/core";
 import { getInternal } from "@middy/util";
-import type { Context as LambdaContext } from "aws-lambda/handler";
+import type { Context as LambdaContext } from "aws-lambda";
 import { captureAWSv3Client } from "aws-xray-sdk";
 import { expectAssignable, expectType } from "tsd";
-import ssm, { type Context, ssmParam } from ".";
+import ssm, { type Context, ssmParam } from "./index.js";
 
 // use with default options
 expectType<middy.MiddlewareObj<unknown, any, Error, Context<undefined>>>(ssm());

--- a/packages/sts/index.test-d.ts
+++ b/packages/sts/index.test-d.ts
@@ -4,7 +4,7 @@ import { getInternal } from "@middy/util";
 import type { Context as LambdaContext } from "aws-lambda";
 import { captureAWSv3Client } from "aws-xray-sdk";
 import { expectType } from "tsd";
-import sts, { type AssumedRoleCredentials, type Context } from ".";
+import sts, { type AssumedRoleCredentials, type Context } from "./index.js";
 
 // use with default options
 expectType<middy.MiddlewareObj<unknown, any, Error, Context<undefined>>>(sts());

--- a/packages/util/index.test-d.ts
+++ b/packages/util/index.test-d.ts
@@ -6,7 +6,7 @@ import type {
 	Context as LambdaContext,
 } from "aws-lambda";
 import { expectType } from "tsd";
-import * as util from ".";
+import * as util from "./index.js";
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type TInternal = {

--- a/packages/validator/index.test-d.ts
+++ b/packages/validator/index.test-d.ts
@@ -1,6 +1,6 @@
 import type middy from "@middy/core";
 import { expectType } from "tsd";
-import validator from ".";
+import validator from "./index.js";
 
 // use with default options
 let middleware = validator();

--- a/packages/validator/transpile.d.ts
+++ b/packages/validator/transpile.d.ts
@@ -1,5 +1,4 @@
-import type Ajv from "ajv";
-import type { Options as AjvOptions } from "ajv";
+import type { Ajv, Options as AjvOptions } from "ajv";
 
 export function transpileSchema(
 	schema: object,

--- a/packages/validator/transpile.test-d.ts
+++ b/packages/validator/transpile.test-d.ts
@@ -1,5 +1,5 @@
 import { expectType } from "tsd";
-import type { transpileLocale, transpileSchema } from "./transpile.t.ds";
+import { transpileLocale, transpileSchema } from "./transpile.js";
 
 const schema = transpileSchema({ type: "object" }, {});
 expectType<any>(schema);

--- a/packages/warmup/index.test-d.ts
+++ b/packages/warmup/index.test-d.ts
@@ -1,6 +1,6 @@
 import type middy from "@middy/core";
 import { expectType } from "tsd";
-import warmup from ".";
+import warmup from "./index.js";
 
 // use with default options
 let middleware = warmup();

--- a/packages/ws-json-body-parser/index.test-d.ts
+++ b/packages/ws-json-body-parser/index.test-d.ts
@@ -1,6 +1,6 @@
 import type middy from "@middy/core";
 import { expectType } from "tsd";
-import jsonBodyParser, { type Event } from ".";
+import jsonBodyParser, { type Event } from "./index.js";
 
 // use with default options
 expectType<middy.MiddlewareObj<Event>>(jsonBodyParser());

--- a/packages/ws-response/index.test-d.ts
+++ b/packages/ws-response/index.test-d.ts
@@ -2,7 +2,7 @@ import { ApiGatewayManagementApiClient } from "@aws-sdk/client-apigatewaymanagem
 import type middy from "@middy/core";
 import { captureAWSv3Client } from "aws-xray-sdk";
 import { expectType } from "tsd";
-import wsResponse from ".";
+import wsResponse from "./index.js";
 
 // use with default options
 let middleware = wsResponse();

--- a/packages/ws-router/index.test-d.ts
+++ b/packages/ws-router/index.test-d.ts
@@ -1,7 +1,7 @@
 import type middy from "@middy/core";
 import type { APIGatewayProxyWebsocketHandlerV2 } from "aws-lambda";
 import { expectType } from "tsd";
-import wsRouterHandler from ".";
+import wsRouterHandler from "./index.js";
 
 const connectLambdaHandler: APIGatewayProxyWebsocketHandlerV2 = async () => {
 	return {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,3 @@
 {
-	"compilerOptions": {
-		"strict": true
-	}
+	"extends": "@tsconfig/node20"
 }


### PR DESCRIPTION
This aim of this Pr is to make the root TSConfig stricter.

I would suggest extending from [`@tsconfig/node20`](https://www.npmjs.com/package/@tsconfig/node20). The other changes you see here are the result of this improvement. This should help to modernize the type testing infrastructure.

