### PR TITLE
Add middy-standard-schema to Third Party Middleware List

### DIFF
--- a/website/docs/middlewares/third-party.md
+++ b/website/docs/middlewares/third-party.md
@@ -19,6 +19,7 @@ If your middleware is missing, feel free to [open a Pull Request](https://github
 - [middy-profiler](https://github.com/serkan-ozal/middy-profiler): Middleware for profiling CPU on AWS Lambda during invocation and shows what methods/modules consume what percent of CPU time
 - [middy-rds](https://www.npmjs.com/package/middy-rds): Creates RDS connection using `knex` or `pg`
 - [middy-recaptcha](https://www.npmjs.com/package/middy-recaptcha): reCAPTCHA validation middleware
+- [middy-standard-schema](https://github.com/flubber2077/middy-standard-schema): Standard Schema based validator, e.g., Zod, Arktype, Valibot, Joi, Yup
 - [middy-sparks-joi](https://www.npmjs.com/package/middy-sparks-joi): Joi validator
 - [middy-store](https://github.com/zirkelc/middy-store): Middleware to automatically store and load payloads from S3 in an AWS Step Functions state machine
 - [middy-mcp](https://github.com/fredericbarthelet/middy-mcp): Middleware for Model Context Protocol (MCP) server integration with AWS Lambda functions


### PR DESCRIPTION

<!-- First and foremost, thank you for taking the time to make middy better. You contribution helps everyone. -->

Took the weekend to write out a middy middleware wrapper for Standard Schema validators. Tested primarily with Zod and also some Arktype, but should work with [this entire list](https://standardschema.dev/#what-schema-libraries-implement-the-spec).

**Environment:**
 - Node.js: 22
 - Middy: 6.4.3

**Any other comments?**
If you have the time, would love any feedback on the middleware. Also still a little confused on the typing of middy.MiddlewareObj's generics inputs.