### PR TITLE
Fix for typings coming back as never

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -163,9 +163,7 @@ declare type MiddlewareHandler<
 	TContext extends LambdaContext = LambdaContext,
 	TResult = any,
 	TEvent = any,
-> = THandler extends LambdaHandler<TEvent, TResult> // always true
-	? MiddyInputHandler<TEvent, TResult, TContext>
-	: never;
+> = MiddyInputHandler<TEvent, TResult, TContext>;
 
 /**
  * Middy factory function. Use it to wrap your existing handler to enable middlewares on it.


### PR DESCRIPTION
---
name: Pull request
about: Pull request
title: 'Fix for typings coming back as never'
labels: ''
assignees: ''

---

<!-- First and foremost, thank you for taking the time to make middy better. You contribution helps everyone. -->

**What does this implement/fix? Explain your changes.**
Right now there is a random scenario where this statement is not actually true and it breaks the function typings. Do we need this ternary? If its expected to always be true, can we just remove the ternary?

**Does this close any currently open issues?**

**Any relevant logs, error output, etc?**

**Environment:**
 - Node.js: [e.g. 22]
 - Middy: [e.g. 6.0.0]
 - AWS SDK [e.g. 3.999.0]

**Any other comments?**

**Todo List:**
- [x] All commits are cryptographically signed
- [ ] Feature/Fix fully implemented
- [ ] Updated relevant types
- [ ] Added tests (if applicable)
  - [ ] Unit tests
  - [ ] Fuzz tests
  - [ ] Type tests
  - [ ] Benchmark tests
- [ ] Updated relevant documentation
- [ ] Updated relevant examples
