### PR TITLE
fix(core): lazy-load durable SDK and mark as optional peer to fix bundler errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9912,7 +9912,8 @@
 			"workspaces": [
 				"tests/deps/*",
 				"tests/projects/*",
-				"tests/projects/workspace/packages/*"
+				"tests/projects/workspace/packages/*",
+				"tests/executionModeDurableContext.test.js*"
 			],
 			"peerDependencies": {
 				"vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/packages/core/executionModeDurableContext.js
+++ b/packages/core/executionModeDurableContext.js
@@ -1,7 +1,13 @@
 // Copyright 2017 - 2026 will Farrell, Luciano Mammino, and Middy contributors.
 // SPDX-License-Identifier: MIT
-import { withDurableExecution } from "@aws/durable-execution-sdk-js";
 import { executionContextKeys, lambdaContextKeys } from "@middy/util";
+
+let withDurableExecution;
+try {
+	({ withDurableExecution } = await import("@aws/durable-execution-sdk-js"));
+} catch {
+	withDurableExecution = undefined;
+}
 
 export const executionModeDurableContext = (
 	{ middyRequest, runRequest },
@@ -11,20 +17,22 @@ export const executionModeDurableContext = (
 	onErrorMiddlewares,
 	plugin,
 ) => {
+	if (!withDurableExecution) {
+		throw new Error(
+			"executionModeDurableContext requires @aws/durable-execution-sdk-js. " +
+				"Install it as a dependency: npm i @aws/durable-execution-sdk-js",
+		);
+	}
+
 	const middy = withDurableExecution(async (event, context) => {
 		const request = middyRequest(event, context);
 		plugin.requestStart(request);
-
-		// normalize context with executionModeStandard
-		// https://docs.aws.amazon.com/lambda/latest/dg/typescript-context.html
-		// Idea: Use Proxy instead of copying. Faster for common use case?
 		copyKeys(
 			request.context,
 			request.context.executionContext,
 			executionContextKeys,
 		);
 		copyKeys(request.context, request.context.lambdaContext, lambdaContextKeys);
-
 		try {
 			const response = await runRequest(
 				request,
@@ -39,10 +47,12 @@ export const executionModeDurableContext = (
 			await plugin.requestEnd(request);
 		}
 	});
+
 	middy.handler = (replaceLambdaHandler) => {
 		lambdaHandler = replaceLambdaHandler;
 		return middy;
 	};
+
 	return middy;
 };
 

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -13,6 +13,15 @@ declare type PluginHookPromise = (
 ) => Promise<unknown> | unknown;
 export type PluginExecutionMode = () => void;
 export declare const executionModeStandard: PluginExecutionMode;
+/**
+ * Execution mode for AWS Lambda Durable Functions.
+ *
+ * **Requires** `@aws/durable-execution-sdk-js` to be installed as
+ * a direct dependency in your project. It is an optional peer of
+ * `@middy/core` and will not be installed automatically.
+ *
+ * @throws {Error} If `@aws/durable-execution-sdk-js` is not installed.
+ */
 export declare const executionModeDurableContext: PluginExecutionMode;
 export declare const executionModeStreamifyResponse: PluginExecutionMode;
 


### PR DESCRIPTION
… peer

---
name: fix(core): lazy-load durable SDK and mark as optional peer to fix bundler errors
about: fix(core): lazy-load durable SDK and mark as optional peer to fix bundler errors
title: ''fix(core): lazy-load durable SDK and mark as optional peer to fix bundler errors"
labels:  dependencies | GitHub_Actions
assignees: ''Suresh-2017"
Email: reachpadala@gmail.com

---

<!-- First and foremost, thank you for taking the time to make middy better. You contribution helps everyone. -->

**What does this implement/fix? Explain your changes.**
@middy/core v7 introduced Durable Functions support but imported @aws/durable-execution-sdk-js as a static top-level import and listed it as a hard dependency. This caused two problems for users who do not use Durable Functions:

Build time failure — bundlers (esbuild, webpack, etc.) fail with Could not resolve "@aws/durable-execution-sdk-js" because they try to follow every static import at build time, even if the code path is never used.
Unnecessary dependency — the SDK was installed for every @middy/core user via dependencies, adding bundle weight for users who never opt into Durable Functions.

Changes made:

executionModeDurableContext.js — replaced the static import with a lazy await import(...) inside a try/catch. If the SDK is absent at runtime, a clear actionable error is thrown pointing to the missing package.
package.json — removed @aws/durable-execution-sdk-js from dependencies, added it to peerDependencies with peerDependenciesMeta.optional: true so it is only installed by users who explicitly need it.
index.d.ts — added JSDoc @throws comment to executionModeDurableContext documenting the optional peer requirement.

**Does this close any currently open issues?**

Closes #1548

**Any relevant logs, error output, etc?**

**Environment:**
 Node.js: 24
Middy: 7.2.3
AWS SDK: not applicable (issue is with @aws/durable-execution-sdk-js peer)

**Any other comments?**
Users who do use Durable Functions simply need to add @aws/durable-execution-sdk-js as a direct dependency in their own project. If they call executionModeDurableContext without installing it, they will now get a clear error message.

**Todo List:**
- [ ] All commits are cryptographically signed
- [Yes ] Feature/Fix fully implemented
- [ Yes ] Updated relevant types
- [Yes  ] Added tests (if applicable)
  - [Yes  ] Unit tests
  - [ ] Fuzz tests
  - [ ] Type tests
  - [ ] Benchmark tests
- [Yes  ] Updated relevant documentation
- [ ] Updated relevant examples
