### PR TITLE
docs(warmup): update link of aws provisioned concurrency announcement

### DIFF
--- a/website/docs/middlewares/warmup.md
+++ b/website/docs/middlewares/warmup.md
@@ -8,7 +8,7 @@ This middleware allows you to specify a schedule to keep Lambdas that always nee
 
 If you use [`serverless-plugin-warmup`](https://www.npmjs.com/package/serverless-plugin-warmup) the scheduling part is done by the plugin and you just have to attach the middleware to your "middyfied" handler. If you don't want to use the plugin you have to create the schedule yourself and define the `isWarmingUp` function to define whether the current event is a warmup event or an actual business logic execution.
 
-**Important:** AWS recently announced Lambda [Provisioned Concurrency](https://aws.amazon.com/about-aws/whats-new/2019/12/aws-lambda-announces-provisioned-concurrency/). If you have this enabled, you do not need this middleware.
+**Important:** AWS recently announced Lambda [Provisioned Concurrency](https://aws.amazon.com/blogs/aws/new-provisioned-concurrency-for-lambda-functions/). If you have this enabled, you do not need this middleware.
 
 To update your code to use Provisioned Concurrency see:
 


### PR DESCRIPTION
---
name: Pull request
about: Pull request
title: ''
labels: ''
assignees: ''

---

<!-- First and foremost, thank you for taking the time to make middy better. You contribution helps everyone. -->

**What does this implement/fix? Explain your changes.**

The link to AWS Provisioned Concurrency announcement page in [warmup](https://middy.js.org/docs/middlewares/warmup/) is redirecting to [AWS About Page](https://aws.amazon.com/about-aws/whats-new/2019/12/aws-lambda-announces-provisioned-concurrency/).
This PR updates the link to point to the [new blog post url](https://aws.amazon.com/blogs/aws/new-provisioned-concurrency-for-lambda-functions/)

**Does this close any currently open issues?**
No

**Any relevant logs, error output, etc?**
No
