### PR TITLE
chore: update TSTyche to v5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "fast-check": "^4.0.0",
         "husky": "^9.0.0",
         "tinybench": "^5.0.0",
-        "tstyche": "^4.3.0",
+        "tstyche": "^5.0.0",
         "typescript": "^5.0.0"
       },
       "engines": {
@@ -5666,22 +5666,22 @@
       "license": "0BSD"
     },
     "node_modules/tstyche": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/tstyche/-/tstyche-4.3.0.tgz",
-      "integrity": "sha512-X5mSVCivhCSDKHr9tWfCH0kmEo5cLApZILK5XfssTIirc9wEvcSYhCaixj5TSR/39cIC7U5TQD+wtGKsYh7nlw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tstyche/-/tstyche-5.0.0.tgz",
+      "integrity": "sha512-ukwBOKfWXLIORtXslLEzUOexRhehNimmOxbjues3xfjBfJv8zHd3kJnrZuufuhQtSJDU18NUF0v6RrnSh9uuaw==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "tstyche": "build/bin.js"
       },
       "engines": {
-        "node": ">=20.9"
+        "node": ">=20.12"
       },
       "funding": {
         "url": "https://github.com/tstyche/tstyche?sponsor=1"
       },
       "peerDependencies": {
-        "typescript": ">=4.7"
+        "typescript": ">=5.0"
       },
       "peerDependenciesMeta": {
         "typescript": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"fast-check": "^4.0.0",
 		"husky": "^9.0.0",
 		"tinybench": "^5.0.0",
-		"tstyche": "^4.3.0",
+		"tstyche": "^5.0.0",
 		"typescript": "^5.0.0"
 	},
 	"devEngines": {

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,5 +1,4 @@
 {
 	"$schema": "https://tstyche.org/schemas/config.json",
-	"checkSuppressedErrors": true,
 	"testFileMatch": ["packages/*/*.test-d.ts"]
 }


### PR DESCRIPTION
This PR updates TSTyche to v5.0.0. Release notes: https://tstyche.org/releases/tstyche-5

**Todo List:**
- [x] All commits are cryptographically signed
