### PR TITLE
chore: remove `eslint-disable` comments

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -68,7 +68,6 @@ export interface MiddyHandlerObject {
 }
 
 // The AWS provided Handler type uses void | Promise<TResult> so we have no choice but to follow and suppress the linter warning
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 type MiddyInputHandler<
 	TEvent,
 	TResult,
@@ -77,7 +76,7 @@ type MiddyInputHandler<
 	event: TEvent,
 	context: TContext,
 	opts: MiddyHandlerObject,
-) => undefined | Promise<TResult> | TResult; // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+) => undefined | Promise<TResult> | TResult;
 type MiddyInputPromiseHandler<
 	TEvent,
 	TResult,

--- a/packages/core/index.test-d.ts
+++ b/packages/core/index.test-d.ts
@@ -20,7 +20,6 @@ type EnhanceHandlerType<T, NewReturn> = T extends (
 type AWSLambdaHandlerWithoutCallback<TEvent = any, TResult = any> = (
 	event: TEvent,
 	context: Context,
-	// eslint-disable-next-line
 ) => undefined | Promise<TResult>;
 
 type LambdaHandler<TEvent = any, TResult = any> = EnhanceHandlerType<
@@ -103,7 +102,6 @@ middy((event: any, context: any, { signal }: { signal: AbortSignal }) =>
 );
 
 // invokes the handler to test that it is callable
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 async function invokeHandler(): Promise<undefined | APIGatewayProxyResult> {
 	const sampleEvent: APIGatewayProxyEvent = {
 		resource: "/",
@@ -346,7 +344,6 @@ syncedHandler = middy(syncedLambdaHandler, {
 expectType<Handler>(syncedHandler);
 
 // invokes the handler to test that it is callable
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 async function invokeSyncedHandler(): Promise<
 	undefined | APIGatewayProxyResult
 > {

--- a/packages/http-content-negotiation/index.d.ts
+++ b/packages/http-content-negotiation/index.d.ts
@@ -12,7 +12,6 @@ interface Options {
 	failOnMismatch?: boolean;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export type Event = {};
 
 export interface Context {

--- a/packages/http-header-normalizer/index.d.ts
+++ b/packages/http-header-normalizer/index.d.ts
@@ -6,7 +6,6 @@ interface Options {
 	normalizeHeaderKey?: (key: string) => string;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export type Event = {};
 
 declare function httpHeaderNormalizer(

--- a/packages/http-router/index.test.js
+++ b/packages/http-router/index.test.js
@@ -222,7 +222,7 @@ test("It should route to a dynamic route (/path/to) with `{proxy+}`", async (t) 
 			path: "/path/{proxy+}",
 			handler: (event) => {
 				deepEqual(event.pathParameters, { proxy: "to" });
-				ok(!!event.pathParameters.__proto__); // eslint-disable-line no-proto
+				ok(!!event.pathParameters.__proto__);
 				return true;
 			},
 		},
@@ -245,7 +245,7 @@ test("It should populate pathParameters to a dynamic route even if they already 
 			path: "/user/{id}",
 			handler: (event) => {
 				deepEqual(event.pathParameters, { id: "123", previous: "321" });
-				ok(!!event.pathParameters.__proto__); // eslint-disable-line no-proto
+				ok(!!event.pathParameters.__proto__);
 				return true;
 			},
 		},

--- a/packages/util/type-utils.d.ts
+++ b/packages/util/type-utils.d.ts
@@ -30,7 +30,6 @@ type LetterUpper = Uppercase<LetterLower>;
 type AlphaNumeric = Digit | LetterLower | LetterUpper;
 
 type SanitizeKeyPrefixLeadingNumber<T> =
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	T extends `${infer _ extends Digit}${any}` ? `_${T}` : T;
 
 type SanitizeKeyRemoveDisallowedChar<T> =


### PR DESCRIPTION
**What does this implement/fix? Explain your changes.**

This removes `eslint-disable` comments. Seems like those are not needed anymore, or did I misunderstood something?

**Todo List:**
- [x] All commits are cryptographically signed
- [x] Feature/Fix fully implemented
- [n/a] Updated relevant types
- [n/a] Added tests (if applicable)
  - [ ] Unit tests
  - [ ] Fuzz tests
  - [ ] Type tests
  - [ ] Benchmark tests
- [n/a] Updated relevant documentation
- [n/a] Updated relevant examples
