### PR TITLE
fix(http-urlencode-body-parser): preserve duplicate keys as arrays using getAll()

### DIFF
--- a/packages/http-urlencode-body-parser/index.js
+++ b/packages/http-urlencode-body-parser/index.js
@@ -28,7 +28,12 @@ const httpUrlencodeBodyParserMiddleware = (opts = {}) => {
 		}
 
 		const data = decodeBody(request.event);
-		const parsedBody = Object.fromEntries(new URLSearchParams(data));
+		const parsedBody = Object.fromEntries(
+    Array.from(new URLSearchParams(data).keys()).map((key) => [
+      key,
+      new URLSearchParams(data).getAll(key),
+    ])
+  );
 
 		// Check if it didn't parse
 		if (parsedBody?.[body] === "") {


### PR DESCRIPTION
## Fix middyjs/middy#1613 - duplicate key bug

### Problem
The  middleware was using  to parse URL-encoded bodies. However,  with  only keeps the **last** value when a key appears multiple times.

For example, with , the result would be  instead of .

### Solution
Replace the single  call with  which returns an array of all values for each key.



This ensures duplicate keys are preserved as arrays, which is the expected behavior for form-encoded data with multiple values for the same key.